### PR TITLE
chore: update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v6.0.0
     hooks:
       - id: check-added-large-files
         args:
@@ -16,7 +16,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/dnephin/pre-commit-golang
-    rev: master
+    rev: v0.5.1
     hooks:
       - id: golangci-lint
       - id: go-unit-tests


### PR DESCRIPTION
## Summary
- pre-commit-hooks: v3.4.0 -> v6.0.0
- pre-commit-golang: master -> v0.5.1

## Changes
Updated `.pre-commit-config.yaml` to use the latest stable versions of both pre-commit hook repositories.

* **Chores**
  * Updated development tool dependencies to newer versions for improved functionality and compatibility.