### PR TITLE
Release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.4.0](https://github.com/skyoo2003/acor/releases/tag/v1.4.0) - 2026-03-18
+
+### Added
+
+- Add CLI commands: migrate, migrate-rollback, schema-version ([#83](https://github.com/skyoo2003/acor/issues/83))
+- Add RollbackToV1() for safe rollback when V1 keys are kept ([#83](https://github.com/skyoo2003/acor/issues/83))
+- Add V2 schema with 80-85% fewer Redis round trips and 99% fewer keys ([#83](https://github.com/skyoo2003/acor/issues/83))
+- Add MigrateV1ToV2() with dry-run support and progress callbacks ([#83](https://github.com/skyoo2003/acor/issues/83))
+- Add parallel matching (FindParallel, FindIndexParallel) with configurable chunk boundaries ([#84](https://github.com/skyoo2003/acor/issues/84))
+- Add batch operations (AddMany, RemoveMany, FindMany) with BestEffort and Transactional modes ([#84](https://github.com/skyoo2003/acor/issues/84))
+- Add pkg/metrics: Prometheus metrics registry with HTTP/gRPC middleware ([#85](https://github.com/skyoo2003/acor/issues/85))
+- Add pkg/health: Kubernetes-compatible health checks (liveness/readiness) for HTTP/gRPC ([#85](https://github.com/skyoo2003/acor/issues/85))
+- Add observability integration to gRPC server (NewGRPCServerWithObservability) ([#85](https://github.com/skyoo2003/acor/issues/85))
+- Add pkg/tracing: OpenTelemetry distributed tracing with HTTP/gRPC middleware ([#85](https://github.com/skyoo2003/acor/issues/85))
+- Add pkg/logging: zerolog structured logging with HTTP/gRPC middleware ([#85](https://github.com/skyoo2003/acor/issues/85))
+
+### Changed
+
+- Go required version 1.24 or higher ([#80](https://github.com/skyoo2003/acor/issues/80))
+- Add SchemaVersion field to AhoCorasickArgs for explicit schema selection ([#83](https://github.com/skyoo2003/acor/issues/83))
+- **BREAKING**: New collections now default to V2 schema. Use SchemaVersion: 1 to keep V1 behavior ([#83](https://github.com/skyoo2003/acor/issues/83))
+- chore: update pre-commit hooks to latest versions ([#88](https://github.com/skyoo2003/acor/issues/88))
+
+### Removed
+
+- Remove unused BatchSize field from MigrationOptions (was never implemented) ([#83](https://github.com/skyoo2003/acor/issues/83))
+
+### Fixed
+
+- Correct migration progress step constants ([#83](https://github.com/skyoo2003/acor/issues/83))
+
+### Documentation
+
+- Add performance tradeoffs and migration notes to README ([#83](https://github.com/skyoo2003/acor/issues/83))
+
 ## [v1.3.0](https://github.com/skyoo2003/acor/releases/tag/v1.3.0) - 2026-03-14
 
 ### Added
@@ -29,7 +64,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed NodeKey output was not written ([#13](https://github.com/skyoo2003/acor/issues/13))
+- Fixed NodeKey output was not writed ([#13](https://github.com/skyoo2003/acor/issues/13))
 
 ## [v1.1.0](https://github.com/skyoo2003/acor/releases/tag/v1.1.0) - 2020-11-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed NodeKey output was not writed ([#13](https://github.com/skyoo2003/acor/issues/13))
+- Fixed NodeKey output was not written ([#13](https://github.com/skyoo2003/acor/issues/13))
 
 ## [v1.1.0](https://github.com/skyoo2003/acor/releases/tag/v1.1.0) - 2020-11-17
 

--- a/changes/unreleased/Added-20260318-003248.yaml
+++ b/changes/unreleased/Added-20260318-003248.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: 'Add CLI commands: migrate, migrate-rollback, schema-version'
-time: 2026-03-18T00:32:48.563215+09:00
-custom:
-    Issue: "83"

--- a/changes/unreleased/Added-20260318-003329.yaml
+++ b/changes/unreleased/Added-20260318-003329.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: Add RollbackToV1() for safe rollback when V1 keys are kept
-time: 2026-03-18T00:33:29.669603+09:00
-custom:
-    Issue: "83"

--- a/changes/unreleased/Added-20260318-003348.yaml
+++ b/changes/unreleased/Added-20260318-003348.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: Add V2 schema with 80-85% fewer Redis round trips and 99% fewer keys
-time: 2026-03-18T00:33:48.544989+09:00
-custom:
-    Issue: "83"

--- a/changes/unreleased/Added-20260318-003413.yaml
+++ b/changes/unreleased/Added-20260318-003413.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: Add MigrateV1ToV2() with dry-run support and progress callbacks
-time: 2026-03-18T00:34:13.999445+09:00
-custom:
-    Issue: "83"

--- a/changes/unreleased/Added-20260318-081526.yaml
+++ b/changes/unreleased/Added-20260318-081526.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: Add parallel matching (FindParallel, FindIndexParallel) with configurable chunk boundaries
-time: 2026-03-18T08:15:26.689629+09:00
-custom:
-    Issue: "84"

--- a/changes/unreleased/Added-20260318-081557.yaml
+++ b/changes/unreleased/Added-20260318-081557.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: Add batch operations (AddMany, RemoveMany, FindMany) with BestEffort and Transactional modes
-time: 2026-03-18T08:15:57.461985+09:00
-custom:
-    Issue: "84"

--- a/changes/unreleased/Added-20260318-190143.yaml
+++ b/changes/unreleased/Added-20260318-190143.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: 'Add pkg/metrics: Prometheus metrics registry with HTTP/gRPC middleware'
-time: 2026-03-18T19:01:43.067007+09:00
-custom:
-    Issue: "85"

--- a/changes/unreleased/Added-20260318-190159.yaml
+++ b/changes/unreleased/Added-20260318-190159.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: 'Add pkg/health: Kubernetes-compatible health checks (liveness/readiness) for HTTP/gRPC'
-time: 2026-03-18T19:01:59.694063+09:00
-custom:
-    Issue: "85"

--- a/changes/unreleased/Added-20260318-190310.yaml
+++ b/changes/unreleased/Added-20260318-190310.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: Add observability integration to gRPC server (NewGRPCServerWithObservability)
-time: 2026-03-18T19:03:10.942714+09:00
-custom:
-    Issue: "85"

--- a/changes/unreleased/Added-20260318-190345.yaml
+++ b/changes/unreleased/Added-20260318-190345.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: 'Add pkg/tracing: OpenTelemetry distributed tracing with HTTP/gRPC middleware'
-time: 2026-03-18T19:03:45.221894+09:00
-custom:
-    Issue: "85"

--- a/changes/unreleased/Added-20260318-190412.yaml
+++ b/changes/unreleased/Added-20260318-190412.yaml
@@ -1,5 +1,0 @@
-kind: Added
-body: 'Add pkg/logging: zerolog structured logging with HTTP/gRPC middleware'
-time: 2026-03-18T19:04:12.973998+09:00
-custom:
-    Issue: "85"

--- a/changes/unreleased/Changed-20260316-220305.yaml
+++ b/changes/unreleased/Changed-20260316-220305.yaml
@@ -1,5 +1,0 @@
-kind: Changed
-body: Go required version 1.24 or higher
-time: 2026-03-16T22:03:05.028813+09:00
-custom:
-    Issue: "80"

--- a/changes/unreleased/Changed-20260318-003329.yaml
+++ b/changes/unreleased/Changed-20260318-003329.yaml
@@ -1,5 +1,0 @@
-kind: Changed
-body: Add SchemaVersion field to AhoCorasickArgs for explicit schema selection
-time: 2026-03-18T00:33:29.673616+09:00
-custom:
-    Issue: "83"

--- a/changes/unreleased/Changed-20260318-003524.yaml
+++ b/changes/unreleased/Changed-20260318-003524.yaml
@@ -1,5 +1,0 @@
-kind: Changed
-body: '**BREAKING**: New collections now default to V2 schema. Use SchemaVersion: 1 to keep V1 behavior'
-time: 2026-03-18T00:35:24.888581+09:00
-custom:
-    Issue: "83"

--- a/changes/unreleased/Changed-20260318-220515.yaml
+++ b/changes/unreleased/Changed-20260318-220515.yaml
@@ -1,5 +1,0 @@
-kind: Changed
-body: 'chore: update pre-commit hooks to latest versions'
-time: 2026-03-18T22:05:15.876919+09:00
-custom:
-    Issue: "88"

--- a/changes/unreleased/Documentation-20260318-003101.yaml
+++ b/changes/unreleased/Documentation-20260318-003101.yaml
@@ -1,5 +1,0 @@
-kind: Documentation
-body: Add performance tradeoffs and migration notes to README
-time: 2026-03-18T00:31:01.8157+09:00
-custom:
-    Issue: "83"

--- a/changes/unreleased/Fixed-20260318-003101.yaml
+++ b/changes/unreleased/Fixed-20260318-003101.yaml
@@ -1,5 +1,0 @@
-kind: Fixed
-body: Correct migration progress step constants
-time: 2026-03-18T00:31:01.818355+09:00
-custom:
-    Issue: "83"

--- a/changes/unreleased/Removed-20260318-003052.yaml
+++ b/changes/unreleased/Removed-20260318-003052.yaml
@@ -1,5 +1,0 @@
-kind: Removed
-body: Remove unused BatchSize field from MigrationOptions (was never implemented)
-time: 2026-03-18T00:30:52.879786+09:00
-custom:
-    Issue: "83"

--- a/changes/v1.2.0.md
+++ b/changes/v1.2.0.md
@@ -1,9 +1,11 @@
 ## [v1.2.0](https://github.com/skyoo2003/acor/releases/tag/v1.2.0) - 2021-07-09
 
 ### Changed
-* Changed to standard project structure ([#2](https://github.com/skyoo2003/acor/issues/2))
-* Changed supported Go versions ([#5](https://github.com/skyoo2003/acor/issues/5))
-* Changed RedisAlreadyClosed error name ([#7](https://github.com/skyoo2003/acor/issues/7))
+
+- Changed to standard project structure ([#2](https://github.com/skyoo2003/acor/issues/2))
+- Changed supported Go versions ([#5](https://github.com/skyoo2003/acor/issues/5))
+- Changed RedisAlreadyClosed error name ([#7](https://github.com/skyoo2003/acor/issues/7))
 
 ### Fixed
-* Fixed NodeKey output was not writed ([#13](https://github.com/skyoo2003/acor/issues/13))
+
+- Fixed NodeKey output was not written ([#13](https://github.com/skyoo2003/acor/issues/13))

--- a/changes/v1.4.0.md
+++ b/changes/v1.4.0.md
@@ -1,0 +1,24 @@
+## [v1.4.0](https://github.com/skyoo2003/acor/releases/tag/v1.4.0) - 2026-03-18
+### Added
+* Add CLI commands: migrate, migrate-rollback, schema-version ([#83](https://github.com/skyoo2003/acor/issues/83))
+* Add RollbackToV1() for safe rollback when V1 keys are kept ([#83](https://github.com/skyoo2003/acor/issues/83))
+* Add V2 schema with 80-85% fewer Redis round trips and 99% fewer keys ([#83](https://github.com/skyoo2003/acor/issues/83))
+* Add MigrateV1ToV2() with dry-run support and progress callbacks ([#83](https://github.com/skyoo2003/acor/issues/83))
+* Add parallel matching (FindParallel, FindIndexParallel) with configurable chunk boundaries ([#84](https://github.com/skyoo2003/acor/issues/84))
+* Add batch operations (AddMany, RemoveMany, FindMany) with BestEffort and Transactional modes ([#84](https://github.com/skyoo2003/acor/issues/84))
+* Add pkg/metrics: Prometheus metrics registry with HTTP/gRPC middleware ([#85](https://github.com/skyoo2003/acor/issues/85))
+* Add pkg/health: Kubernetes-compatible health checks (liveness/readiness) for HTTP/gRPC ([#85](https://github.com/skyoo2003/acor/issues/85))
+* Add observability integration to gRPC server (NewGRPCServerWithObservability) ([#85](https://github.com/skyoo2003/acor/issues/85))
+* Add pkg/tracing: OpenTelemetry distributed tracing with HTTP/gRPC middleware ([#85](https://github.com/skyoo2003/acor/issues/85))
+* Add pkg/logging: zerolog structured logging with HTTP/gRPC middleware ([#85](https://github.com/skyoo2003/acor/issues/85))
+### Changed
+* Go required version 1.24 or higher ([#80](https://github.com/skyoo2003/acor/issues/80))
+* Add SchemaVersion field to AhoCorasickArgs for explicit schema selection ([#83](https://github.com/skyoo2003/acor/issues/83))
+* **BREAKING**: New collections now default to V2 schema. Use SchemaVersion: 1 to keep V1 behavior ([#83](https://github.com/skyoo2003/acor/issues/83))
+* chore: update pre-commit hooks to latest versions ([#88](https://github.com/skyoo2003/acor/issues/88))
+### Removed
+* Remove unused BatchSize field from MigrationOptions (was never implemented) ([#83](https://github.com/skyoo2003/acor/issues/83))
+### Fixed
+* Correct migration progress step constants ([#83](https://github.com/skyoo2003/acor/issues/83))
+### Documentation
+* Add performance tradeoffs and migration notes to README ([#83](https://github.com/skyoo2003/acor/issues/83))


### PR DESCRIPTION
Bump v1.3.0 to v1.4.0

* **New Features**
  * CLI commands for migrations and schema management
  * V2 schema with improved efficiency
  * Parallel and batch operations
  * Observability features including metrics, health checks, distributed tracing, and structured logging

* **Changed**
  * Default schema version now V2 (with option to retain V1)

* **Removed**
  * Unused configuration option