### PR TITLE
docs: add cross-references between Hugo documentation pages

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -149,7 +149,7 @@ import (
 ## Documentation Sections
 
 - [Getting Started](/getting-started/) - Installation and quick start guide
-- [Guides](/guides/) - Batch operations and parallel matching
+- [Guides](/guides/) - Usage patterns and advanced features
 - [Reference](/reference/) - API and schema documentation
 - [Operations](/operations/) - Deployment and monitoring
 - [Extending](/extending/) - Custom storage backends

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -148,7 +148,7 @@ import (
 
 ## Documentation Sections
 
-## Documentation Sections
+- [Getting Started][getting-started-link] - Installation and quick start guide
 
 - [Getting Started][getting-started-link] - Installation and quick start guide
 - [Guides][guides-link] - Usage patterns and advanced features

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -148,11 +148,19 @@ import (
 
 ## Documentation Sections
 
-- [Getting Started](/getting-started/) - Installation and quick start guide
-- [Guides](/guides/) - Usage patterns and advanced features
-- [Reference](/reference/) - API and schema documentation
-- [Operations](/operations/) - Deployment and monitoring
-- [Extending](/extending/) - Custom storage backends
+## Documentation Sections
+
+- [Getting Started][getting-started-link] - Installation and quick start guide
+- [Guides][guides-link] - Usage patterns and advanced features
+- [Reference][reference-link] - API and schema documentation
+- [Operations][operations-link] - Deployment and monitoring
+- [Extending][extending-link] - Custom storage backends
+
+[getting-started-link]: /getting-started/
+[guides-link]: /guides/
+[reference-link]: /reference/
+[operations-link]: /operations/
+[extending-link]: /extending/
 
 ## Development Workflow
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -149,8 +149,6 @@ import (
 ## Documentation Sections
 
 - [Getting Started][getting-started-link] - Installation and quick start guide
-
-- [Getting Started][getting-started-link] - Installation and quick start guide
 - [Guides][guides-link] - Usage patterns and advanced features
 - [Reference][reference-link] - API and schema documentation
 - [Operations][operations-link] - Deployment and monitoring

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -146,6 +146,14 @@ import (
 )
 ```
 
+## Documentation Sections
+
+- [Getting Started](/getting-started/) - Installation and quick start guide
+- [Guides](/guides/) - Batch operations and parallel matching
+- [Reference](/reference/) - API and schema documentation
+- [Operations](/operations/) - Deployment and monitoring
+- [Extending](/extending/) - Custom storage backends
+
 ## Development Workflow
 
 Run local checks with:

--- a/docs/content/extending/_index.md
+++ b/docs/content/extending/_index.md
@@ -10,3 +10,7 @@ Extend ACOR with custom functionality.
 ## Sections
 
 - [Custom Storage](/extending/custom-storage/) - Implement custom storage backends
+
+## Navigation
+
+← [Operations](/operations/)

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -22,3 +22,7 @@ go get -u github.com/skyoo2003/acor
 
 - [Installation](/getting-started/installation/) - Detailed setup instructions
 - [Quick Start](/getting-started/quick-start/) - Your first ACOR application
+
+## Continue Learning
+
+After getting started, explore the [Guides](/guides/) for advanced usage patterns.

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -61,3 +61,4 @@ acor --help
 ## Next Steps
 
 - [Quick Start](/getting-started/quick-start/) - Build your first application
+- [Guides](/guides/) - Learn about batch operations and parallel matching

--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -103,3 +103,4 @@ args := &acor.AhoCorasickArgs{
 
 - [Batch Operations](/guides/batch-operations/) - Optimize bulk operations
 - [Parallel Matching](/guides/parallel-matching/) - Process large texts efficiently
+- [API Reference](/reference/api/) - Complete API documentation

--- a/docs/content/guides/_index.md
+++ b/docs/content/guides/_index.md
@@ -11,3 +11,7 @@ Practical guides for using ACOR effectively.
 
 - [Batch Operations](/guides/batch-operations/) - Optimize bulk keyword operations
 - [Parallel Matching](/guides/parallel-matching/) - Process large texts with multiple workers
+
+## Navigation
+
+← [Getting Started](/getting-started/) | [Reference](/reference/) →

--- a/docs/content/guides/batch-operations.md
+++ b/docs/content/guides/batch-operations.md
@@ -84,3 +84,8 @@ type BatchResult struct {
 1. Use batch sizes between 100-1000 keywords
 2. Use `Transactional` mode when data consistency is critical
 3. Use `BestEffort` mode when partial success is acceptable
+
+## Next Steps
+
+- [Parallel Matching](/guides/parallel-matching/) - Process large texts efficiently
+- [API Reference](/reference/api/) - Complete API documentation

--- a/docs/content/guides/parallel-matching.md
+++ b/docs/content/guides/parallel-matching.md
@@ -98,3 +98,8 @@ opts := &acor.ParallelOptions{
 - Small texts (< 10KB)
 - Single-match scenarios
 - Resource-constrained environments
+
+## Next Steps
+
+- [Batch Operations](/guides/batch-operations/) - Optimize bulk keyword operations
+- [API Reference](/reference/api/) - Complete API documentation

--- a/docs/content/operations/_index.md
+++ b/docs/content/operations/_index.md
@@ -12,3 +12,7 @@ Operational guides for running ACOR in production.
 - [Deployment](/operations/deployment/) - Deploy ACOR in various environments
 - [Monitoring](/operations/monitoring/) - Monitor ACOR performance
 - [Troubleshooting](/operations/troubleshooting/) - Diagnose and fix issues
+
+## Navigation
+
+← [Reference](/reference/) | [Extending](/extending/) →

--- a/docs/content/reference/_index.md
+++ b/docs/content/reference/_index.md
@@ -12,3 +12,7 @@ Technical reference documentation for ACOR.
 - [API Reference](/reference/api/) - Public API documentation
 - [Schema V1](/reference/schema-v1/) - Legacy schema details
 - [Schema V2](/reference/schema-v2/) - Optimized schema (recommended)
+
+## Navigation
+
+← [Guides](/guides/) | [Operations](/operations/) →


### PR DESCRIPTION
## Summary
- Added cross-reference links to homepage documentation section
- Added "Next Steps" sections with navigation links to guides and API reference
- Added navigation links between major documentation sections (Getting Started → Guides → Reference → Operations → Extending)

## Test Plan
- [ ] Build Hugo site locally and verify all links work correctly
- [ ] Verify navigation flow between documentation sections
* **Documentation**
  * Added a “Documentation Sections” navigation block and directional navigation links to surface Getting Started, Guides, Reference, Operations, and Extending.
  * Added cross-references, back-links, and new “Next Steps” / “Continue Learning” entries across guides and reference pages to improve discovery of related guides (batch/parallel workflows) and the API reference.