### PR TITLE
Release v1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 acor.test
 cov*.out
 coverage*.out
+/tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.5.0](https://github.com/skyoo2003/acor/releases/tag/v1.5.0) - 2026-04-13
+
+### Added
+
+- Add local caching for Find/FindIndex operations with Redis Pub/Sub invalidation ([#99](https://github.com/skyoo2003/acor/issues/99))
+- Add *Context variants for all public API methods (AddContext, FindContext, etc.) ([#96](https://github.com/skyoo2003/acor/issues/96))
+- Add BatchOptions support to RemoveMany for API symmetry with AddMany ([#96](https://github.com/skyoo2003/acor/issues/96))
+- Add V1+Cache guard to prevent unsupported schema/cache configuration ([#96](https://github.com/skyoo2003/acor/issues/96))
+- Add internal Operations interface with Strategy pattern for V1/V2 dispatch ([#102](https://github.com/skyoo2003/acor/issues/102))
+- Add KVStorage interface for Redis dependency injection ([#102](https://github.com/skyoo2003/acor/issues/102))
+- Add redisStorage adapter wrapping go-redis UniversalClient ([#102](https://github.com/skyoo2003/acor/issues/102))
+- Add CI hardening: race detector, coverage threshold (70%), and fuzz testing ([#96](https://github.com/skyoo2003/acor/issues/96))
+- Add Makefile targets: vet, lint-fix, fuzz, race ([#96](https://github.com/skyoo2003/acor/issues/96))
+- Add Issue/PR templates and SECURITY.md ([#96](https://github.com/skyoo2003/acor/issues/96))
+
+### Changed
+
+- Go required version 1.25 or higher ([#97](https://github.com/skyoo2003/acor/issues/97))
+- Refactor AhoCorasick struct to use KVStorage DI and operations Strategy pattern ([#102](https://github.com/skyoo2003/acor/issues/102))
+- Activate error helpers (newRedisError, newOperationError) in V1 and V2 operations ([#96](https://github.com/skyoo2003/acor/issues/96))
+- Replace mustJSON panic with toJSON error return for safer error propagation ([#96](https://github.com/skyoo2003/acor/issues/96))
+- Rename underscore-prefixed methods in trie.go (buildTrie, gotoNode, failNode, collectOutputs) ([#96](https://github.com/skyoo2003/acor/issues/96))
+- Split monolithic test file into feature-specific test files ([#96](https://github.com/skyoo2003/acor/issues/96))
+- Fix README example API names (BatchModeTransactional, ChunkBoundaryWord, Boundary) ([#96](https://github.com/skyoo2003/acor/issues/96))
+- Bump dependencies: go-redis, gRPC, OpenTelemetry, zerolog ([#100](https://github.com/skyoo2003/acor/issues/100), [#103](https://github.com/skyoo2003/acor/issues/103))
+- Bump CI dependencies: GitHub Actions ([#101](https://github.com/skyoo2003/acor/issues/101))
+
+### Removed
+
+- Remove unused non-Context wrapper functions in trie.go ([#96](https://github.com/skyoo2003/acor/issues/96))
+
+### Documentation
+
+- Add cross-references between Hugo documentation pages ([#98](https://github.com/skyoo2003/acor/issues/98))
+- Add comprehensive Hugo documentation: guides, API reference, deployment, monitoring, troubleshooting ([#96](https://github.com/skyoo2003/acor/issues/96))
+
 ## [v1.4.0](https://github.com/skyoo2003/acor/releases/tag/v1.4.0) - 2026-03-18
 
 ### Added

--- a/changes/v1.5.0.md
+++ b/changes/v1.5.0.md
@@ -1,0 +1,27 @@
+## [v1.5.0](https://github.com/skyoo2003/acor/releases/tag/v1.5.0) - 2026-04-13
+### Added
+* Add local caching for Find/FindIndex operations with Redis Pub/Sub invalidation ([#99](https://github.com/skyoo2003/acor/issues/99))
+* Add *Context variants for all public API methods (AddContext, FindContext, etc.) ([#96](https://github.com/skyoo2003/acor/issues/96))
+* Add BatchOptions support to RemoveMany for API symmetry with AddMany ([#96](https://github.com/skyoo2003/acor/issues/96))
+* Add V1+Cache guard to prevent unsupported schema/cache configuration ([#96](https://github.com/skyoo2003/acor/issues/96))
+* Add internal Operations interface with Strategy pattern for V1/V2 dispatch ([#102](https://github.com/skyoo2003/acor/issues/102))
+* Add KVStorage interface for Redis dependency injection ([#102](https://github.com/skyoo2003/acor/issues/102))
+* Add redisStorage adapter wrapping go-redis UniversalClient ([#102](https://github.com/skyoo2003/acor/issues/102))
+* Add CI hardening: race detector, coverage threshold (70%), and fuzz testing ([#96](https://github.com/skyoo2003/acor/issues/96))
+* Add Makefile targets: vet, lint-fix, fuzz, race ([#96](https://github.com/skyoo2003/acor/issues/96))
+* Add Issue/PR templates and SECURITY.md ([#96](https://github.com/skyoo2003/acor/issues/96))
+### Changed
+* Go required version 1.25 or higher ([#97](https://github.com/skyoo2003/acor/issues/97))
+* Refactor AhoCorasick struct to use KVStorage DI and operations Strategy pattern ([#102](https://github.com/skyoo2003/acor/issues/102))
+* Activate error helpers (newRedisError, newOperationError) in V1 and V2 operations ([#96](https://github.com/skyoo2003/acor/issues/96))
+* Replace mustJSON panic with toJSON error return for safer error propagation ([#96](https://github.com/skyoo2003/acor/issues/96))
+* Rename underscore-prefixed methods in trie.go (buildTrie, gotoNode, failNode, collectOutputs) ([#96](https://github.com/skyoo2003/acor/issues/96))
+* Split monolithic test file into feature-specific test files ([#96](https://github.com/skyoo2003/acor/issues/96))
+* Fix README example API names (BatchModeTransactional, ChunkBoundaryWord, Boundary) ([#96](https://github.com/skyoo2003/acor/issues/96))
+* Bump dependencies: go-redis, gRPC, OpenTelemetry, zerolog ([#100](https://github.com/skyoo2003/acor/issues/100), [#103](https://github.com/skyoo2003/acor/issues/103))
+* Bump CI dependencies: GitHub Actions ([#101](https://github.com/skyoo2003/acor/issues/101))
+### Removed
+* Remove unused non-Context wrapper functions in trie.go ([#96](https://github.com/skyoo2003/acor/issues/96))
+### Documentation
+* Add cross-references between Hugo documentation pages ([#98](https://github.com/skyoo2003/acor/issues/98))
+* Add comprehensive Hugo documentation: guides, API reference, deployment, monitoring, troubleshooting ([#96](https://github.com/skyoo2003/acor/issues/96))

--- a/pkg/acor/benchmark_test.go
+++ b/pkg/acor/benchmark_test.go
@@ -13,6 +13,15 @@ import (
 
 const benchmarkInputText = "ushers hello world benchmark test"
 
+func toJSONOrFatal(tb testing.TB, v interface{}) string {
+	tb.Helper()
+	result, err := toJSON(v)
+	if err != nil {
+		tb.Fatalf("toJSON(%T) failed: %v", v, err)
+	}
+	return result
+}
+
 func BenchmarkFindV1(b *testing.B) {
 	mr := miniredis.RunT(b)
 
@@ -63,9 +72,9 @@ func BenchmarkFindV2(b *testing.B) {
 	}
 
 	client.HSet(context.Background(), "{bench}:trie", map[string]interface{}{
-		"keywords": mustJSON(keywords),
-		"prefixes": mustJSON(prefixes),
-		"suffixes": mustJSON(suffixes),
+		"keywords": toJSONOrFatal(b, keywords),
+		"prefixes": toJSONOrFatal(b, prefixes),
+		"suffixes": toJSONOrFatal(b, suffixes),
 		"version":  time.Now().Unix(),
 	})
 

--- a/pkg/acor/migration.go
+++ b/pkg/acor/migration.go
@@ -217,10 +217,22 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 	}
 
 	trieFields := map[string]interface{}{
-		"keywords": mustJSON(keywords),
-		"prefixes": mustJSON(prefixes),
-		"suffixes": mustJSON(suffixes),
-		"version":  time.Now().Unix(),
+		"version": time.Now().Unix(),
+	}
+	if keywordsJSON, marshalErr := toJSON(keywords); marshalErr != nil {
+		return result, fmt.Errorf("migration: failed to marshal keywords: %w", marshalErr)
+	} else {
+		trieFields["keywords"] = keywordsJSON
+	}
+	if prefixesJSON, marshalErr := toJSON(prefixes); marshalErr != nil {
+		return result, fmt.Errorf("migration: failed to marshal prefixes: %w", marshalErr)
+	} else {
+		trieFields["prefixes"] = prefixesJSON
+	}
+	if suffixesJSON, marshalErr := toJSON(suffixes); marshalErr != nil {
+		return result, fmt.Errorf("migration: failed to marshal suffixes: %w", marshalErr)
+	} else {
+		trieFields["suffixes"] = suffixesJSON
 	}
 	if hsetErr := ac.redisClient.HSet(ac.ctx, tempTrieKey, trieFields).Err(); hsetErr != nil {
 		cleanup()
@@ -232,7 +244,14 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 	if len(outputs) > 0 {
 		outputFields := make(map[string]interface{})
 		for state, outs := range outputs {
-			outputFields[state] = mustJSON(outs)
+			jsonOuts, marshalErr := toJSON(outs)
+			if marshalErr != nil {
+				cleanup()
+				result.Status = migrationStatusError
+				result.ErrorMessage = marshalErr.Error()
+				return result, fmt.Errorf("migration: failed to marshal outputs: %w", marshalErr)
+			}
+			outputFields[state] = jsonOuts
 		}
 		if outputsErr := ac.redisClient.HSet(ac.ctx, tempOutputsKey, outputFields).Err(); outputsErr != nil {
 			cleanup()
@@ -245,7 +264,14 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 	if len(nodes) > 0 {
 		nodeFields := make(map[string]interface{})
 		for kw, states := range nodes {
-			nodeFields[kw] = mustJSON(states)
+			jsonStates, marshalErr := toJSON(states)
+			if marshalErr != nil {
+				cleanup()
+				result.Status = migrationStatusError
+				result.ErrorMessage = marshalErr.Error()
+				return result, fmt.Errorf("migration: failed to marshal nodes: %w", err)
+			}
+			nodeFields[kw] = jsonStates
 		}
 		if nodesErr := ac.redisClient.HSet(ac.ctx, tempNodesKey, nodeFields).Err(); nodesErr != nil {
 			cleanup()

--- a/pkg/acor/migration.go
+++ b/pkg/acor/migration.go
@@ -269,7 +269,7 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 				cleanup()
 				result.Status = migrationStatusError
 				result.ErrorMessage = marshalErr.Error()
-				return result, fmt.Errorf("migration: failed to marshal nodes: %w", err)
+				return result, fmt.Errorf("migration: failed to marshal nodes: %w", marshalErr)
 			}
 			nodeFields[kw] = jsonStates
 		}

--- a/pkg/acor/trie.go
+++ b/pkg/acor/trie.go
@@ -14,21 +14,6 @@ func (ac *AhoCorasick) buildTrie(keyword string) error {
 	return ac.buildTrieWithContext(ac.ctx, keyword)
 }
 
-//nolint:unused
-func (ac *AhoCorasick) rebuildOutput(suffix string) error {
-	return ac.rebuildOutputWithContext(ac.ctx, suffix)
-}
-
-//nolint:unused
-func (ac *AhoCorasick) buildOutput(state string) error {
-	return ac.buildOutputWithContext(ac.ctx, state)
-}
-
-//nolint:unused
-func (ac *AhoCorasick) removePrefixAndSuffix(keyword, prefix, suffix string) error {
-	return ac.removePrefixAndSuffixWithContext(ac.ctx, keyword, prefix, suffix)
-}
-
 func (ac *AhoCorasick) gotoNode(inState string, input rune) (string, error) {
 	return ac.goWithContext(ac.ctx, inState, input)
 }

--- a/pkg/acor/v2_operations_extras_test.go
+++ b/pkg/acor/v2_operations_extras_test.go
@@ -275,27 +275,29 @@ func TestFindFailStateLongestSuffix(t *testing.T) {
 	}
 }
 
-func TestMustJSON(t *testing.T) {
-	result := mustJSON([]string{"a", "b"})
+func TestToJSON(t *testing.T) {
+	result, err := toJSON([]string{"a", "b"})
+	if err != nil {
+		t.Fatalf("toJSON failed: %v", err)
+	}
 	if result != `["a","b"]` {
-		t.Errorf("mustJSON([a,b]) = %q, want %q", result, `["a","b"]`)
+		t.Errorf("toJSON([a,b]) = %q, want %q", result, `["a","b"]`)
 	}
 
-	result = mustJSON(map[string]int{"x": 1})
+	result, err = toJSON(map[string]int{"x": 1})
+	if err != nil {
+		t.Fatalf("toJSON failed: %v", err)
+	}
 	if result != `{"x":1}` {
-		t.Errorf("mustJSON({x:1}) = %q, want %q", result, `{"x":1}`)
+		t.Errorf("toJSON({x:1}) = %q, want %q", result, `{"x":1}`)
 	}
 }
 
-func TestMustJSONPanics(t *testing.T) {
-	defer func() {
-		r := recover()
-		if r == nil {
-			t.Fatal("expected mustJSON to panic for unmarshallable value")
-		}
-	}()
-
-	mustJSON(func() {})
+func TestToJSONError(t *testing.T) {
+	_, err := toJSON(func() {})
+	if err == nil {
+		t.Fatal("expected toJSON to return error for unmarshallable value")
+	}
 }
 
 func TestComputeOutputsV2(t *testing.T) {

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -19,12 +19,12 @@ const retryBackoffBase = 10 * time.Millisecond
 
 const luaKeys = 2
 
-func mustJSON(v interface{}) string {
+func toJSON(v interface{}) (string, error) {
 	b, err := json.Marshal(v)
 	if err != nil {
-		panic(fmt.Sprintf("json.Marshal failed: %v", err))
+		return "", fmt.Errorf("json.Marshal failed: %w", err)
 	}
-	return string(b)
+	return string(b), nil
 }
 
 func (o *v2Operations) tryAddV2(ctx context.Context, keyword string) (int, error) { //nolint:gocyclo,funlen
@@ -111,19 +111,33 @@ func (o *v2Operations) tryAddV2(ctx context.Context, keyword string) (int, error
 
 	outputsToUpdate := make(map[string]string)
 	for state, outs := range newOutputs {
-		outputsToUpdate[state] = mustJSON(outs)
+		jsonOuts, marshalErr := toJSON(outs)
+		if marshalErr != nil {
+			return 0, newOperationError("marshal", SchemaV2, marshalErr)
+		}
+		outputsToUpdate[state] = jsonOuts
 	}
 
-	result, err := o.addV2Script(ctx, o.client, map[string]interface{}{
+	args := map[string]interface{}{
 		"trieKey":    trieKey(o.name),
 		"outputsKey": outputsKey(o.name),
-		"keywords":   mustJSON(keywords),
-		"prefixes":   mustJSON(prefixes),
-		"suffixes":   mustJSON(suffixes),
 		"newVersion": newVersion,
 		"oldVersion": oldVersion,
-		"outputs":    mustJSON(outputsToUpdate),
-	}).Result()
+	}
+	if args["keywords"], err = toJSON(keywords); err != nil {
+		return 0, newOperationError("marshal", SchemaV2, err)
+	}
+	if args["prefixes"], err = toJSON(prefixes); err != nil {
+		return 0, newOperationError("marshal", SchemaV2, err)
+	}
+	if args["suffixes"], err = toJSON(suffixes); err != nil {
+		return 0, newOperationError("marshal", SchemaV2, err)
+	}
+	if args["outputs"], err = toJSON(outputsToUpdate); err != nil {
+		return 0, newOperationError("marshal", SchemaV2, err)
+	}
+
+	result, err := o.addV2Script(ctx, o.client, args).Result()
 
 	if err != nil {
 		return 0, newRedisError("EVAL", trieKey(o.name), err)
@@ -229,19 +243,33 @@ func (o *v2Operations) tryRemoveV2(ctx context.Context, keyword string) (int, er
 
 	outputsToSet := make(map[string]string)
 	for state, outs := range newOutputs {
-		outputsToSet[state] = mustJSON(outs)
+		jsonOuts, marshalErr := toJSON(outs)
+		if marshalErr != nil {
+			return 0, newOperationError("marshal", SchemaV2, marshalErr)
+		}
+		outputsToSet[state] = jsonOuts
 	}
 
-	result, err := o.removeV2Script(ctx, o.client, map[string]interface{}{
+	args := map[string]interface{}{
 		"trieKey":    trieKey(o.name),
 		"outputsKey": outputsKey(o.name),
-		"keywords":   mustJSON(newKeywords),
-		"prefixes":   mustJSON(newPrefixes),
-		"suffixes":   mustJSON(newSuffixes),
 		"newVersion": newVersion,
 		"oldVersion": oldVersion,
-		"outputs":    mustJSON(outputsToSet),
-	}).Result()
+	}
+	if args["keywords"], err = toJSON(newKeywords); err != nil {
+		return 0, newOperationError("marshal", SchemaV2, err)
+	}
+	if args["prefixes"], err = toJSON(newPrefixes); err != nil {
+		return 0, newOperationError("marshal", SchemaV2, err)
+	}
+	if args["suffixes"], err = toJSON(newSuffixes); err != nil {
+		return 0, newOperationError("marshal", SchemaV2, err)
+	}
+	if args["outputs"], err = toJSON(outputsToSet); err != nil {
+		return 0, newOperationError("marshal", SchemaV2, err)
+	}
+
+	result, err := o.removeV2Script(ctx, o.client, args).Result()
 
 	if err != nil {
 		return 0, newRedisError("EVAL", trieKey(o.name), err)


### PR DESCRIPTION
## Summary

Release v1.5.0 — local caching, Context API, architecture improvements, and code quality hardening.

### Changes since v1.4.0

- **Local caching** for Find/FindIndex with Redis Pub/Sub invalidation
- **\*Context variants** for all public API methods
- **Architecture refactor**: KVStorage DI, Operations Strategy pattern (V1/V2)
- **mustJSON → toJSON**: Replace panic with error return for safer propagation
- **CI hardening**: Race detector, 70% coverage threshold, fuzz testing
- **Community files**: Issue/PR templates, SECURITY.md
- **Go 1.25** minimum version

### Commits

| Commit | Description |
|--------|-------------|
| `5259e9a` | refactor: replace mustJSON panic with toJSON error return |
| `0f22443` | refactor: remove unused non-Context wrapper functions in trie.go |
| `91b02c9` | chore: add tmp/ to .gitignore |
| `3e9d11b` | docs: add v1.5.0 changelog and release notes |

### Pre-merge Checklist

- [x] `go build ./...` — PASS
- [x] `go test -race -count=1 ./...` — PASS (8 packages)
- [x] `golangci-lint run` — 0 issues
- [x] `go vet ./...` — 0 issues
- [x] Pre-commit hooks — all passed
- [x] `changes/v1.5.0.md` — release notes ready for goreleaser
- [x] `CHANGELOG.md` — v1.5.0 section added

## Release Notes

* **New Features**
  * Added local caching for Find/FindIndex operations with Redis Pub/Sub invalidation.
  * Introduced Context-based variants for all public API methods.
  * Extended RemoveMany with BatchOptions support for API consistency.

* **Chores**
  * Raised Go minimum version to 1.25.
  * Enhanced CI with race detection, coverage thresholds, and fuzz testing.
  * Updated key dependencies.