### PR TITLE
fix(cache): prevent pub/sub self-message from invalidating cache

### DIFF
--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+  <article class="content">
+    {{ .Content }}
+  </article>
+{{ end }}

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -463,79 +463,79 @@ func (ac *AhoCorasick) debugV1() {
 	kKey := keywordKey(ac.name)
 	kMembers, err := ac.storage.SMembers(ac.ctx, kKey)
 	if err != nil {
-		fmt.Println("-", err)
+		ac.logger.Println("-", err)
 		return
 	}
-	fmt.Println("-", kMembers)
+	ac.logger.Println("-", kMembers)
 
 	pKey := prefixKey(ac.name)
 	pMembers, err := ac.storage.ZRange(ac.ctx, pKey, 0, -1)
 	if err != nil {
-		fmt.Println("-", err)
+		ac.logger.Println("-", err)
 		return
 	}
-	fmt.Println("-", pMembers)
+	ac.logger.Println("-", pMembers)
 
 	sKey := suffixKey(ac.name)
 	sMembers, err := ac.storage.ZRange(ac.ctx, sKey, 0, -1)
 	if err != nil {
-		fmt.Println("-", err)
+		ac.logger.Println("-", err)
 		return
 	}
-	fmt.Println("-", sMembers)
+	ac.logger.Println("-", sMembers)
 
 	outputs := make([]string, 0)
 	for _, prefix := range pMembers {
 		oOutputs, err := ac.collectOutputs(prefix)
 		if err != nil {
-			fmt.Println("-", err)
+			ac.logger.Println("-", err)
 			return
 		}
 		outputs = append(outputs, oOutputs...)
 	}
-	fmt.Println("-", outputs)
+	ac.logger.Println("-", outputs)
 
 	nodes := make([]string, 0)
 	for _, kw := range kMembers {
 		nKey := nodeKey(ac.name, kw)
 		nodeMembers, err := ac.storage.SMembers(ac.ctx, nKey)
 		if err != nil {
-			fmt.Println("-", err)
+			ac.logger.Println("-", err)
 			continue
 		}
 		nodes = append(nodes, nodeMembers...)
 	}
-	fmt.Println("-", nodes)
+	ac.logger.Println("-", nodes)
 }
 
 func (ac *AhoCorasick) debugV2() {
 	trieData, err := ac.storage.HGetAll(ac.ctx, trieKey(ac.name))
 	if err != nil {
-		fmt.Println("Error reading trie:", err)
+		ac.logger.Println("Error reading trie:", err)
 		return
 	}
-	fmt.Println("Trie data:")
+	ac.logger.Println("Trie data:")
 	for key, value := range trieData {
-		fmt.Printf("  %s: %s\n", key, value)
+		ac.logger.Printf("  %s: %s\n", key, value)
 	}
 
 	outputsData, err := ac.storage.HGetAll(ac.ctx, outputsKey(ac.name))
 	if err != nil {
-		fmt.Println("Error reading outputs:", err)
+		ac.logger.Println("Error reading outputs:", err)
 		return
 	}
-	fmt.Println("Outputs data:")
+	ac.logger.Println("Outputs data:")
 	for key, value := range outputsData {
-		fmt.Printf("  %s: %s\n", key, value)
+		ac.logger.Printf("  %s: %s\n", key, value)
 	}
 
 	nodesData, err := ac.storage.HGetAll(ac.ctx, nodesKey(ac.name))
 	if err != nil {
-		fmt.Println("Error reading nodes:", err)
+		ac.logger.Println("Error reading nodes:", err)
 		return
 	}
-	fmt.Println("Nodes data:")
+	ac.logger.Println("Nodes data:")
 	for key, value := range nodesData {
-		fmt.Printf("  %s: %s\n", key, value)
+		ac.logger.Printf("  %s: %s\n", key, value)
 	}
 }

--- a/pkg/acor/batch_extras_test.go
+++ b/pkg/acor/batch_extras_test.go
@@ -1360,6 +1360,7 @@ func TestDebugV1WithNoData(t *testing.T) {
 		storage:       newRedisStorage(client),
 		ctx:           context.Background(),
 		name:          "test",
+		logger:        &testLogger{},
 		schemaVersion: SchemaV1,
 		ops: &v1Operations{
 			storage: newRedisStorage(client),
@@ -1383,6 +1384,7 @@ func TestDebugV1WithClosedRedis(t *testing.T) {
 		storage:       newRedisStorage(client),
 		ctx:           context.Background(),
 		name:          "test",
+		logger:        &testLogger{},
 		schemaVersion: SchemaV1,
 		ops: &v1Operations{
 			storage: newRedisStorage(client),
@@ -1424,6 +1426,7 @@ func TestDebugV2WithData(t *testing.T) {
 		storage:       newRedisStorage(client),
 		ctx:           ctx,
 		name:          "test",
+		logger:        &testLogger{},
 		schemaVersion: SchemaV2,
 		ops: &v2Operations{
 			storage: newRedisStorage(client),
@@ -1447,6 +1450,7 @@ func TestDebugV2WithClosedRedis(t *testing.T) {
 		storage:       newRedisStorage(client),
 		ctx:           context.Background(),
 		name:          "test",
+		logger:        &testLogger{},
 		schemaVersion: SchemaV2,
 		ops: &v2Operations{
 			storage: newRedisStorage(client),

--- a/pkg/acor/cache.go
+++ b/pkg/acor/cache.go
@@ -2,6 +2,7 @@ package acor
 
 import (
 	"sync"
+	"sync/atomic"
 )
 
 type trieCache struct {
@@ -10,6 +11,17 @@ type trieCache struct {
 	prefixes []string
 	outputs  map[string][]string
 	valid    bool
+	// skipSelf is an atomic flag used to skip cache invalidation caused by
+	// the instance's own publishInvalidate call. Without this, the pub/sub
+	// listener would receive the message it published and invalidate the
+	// cache a second time, creating a race with concurrent Find calls.
+	skipSelf int32
+}
+
+func skipSelfSet(c *trieCache)   { atomic.StoreInt32(&c.skipSelf, 1) }
+func skipSelfClear(c *trieCache) { atomic.StoreInt32(&c.skipSelf, 0) }
+func skipSelfCheck(c *trieCache) bool {
+	return atomic.CompareAndSwapInt32(&c.skipSelf, 1, 0)
 }
 
 func cloneOutputs(in map[string][]string) map[string][]string {

--- a/pkg/acor/cache.go
+++ b/pkg/acor/cache.go
@@ -6,22 +6,26 @@ import (
 )
 
 type trieCache struct {
-	mu       sync.RWMutex
-	loadMu   sync.Mutex
-	prefixes []string
-	outputs  map[string][]string
-	valid    bool
-	// skipSelf is an atomic flag used to skip cache invalidation caused by
-	// the instance's own publishInvalidate call. Without this, the pub/sub
-	// listener would receive the message it published and invalidate the
-	// cache a second time, creating a race with concurrent Find calls.
-	skipSelf int32
+	mu                       sync.RWMutex
+	loadMu                   sync.Mutex
+	prefixes                 []string
+	outputs                  map[string][]string
+	valid                    bool
+	pendingSelfInvalidations int32
 }
 
-func skipSelfSet(c *trieCache)   { atomic.StoreInt32(&c.skipSelf, 1) }
-func skipSelfClear(c *trieCache) { atomic.StoreInt32(&c.skipSelf, 0) }
+func skipSelfSet(c *trieCache)   { atomic.AddInt32(&c.pendingSelfInvalidations, 1) }
+func skipSelfClear(c *trieCache) { atomic.AddInt32(&c.pendingSelfInvalidations, -1) }
 func skipSelfCheck(c *trieCache) bool {
-	return atomic.CompareAndSwapInt32(&c.skipSelf, 1, 0)
+	for {
+		n := atomic.LoadInt32(&c.pendingSelfInvalidations)
+		if n == 0 {
+			return false
+		}
+		if atomic.CompareAndSwapInt32(&c.pendingSelfInvalidations, n, n-1) {
+			return true
+		}
+	}
 }
 
 func cloneOutputs(in map[string][]string) map[string][]string {

--- a/pkg/acor/pubsub.go
+++ b/pkg/acor/pubsub.go
@@ -28,6 +28,9 @@ func (ac *AhoCorasick) startCacheListener() error {
 				}
 				if msg.Payload == ac.name {
 					if ac.cache != nil {
+						if skipSelfCheck(ac.cache) {
+							continue
+						}
 						ac.cache.invalidate()
 					}
 				}

--- a/pkg/acor/test_helpers_test.go
+++ b/pkg/acor/test_helpers_test.go
@@ -2,11 +2,21 @@ package acor
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	miniredis "github.com/alicebob/miniredis/v2"
 	redis "github.com/go-redis/redis/v8"
 )
+
+type noopLogger struct{}
+
+func (noopLogger) Printf(_ context.Context, _ string, _ ...interface{}) {}
+
+func TestMain(m *testing.M) {
+	redis.SetLogger(noopLogger{})
+	os.Exit(m.Run())
+}
 
 // Shared test constants used across multiple test files.
 const (

--- a/pkg/acor/v2_operations.go
+++ b/pkg/acor/v2_operations.go
@@ -261,10 +261,15 @@ func (o *v2Operations) getOrLoadCache(ctx context.Context) (prefixes []string, o
 // message so other instances refresh their caches.
 func (o *v2Operations) publishInvalidate(ctx context.Context) {
 	channel := invalidateChannelPrefix + o.name
-	if err := o.storage.Publish(ctx, channel, o.name); err != nil {
-		if o.logger != nil {
-			o.logger.Printf("failed to publish cache invalidation: channel=%s error=%v", channel, err)
-		}
+	if o.cache != nil {
+		skipSelfSet(o.cache)
+	}
+	err := o.storage.Publish(ctx, channel, o.name)
+	if err != nil && o.cache != nil {
+		skipSelfClear(o.cache)
+	}
+	if err != nil && o.logger != nil {
+		o.logger.Printf("failed to publish cache invalidation: channel=%s error=%v", channel, err)
 	}
 	if o.cache != nil {
 		o.cache.invalidate()


### PR DESCRIPTION
## Summary
- Fix race condition in `publishInvalidate()` where the instance's own PubSub message invalidates its cache after `Find()` reloads it
- Add atomic `skipSelf` flag to `trieCache` to skip self-published invalidation messages

## Root Cause

`publishInvalidate()` publishes a cache invalidation message to PubSub AND immediately invalidates the local cache. However, the instance's own PubSub listener goroutine also receives this message asynchronously. If the message arrives after `Find()` has already reloaded the cache from Redis, the freshly loaded cache gets incorrectly invalidated.

```
Timeline:
1. Add("first") → Publish + cache.invalidate()           [valid=false]
2. Find("first test") → reload from Redis               [valid=true]
3. [PubSub listener receives step 1's message] → invalidate() [valid=false] ← BUG
4. Test checks valid → false → FAIL
```

## Fix

Add an atomic `skipSelf` flag to `trieCache`:
- `publishInvalidate()`: sets `skipSelf=1` before Publish, clears on Publish failure
- PubSub listener: uses `CompareAndSwap` to skip exactly one self-message

This ensures the instance skips the invalidation message it published itself, while still processing messages from other instances.

## Verification

- `TestCache_AddInvalidatesCache` ×10 + race detector: all PASS
- `TestV2PublishInvalidateWithPublishError`: PASS (cache still invalidated on publish failure)
- `TestPubSub_Invalidate`: PASS (cross-instance invalidation works)
- `FuzzFind` 10s: PASS (416 tests, 0 failures)
* **Documentation**
  * Updated single-page content layout template.

* **Bug Fixes / Reliability**
  * Prevents unnecessary local cache invalidation when handling self-originated invalidation messages.
  * Ensures publish failures properly restore local invalidation behavior.

* **Improvements**
  * Debug output now routes through the configured logger instead of standard output.

* **Tests**
  * Tests and test runner updated to set/suppress loggers for deterministic test output.