### PR TITLE
docs: fix broken Hugo documentation links

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -154,11 +154,11 @@ import (
 - [Operations][operations-link] - Deployment and monitoring
 - [Extending][extending-link] - Custom storage backends
 
-[getting-started-link]: /getting-started/
-[guides-link]: /guides/
-[reference-link]: /reference/
-[operations-link]: /operations/
-[extending-link]: /extending/
+[getting-started-link]: getting-started/
+[guides-link]: guides/
+[reference-link]: reference/
+[operations-link]: operations/
+[extending-link]: extending/
 
 ## Development Workflow
 

--- a/docs/content/extending/_index.md
+++ b/docs/content/extending/_index.md
@@ -9,8 +9,8 @@ Extend ACOR with custom functionality.
 
 ## Sections
 
-- [Custom Storage](/extending/custom-storage/) - Implement custom storage backends
+- [Custom Storage](custom-storage/) - Implement custom storage backends
 
 ## Navigation
 
-← [Operations](/operations/)
+← [Operations](../operations/)

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -20,9 +20,9 @@ go get -u github.com/skyoo2003/acor
 
 ## Next Steps
 
-- [Installation](/getting-started/installation/) - Detailed setup instructions
-- [Quick Start](/getting-started/quick-start/) - Your first ACOR application
+- [Installation](installation/) - Detailed setup instructions
+- [Quick Start](quick-start/) - Your first ACOR application
 
 ## Continue Learning
 
-After getting started, explore the [Guides](/guides/) for advanced usage patterns.
+After getting started, explore the [Guides](../guides/) for advanced usage patterns.

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -33,13 +33,13 @@ func main() {
         Addr: "localhost:6379",
         Name: "test",
     }
-    
+
     ac, err := acor.Create(args)
     if err != nil {
         panic(err)
     }
     defer ac.Close()
-    
+
     fmt.Println("ACOR installed successfully!")
 }
 ```
@@ -60,5 +60,5 @@ acor --help
 
 ## Next Steps
 
-- [Quick Start](/getting-started/quick-start/) - Build your first application
-- [Guides](/guides/) - Learn about batch operations and parallel matching
+- [Quick Start](quick-start/) - Build your first application
+- [Guides](../guides/) - Learn about batch operations and parallel matching

--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -22,7 +22,7 @@ func main() {
         Addr: "localhost:6379",
         Name: "sample",
     }
-    
+
     ac, err := acor.Create(args)
     if err != nil {
         panic(err)
@@ -101,6 +101,6 @@ args := &acor.AhoCorasickArgs{
 
 ## Next Steps
 
-- [Batch Operations](/guides/batch-operations/) - Optimize bulk operations
-- [Parallel Matching](/guides/parallel-matching/) - Process large texts efficiently
-- [API Reference](/reference/api/) - Complete API documentation
+- [Batch Operations](../guides/batch-operations/) - Optimize bulk operations
+- [Parallel Matching](../guides/parallel-matching/) - Process large texts efficiently
+- [API Reference](../reference/api/) - Complete API documentation

--- a/docs/content/guides/_index.md
+++ b/docs/content/guides/_index.md
@@ -9,9 +9,9 @@ Practical guides for using ACOR effectively.
 
 ## Available Guides
 
-- [Batch Operations](/guides/batch-operations/) - Optimize bulk keyword operations
-- [Parallel Matching](/guides/parallel-matching/) - Process large texts with multiple workers
+- [Batch Operations](batch-operations/) - Optimize bulk keyword operations
+- [Parallel Matching](parallel-matching/) - Process large texts with multiple workers
 
 ## Navigation
 
-← [Getting Started](/getting-started/) | [Reference](/reference/) →
+← [Getting Started](../getting-started/) | [Reference](../reference/) →

--- a/docs/content/guides/batch-operations.md
+++ b/docs/content/guides/batch-operations.md
@@ -87,5 +87,5 @@ type BatchResult struct {
 
 ## Next Steps
 
-- [Parallel Matching](/guides/parallel-matching/) - Process large texts efficiently
-- [API Reference](/reference/api/) - Complete API documentation
+- [Parallel Matching](parallel-matching/) - Process large texts efficiently
+- [API Reference](../reference/api/) - Complete API documentation

--- a/docs/content/guides/parallel-matching.md
+++ b/docs/content/guides/parallel-matching.md
@@ -101,5 +101,5 @@ opts := &acor.ParallelOptions{
 
 ## Next Steps
 
-- [Batch Operations](/guides/batch-operations/) - Optimize bulk keyword operations
-- [API Reference](/reference/api/) - Complete API documentation
+- [Batch Operations](batch-operations/) - Optimize bulk keyword operations
+- [API Reference](../reference/api/) - Complete API documentation

--- a/docs/content/operations/_index.md
+++ b/docs/content/operations/_index.md
@@ -9,10 +9,10 @@ Operational guides for running ACOR in production.
 
 ## Sections
 
-- [Deployment](/operations/deployment/) - Deploy ACOR in various environments
-- [Monitoring](/operations/monitoring/) - Monitor ACOR performance
-- [Troubleshooting](/operations/troubleshooting/) - Diagnose and fix issues
+- [Deployment](deployment/) - Deploy ACOR in various environments
+- [Monitoring](monitoring/) - Monitor ACOR performance
+- [Troubleshooting](troubleshooting/) - Diagnose and fix issues
 
 ## Navigation
 
-← [Reference](/reference/) | [Extending](/extending/) →
+← [Reference](../reference/) | [Extending](../extending/) →

--- a/docs/content/reference/_index.md
+++ b/docs/content/reference/_index.md
@@ -9,10 +9,10 @@ Technical reference documentation for ACOR.
 
 ## Sections
 
-- [API Reference](/reference/api/) - Public API documentation
-- [Schema V1](/reference/schema-v1/) - Legacy schema details
-- [Schema V2](/reference/schema-v2/) - Optimized schema (recommended)
+- [API Reference](api/) - Public API documentation
+- [Schema V1](schema-v1/) - Legacy schema details
+- [Schema V2](schema-v2/) - Optimized schema (recommended)
 
 ## Navigation
 
-← [Guides](/guides/) | [Operations](/operations/) →
+← [Guides](../guides/) | [Operations](../operations/) →


### PR DESCRIPTION
## Summary

- Fix all 25 absolute link references (`/getting-started/`, `/guides/`, etc.) across 10 markdown files that resolved to `skyoo2003.github.io/getting-started/` (404) instead of `skyoo2003.github.io/acor/getting-started/`
- Convert to relative paths: same-section links use `page/`, cross-section links use `../section/`
- Hugo's `baseURL` only rewrites its own generated URLs, not hardcoded absolute paths in markdown content

## Verification

Built locally with `hugo --source docs --baseURL "https://skyoo2003.github.io/acor/"` — zero `href="/"` links without `/acor/` prefix remain.