### PR TITLE
fix(security): run containers as non-root user to prevent RCE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ WORKDIR /github.com/skyoo2003/acor
 COPY . .
 RUN make build
 
-FROM alpine:3.15.11
+FROM alpine:3.21
 
-RUN addgroup app \
-  && adduser -D -h /acor -G app appuser \
+RUN addgroup -S -g 1000 app \
+  && adduser -S -u 1000 -h /acor -G app appuser \
   && mkdir -p /acor \
   && chown appuser:app /acor
 VOLUME /acor

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ RUN make build
 
 FROM alpine:3.15.11
 
+RUN adduser --system --home /acor appuser
 VOLUME /acor
 WORKDIR /acor
 COPY --from=builder /github.com/skyoo2003/acor/dist/acor /usr/bin/acor
 
+USER appuser
 ENTRYPOINT ["acor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN make build
 
 FROM alpine:3.15.11
 
-RUN adduser --system --home /acor appuser
+RUN adduser -D -h /acor appuser && mkdir -p /acor && chown appuser:appuser /acor
 VOLUME /acor
 WORKDIR /acor
 COPY --from=builder /github.com/skyoo2003/acor/dist/acor /usr/bin/acor

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,13 @@ RUN make build
 
 FROM alpine:3.15.11
 
-RUN addgroup -g 1000 app \
-  && adduser -D -h /acor -u 1000 -G app appuser \
+RUN addgroup app \
+  && adduser -D -h /acor -G app appuser \
   && mkdir -p /acor \
-  && chown 1000:1000 /acor
+  && chown appuser:app /acor
 VOLUME /acor
 WORKDIR /acor
-COPY --from=builder --chown=1000:1000 /github.com/skyoo2003/acor/dist/acor /usr/bin/acor
+COPY --from=builder --chown=appuser:app /github.com/skyoo2003/acor/dist/acor /usr/bin/acor
 
 USER appuser
 ENTRYPOINT ["acor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,12 @@ RUN make build
 FROM alpine:3.15.11
 
 RUN addgroup -g 1000 app \
-  && adduser -D -h /acor -u 1000 -G app appuser
+  && adduser -D -h /acor -u 1000 -G app appuser \
+  && mkdir -p /acor \
+  && chown 1000:1000 /acor
 VOLUME /acor
 WORKDIR /acor
 COPY --from=builder --chown=1000:1000 /github.com/skyoo2003/acor/dist/acor /usr/bin/acor
 
-USER 1000:1000
+USER appuser
 ENTRYPOINT ["acor"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,11 @@ RUN make build
 
 FROM alpine:3.15.11
 
-RUN adduser -D -h /acor appuser && mkdir -p /acor && chown appuser:appuser /acor
+RUN addgroup -g 1000 app \
+  && adduser -D -h /acor -u 1000 -G app appuser
 VOLUME /acor
 WORKDIR /acor
-COPY --from=builder /github.com/skyoo2003/acor/dist/acor /usr/bin/acor
+COPY --from=builder --chown=1000:1000 /github.com/skyoo2003/acor/dist/acor /usr/bin/acor
 
-USER appuser
+USER 1000:1000
 ENTRYPOINT ["acor"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,7 +1,9 @@
 FROM alpine:3.21
 
+RUN adduser --system --home /acor appuser
 VOLUME /acor
 WORKDIR /acor
 COPY acor /usr/bin/acor
 
+USER appuser
 ENTRYPOINT ["acor"]


### PR DESCRIPTION
## Summary
- Create a dedicated `appuser` (unprivileged system user) in both `Dockerfile` and `Dockerfile.goreleaser`
- Add `USER appuser` directive to run the container process as non-root
- This prevents full root privilege escalation if the container is compromised

## Security Context
Resolves RCE risk where an exploited service inside the container would have full root access, enabling lateral movement, container escape attempts, and host impact via mounted volumes or the Docker socket.

## Test Plan
- [ ] Verify `docker build` succeeds for both Dockerfiles
- [ ] Verify container runs as `appuser` (`docker exec <id> whoami` returns `appuser`)
- [ ] Verify application still functions correctly (no permission issues on `/acor` volume)

## Summary by Sourcery

Run container images as a non-root application user to reduce privilege escalation risk.

Bug Fixes:
- Ensure application binaries and working directory are owned by an unprivileged user to avoid running containers as root.

Enhancements:
- Define a dedicated unprivileged app user and group in Docker images and set it as the container runtime user.

Build:
- Update Dockerfile and Dockerfile.goreleaser to configure user ownership and permissions for the application binary and working directory.