### PR TITLE
ci(security): pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache-dependency-path: go.sum
       - name: Execute golangci-lint
-        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # golangci-lint-action v9.2.0
         with:
           version: v2.11.3
       - name: Run go vet

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache-dependency-path: go.sum
       - name: Execute golangci-lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20
         with:
           version: v2.11.3
       - name: Run go vet

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,13 +20,13 @@ jobs:
         cache-dependency-path: go.sum
     - name: Get current tag name
       id: getTag
-      uses: olegtarasov/get-tag@ee816a9e9fa8b2ecd226d546d32445ddcbec1307
+      uses: olegtarasov/get-tag@ee816a9e9fa8b2ecd226d546d32445ddcbec1307  # get-tag v2.1
     - name: Login to Docker Registry
       run: >
         echo "${{ secrets.GH_PAT }}" |
         docker login ghcr.io -u skyoo2003 --password-stdin
     - name: Execute GoReleaser
-      uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29
+      uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29  # goreleaser-action v7
       with:
         distribution: goreleaser
         version: "~> v2"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,13 +20,13 @@ jobs:
         cache-dependency-path: go.sum
     - name: Get current tag name
       id: getTag
-      uses: olegtarasov/get-tag@v2.1
+      uses: olegtarasov/get-tag@ee816a9e9fa8b2ecd226d546d32445ddcbec1307
     - name: Login to Docker Registry
       run: >
         echo "${{ secrets.GH_PAT }}" |
         docker login ghcr.io -u skyoo2003 --password-stdin
     - name: Execute GoReleaser
-      uses: goreleaser/goreleaser-action@v7.0.0
+      uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29
       with:
         distribution: goreleaser
         version: "~> v2"


### PR DESCRIPTION
## Summary
- Pin `golangci/golangci-lint-action` to `@1e7e51e` (was `@v9.2.0`)
- Pin `olegtarasov/get-tag` to `@ee816a9` (was `@v2.1`)
- Pin `goreleaser/goreleaser-action` to `@ec59f47` (was `@v7.0.0`)

## Motivation
Third-party actions referenced by tag/branch are mutable — an attacker could alter the action and run arbitrary code in CI, exfiltrating secrets or injecting backdoors into build outputs. Pinning to full-length commit SHAs guarantees action integrity.

Fixes: Remote code execution (RCE) from unpinned third-party action

## Summary by Sourcery

Pin third-party GitHub Actions used in CI and release workflows to specific commit SHAs to improve supply-chain security.

CI:
- Pin golangci/golangci-lint-action in the CI workflow to a fixed commit SHA instead of a mutable version tag.

Deployment:
- Pin olegtarasov/get-tag and goreleaser/goreleaser-action in the release workflow to fixed commit SHAs instead of mutable version tags.