### PR TITLE
fix(ci): migrate goreleaser config to v2 format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,28 +46,28 @@ archives:
     - CODE_OF_CONDUCT.md
 
 changelog:
-  skip: true
+  disable: true
 
 checksum:
   algorithm: sha256
   name_template: 'CHECKSUMS'
 
-docker:
-- ids:
-  - acor
+dockers_v2:
+- images:
+  - ghcr.io/skyoo2003/acor
   dockerfile: Dockerfile.goreleaser
-  use: buildx
-  image_templates:
-  - "ghcr.io/skyoo2003/acor:{{ .Tag }}-alpine"
-  - "ghcr.io/skyoo2003/acor:v{{ .Major }}.{{ .Minor }}-alpine"
-  - "ghcr.io/skyoo2003/acor:v{{ .Major }}-alpine"
-  - "ghcr.io/skyoo2003/acor:latest-alpine"
+  ids:
+  - acor
+  tags:
+  - "{{ .Tag }}-alpine"
+  - "v{{ .Major }}.{{ .Minor }}-alpine"
+  - "v{{ .Major }}-alpine"
+  - "latest-alpine"
   build_flag_templates:
   - "--label=org.opencontainers.image.created={{ .Date }}"
   - "--label=org.opencontainers.image.title={{ .ProjectName }}"
   - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
   - "--label=org.opencontainers.image.version={{ .Version }}"
-  skip_push: false
 
 release:
   github:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,11 +63,11 @@ dockers_v2:
   - "v{{ .Major }}.{{ .Minor }}-alpine"
   - "v{{ .Major }}-alpine"
   - "latest-alpine"
-  build_flag_templates:
-  - "--label=org.opencontainers.image.created={{ .Date }}"
-  - "--label=org.opencontainers.image.title={{ .ProjectName }}"
-  - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
-  - "--label=org.opencontainers.image.version={{ .Version }}"
+  labels:
+    org.opencontainers.image.created: "{{ .Date }}"
+    org.opencontainers.image.title: "{{ .ProjectName }}"
+    org.opencontainers.image.revision: "{{ .FullCommit }}"
+    org.opencontainers.image.version: "{{ .Version }}"
 
 release:
   github:


### PR DESCRIPTION
## Summary
- `changelog.skip` → `changelog.disable` (removed in GoReleaser v2)
- `docker` → `dockers_v2` with new `images`/`tags` syntax

Fixes the CI release failure:
```
line 49: field skip not found in type config.Changelog
line 55: field docker not found in type config.Project
```

## Test plan
- [ ] Verify `goreleaser check` passes locally
- [ ] Confirm CI release workflow runs successfully


## Summary by Sourcery

Update GoReleaser configuration to be compatible with v2 and restore release pipeline.

Build:
- Migrate changelog configuration from deprecated `skip` field to `disable` for GoReleaser v2.
- Update Docker release configuration from `docker` to `dockers_v2` with new images/tags layout to fix CI release failures.