### PR TITLE
fix(docker): use platform-specific binary path for GoReleaser v2

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,9 +1,11 @@
-FROM alpine:3.21
+FROM --platform=$BUILDPLATFORM alpine:3.21
 
 RUN adduser --system --home /acor appuser
 VOLUME /acor
 WORKDIR /acor
-COPY acor /usr/bin/acor
+ARG TARGETOS
+ARG TARGETARCH
+COPY ${TARGETOS}/${TARGETARCH}/acor /usr/bin/acor
 
 USER appuser
 ENTRYPOINT ["acor"]


### PR DESCRIPTION
## Summary
- Update `Dockerfile.goreleaser` to use `${TARGETOS}/${TARGETARCH}/acor` path instead of `acor` for compatibility with GoReleaser v2 `dockers_v2`
- Add `--platform=$BUILDPLATFORM` to base image for multi-arch builds
- Add `ARG TARGETOS` and `ARG TARGETARCH` for platform-specific COPY

## Test plan
- [x] Verified locally with `goreleaser release` — Docker images built and pushed successfully
- [ ] CI workflow passes on merge
## Summary by Sourcery

Update GoReleaser Dockerfile to support GoReleaser v2 multi-arch Docker builds with platform-specific binary paths.

Build:
- Adjust GoReleaser Dockerfile to copy binaries from platform-specific ${TARGETOS}/${TARGETARCH} paths required by GoReleaser v2 dockers_v2.
- Configure Docker build to use --platform=$BUILDPLATFORM and ARG TARGETOS/TARGETARCH to enable correct multi-architecture image builds.