### PR TITLE
fix(ci): disable SBOM attestation and add source label for Docker images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,8 +56,11 @@ dockers_v2:
 - images:
   - ghcr.io/skyoo2003/acor
   dockerfile: Dockerfile.goreleaser
+  use: buildx
   ids:
   - acor
+  sbom:
+    disabled: true
   tags:
   - "{{ .Tag }}-alpine"
   - "v{{ .Major }}.{{ .Minor }}-alpine"
@@ -65,6 +68,7 @@ dockers_v2:
   - "latest-alpine"
   labels:
     org.opencontainers.image.created: "{{ .Date }}"
+    org.opencontainers.image.source: "https://github.com/skyoo2003/acor"
     org.opencontainers.image.title: "{{ .ProjectName }}"
     org.opencontainers.image.revision: "{{ .FullCommit }}"
     org.opencontainers.image.version: "{{ .Version }}"


### PR DESCRIPTION
## Summary
- Disable SBOM attestation (`sbom.disabled: true`) in `dockers_v2` — `--attest=type=sbom` is not supported by the docker driver on GitHub Actions runners
- Add `use: buildx` to explicitly use buildx builder
- Add `org.opencontainers.image.source` label

## Test plan
- [ ] GoReleaser release workflow passes
## Summary by Sourcery

Adjust Docker image build configuration in GoReleaser to improve compatibility with GitHub Actions and enrich image metadata.

Build:
- Configure Docker builds to explicitly use the buildx builder in GoReleaser.
- Add org.opencontainers.image.source label to Docker images built via GoReleaser.

CI:
- Disable SBOM attestation in GoReleaser Docker builds to avoid unsupported options on GitHub Actions runners.