### PR TITLE
fix(ci): remove unsupported  field from dockers_v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,7 +56,6 @@ dockers_v2:
 - images:
   - ghcr.io/skyoo2003/acor
   dockerfile: Dockerfile.goreleaser
-  use: buildx
   ids:
   - acor
   sbom: false


### PR DESCRIPTION
## Summary
- Remove `use: buildx` from `dockers_v2` — this field is not supported in `config.DockerV2` and causes `yaml: unmarshal errors`

## Test plan
- [ ] GoReleaser release workflow passes
## Summary by Sourcery

Build:
- Remove unsupported `use: buildx` option from the `dockers_v2` GoReleaser configuration to prevent YAML unmarshal errors.