### PR TITLE
fix: address code review findings for v0.6.0

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -52,7 +52,6 @@ linters:
         - style
     gocyclo:
       min-complexity: 15
-    gosec:
     govet:
       enable:
         - shadow

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -52,6 +52,9 @@ linters:
         - style
     gocyclo:
       min-complexity: 15
+    gosec:
+      excludes:
+        - G118
     govet:
       enable:
         - shadow

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -53,8 +53,6 @@ linters:
     gocyclo:
       min-complexity: 15
     gosec:
-      excludes:
-        - G118
     govet:
       enable:
         - shadow

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -445,10 +445,10 @@ func (ac *AhoCorasick) Close() error {
 			return
 		}
 		alreadyClosed = false
-		ac.stopCacheListener()
 		if ac.cancel != nil {
 			ac.cancel()
 		}
+		ac.stopCacheListener()
 		closeErr = ac.storage.Close()
 		ac.storage = nil
 	})

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -372,24 +372,9 @@ func Create(args *AhoCorasickArgs) (*AhoCorasick, error) {
 		if cleanupInterval == 0 {
 			cleanupInterval = defaultSelfInvalidationCleanupInterval
 		}
-		ac.ops = &v2Operations{
-			storage:                         storage,
-			client:                          redisClient,
-			name:                            args.Name,
-			cache:                           cache,
-			logger:                          logger,
-			selfInvalidationCleanupInterval: cleanupInterval,
-			caseSensitive:                   args.CaseSensitive,
-		}
+		ac.ops = ac.newV2Ops(args.CaseSensitive, cache, cleanupInterval)
 	} else {
-		ac.ops = &v1Operations{
-			storage:         storage,
-			name:            args.Name,
-			logger:          logger,
-			ac:              ac,
-			caseSensitive:   args.CaseSensitive,
-			rollbackTimeout: resolveRollbackTimeout(args.RollbackTimeout),
-		}
+		ac.ops = ac.newV1Ops(args.CaseSensitive, resolveRollbackTimeout(args.RollbackTimeout))
 	}
 
 	if err := ac.init(); err != nil {
@@ -466,6 +451,29 @@ func (ac *AhoCorasick) Close() error {
 		return ErrRedisAlreadyClosed
 	}
 	return closeErr
+}
+
+func (ac *AhoCorasick) newV2Ops(caseSensitive bool, cache *trieCache, cleanupInterval uint64) operations {
+	return &v2Operations{
+		storage:                         ac.storage,
+		client:                          ac.redisClient,
+		name:                            ac.name,
+		cache:                           cache,
+		logger:                          ac.logger,
+		selfInvalidationCleanupInterval: cleanupInterval,
+		caseSensitive:                   caseSensitive,
+	}
+}
+
+func (ac *AhoCorasick) newV1Ops(caseSensitive bool, rollbackTimeout time.Duration) operations {
+	return &v1Operations{
+		storage:         ac.storage,
+		name:            ac.name,
+		logger:          ac.logger,
+		ac:              ac,
+		caseSensitive:   caseSensitive,
+		rollbackTimeout: rollbackTimeout,
+	}
 }
 
 // Add inserts a keyword into the Aho-Corasick automaton.

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -264,6 +264,7 @@ type AhoCorasickArgs struct {
 // All methods are safe for concurrent use across multiple goroutines.
 type AhoCorasick struct {
 	ctx           context.Context
+	cancel        context.CancelFunc
 	name          string
 	logger        Logger
 	storage       KVStorage             // DI: all Redis ops go through this
@@ -357,12 +358,14 @@ func Create(args *AhoCorasickArgs) (*AhoCorasick, error) {
 	ac := &AhoCorasick{
 		redisClient:   redisClient,
 		storage:       storage,
-		ctx:           context.Background(),
 		name:          args.Name,
 		logger:        logger,
 		schemaVersion: schemaVersion,
 		cache:         cache,
 	}
+	var ctxCancel context.CancelFunc
+	ac.ctx, ctxCancel = context.WithCancel(context.Background())
+	ac.cancel = ctxCancel
 
 	if schemaVersion == SchemaV2 {
 		cleanupInterval := args.SelfInvalidationCleanupInterval
@@ -453,6 +456,9 @@ func (ac *AhoCorasick) Close() error {
 		}
 		alreadyClosed = false
 		ac.stopCacheListener()
+		if ac.cancel != nil {
+			ac.cancel()
+		}
 		closeErr = ac.storage.Close()
 		ac.storage = nil
 	})

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -374,9 +374,7 @@ func Create(args *AhoCorasickArgs) (*AhoCorasick, error) {
 	}
 	ac.rollbackTimeout = resolveRollbackTimeout(args.RollbackTimeout)
 	ac.caseSensitive = args.CaseSensitive
-	var ctxCancel context.CancelFunc
-	ac.ctx, ctxCancel = context.WithCancel(context.Background()) //nolint:gosec // G118: storing cancel func is intentional for lifecycle management
-	ac.cancel = ctxCancel
+	ac.ctx, ac.cancel = context.WithCancel(context.Background()) //nolint:gosec // G118: storing cancel func is intentional for lifecycle management
 
 	if schemaVersion == SchemaV2 {
 		ac.ops = ac.newV2Ops(cache)
@@ -385,14 +383,14 @@ func Create(args *AhoCorasickArgs) (*AhoCorasick, error) {
 	}
 
 	if err := ac.init(); err != nil {
-		ctxCancel()
+		ac.cancel()
 		_ = storage.Close()
 		return nil, err
 	}
 
 	if args.EnableCache {
 		if err := ac.startCacheListener(); err != nil {
-			ctxCancel()
+			ac.cancel()
 			_ = storage.Close()
 			return nil, err
 		}

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -275,6 +275,7 @@ type AhoCorasick struct {
 
 	selfInvalidationCleanupInterval uint64
 	rollbackTimeout                 time.Duration
+	caseSensitive                   bool
 
 	cache     *trieCache
 	pubsub    Subscription
@@ -372,23 +373,26 @@ func Create(args *AhoCorasickArgs) (*AhoCorasick, error) {
 		ac.selfInvalidationCleanupInterval = defaultSelfInvalidationCleanupInterval
 	}
 	ac.rollbackTimeout = resolveRollbackTimeout(args.RollbackTimeout)
+	ac.caseSensitive = args.CaseSensitive
 	var ctxCancel context.CancelFunc
-	ac.ctx, ctxCancel = context.WithCancel(context.Background())
+	ac.ctx, ctxCancel = context.WithCancel(context.Background()) //nolint:gosec // G118: storing cancel func is intentional for lifecycle management
 	ac.cancel = ctxCancel
 
 	if schemaVersion == SchemaV2 {
-		ac.ops = ac.newV2Ops(args.CaseSensitive, cache)
+		ac.ops = ac.newV2Ops(cache)
 	} else {
-		ac.ops = ac.newV1Ops(args.CaseSensitive)
+		ac.ops = ac.newV1Ops()
 	}
 
 	if err := ac.init(); err != nil {
+		ctxCancel()
 		_ = storage.Close()
 		return nil, err
 	}
 
 	if args.EnableCache {
 		if err := ac.startCacheListener(); err != nil {
+			ctxCancel()
 			_ = storage.Close()
 			return nil, err
 		}
@@ -458,7 +462,7 @@ func (ac *AhoCorasick) Close() error {
 	return closeErr
 }
 
-func (ac *AhoCorasick) newV2Ops(caseSensitive bool, cache *trieCache) operations {
+func (ac *AhoCorasick) newV2Ops(cache *trieCache) operations {
 	return &v2Operations{
 		storage:                         ac.storage,
 		client:                          ac.redisClient,
@@ -466,17 +470,17 @@ func (ac *AhoCorasick) newV2Ops(caseSensitive bool, cache *trieCache) operations
 		cache:                           cache,
 		logger:                          ac.logger,
 		selfInvalidationCleanupInterval: ac.selfInvalidationCleanupInterval,
-		caseSensitive:                   caseSensitive,
+		caseSensitive:                   ac.caseSensitive,
 	}
 }
 
-func (ac *AhoCorasick) newV1Ops(caseSensitive bool) operations {
+func (ac *AhoCorasick) newV1Ops() operations {
 	return &v1Operations{
 		storage:         ac.storage,
 		name:            ac.name,
 		logger:          ac.logger,
 		ac:              ac,
-		caseSensitive:   caseSensitive,
+		caseSensitive:   ac.caseSensitive,
 		rollbackTimeout: ac.rollbackTimeout,
 	}
 }

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -273,6 +273,9 @@ type AhoCorasick struct {
 	buildTrieHook func(string) error
 	schemaVersion int // kept for SchemaVersion() and migration.go
 
+	selfInvalidationCleanupInterval uint64
+	rollbackTimeout                 time.Duration
+
 	cache     *trieCache
 	pubsub    Subscription
 	stopCh    chan struct{}
@@ -363,18 +366,20 @@ func Create(args *AhoCorasickArgs) (*AhoCorasick, error) {
 		schemaVersion: schemaVersion,
 		cache:         cache,
 	}
+	if args.SelfInvalidationCleanupInterval > 0 {
+		ac.selfInvalidationCleanupInterval = args.SelfInvalidationCleanupInterval
+	} else {
+		ac.selfInvalidationCleanupInterval = defaultSelfInvalidationCleanupInterval
+	}
+	ac.rollbackTimeout = resolveRollbackTimeout(args.RollbackTimeout)
 	var ctxCancel context.CancelFunc
 	ac.ctx, ctxCancel = context.WithCancel(context.Background())
 	ac.cancel = ctxCancel
 
 	if schemaVersion == SchemaV2 {
-		cleanupInterval := args.SelfInvalidationCleanupInterval
-		if cleanupInterval == 0 {
-			cleanupInterval = defaultSelfInvalidationCleanupInterval
-		}
-		ac.ops = ac.newV2Ops(args.CaseSensitive, cache, cleanupInterval)
+		ac.ops = ac.newV2Ops(args.CaseSensitive, cache)
 	} else {
-		ac.ops = ac.newV1Ops(args.CaseSensitive, resolveRollbackTimeout(args.RollbackTimeout))
+		ac.ops = ac.newV1Ops(args.CaseSensitive)
 	}
 
 	if err := ac.init(); err != nil {
@@ -453,26 +458,26 @@ func (ac *AhoCorasick) Close() error {
 	return closeErr
 }
 
-func (ac *AhoCorasick) newV2Ops(caseSensitive bool, cache *trieCache, cleanupInterval uint64) operations {
+func (ac *AhoCorasick) newV2Ops(caseSensitive bool, cache *trieCache) operations {
 	return &v2Operations{
 		storage:                         ac.storage,
 		client:                          ac.redisClient,
 		name:                            ac.name,
 		cache:                           cache,
 		logger:                          ac.logger,
-		selfInvalidationCleanupInterval: cleanupInterval,
+		selfInvalidationCleanupInterval: ac.selfInvalidationCleanupInterval,
 		caseSensitive:                   caseSensitive,
 	}
 }
 
-func (ac *AhoCorasick) newV1Ops(caseSensitive bool, rollbackTimeout time.Duration) operations {
+func (ac *AhoCorasick) newV1Ops(caseSensitive bool) operations {
 	return &v1Operations{
 		storage:         ac.storage,
 		name:            ac.name,
 		logger:          ac.logger,
 		ac:              ac,
 		caseSensitive:   caseSensitive,
-		rollbackTimeout: rollbackTimeout,
+		rollbackTimeout: ac.rollbackTimeout,
 	}
 }
 

--- a/pkg/acor/migration.go
+++ b/pkg/acor/migration.go
@@ -326,11 +326,7 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 
 	// Swap ops to v2Operations so the instance uses V2 schema operations
 	// going forward. The cache is already set up if EnableCache was true.
-	var caseSensitive bool
-	if v1, ok := ac.ops.(*v1Operations); ok {
-		caseSensitive = v1.caseSensitive
-	}
-	ac.ops = ac.newV2Ops(caseSensitive, ac.cache)
+	ac.ops = ac.newV2Ops(ac.cache)
 
 	result.Status = migrationStatusSuccess
 	result.DurationMs = time.Since(start).Milliseconds()
@@ -362,11 +358,7 @@ func (ac *AhoCorasick) RollbackToV1() error {
 	// Swap ops to v1Operations so the instance uses V1 schema operations
 	// going forward. Cache is not supported in V1, so set it to nil.
 	ac.cache = nil
-	var caseSensitive bool
-	if v2, ok := ac.ops.(*v2Operations); ok {
-		caseSensitive = v2.caseSensitive
-	}
-	ac.ops = ac.newV1Ops(caseSensitive)
+	ac.ops = ac.newV1Ops()
 
 	return nil
 }

--- a/pkg/acor/migration.go
+++ b/pkg/acor/migration.go
@@ -356,7 +356,9 @@ func (ac *AhoCorasick) RollbackToV1() error {
 	ac.schemaVersion = SchemaV1
 
 	// Swap ops to v1Operations so the instance uses V1 schema operations
-	// going forward. Cache is not supported in V1, so set it to nil.
+	// going forward. Cache is not supported in V1, so stop the listener
+	// and clear the cache.
+	ac.stopCacheListener()
 	ac.cache = nil
 	ac.ops = ac.newV1Ops()
 

--- a/pkg/acor/migration.go
+++ b/pkg/acor/migration.go
@@ -330,7 +330,7 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 	if v1, ok := ac.ops.(*v1Operations); ok {
 		caseSensitive = v1.caseSensitive
 	}
-	ac.ops = ac.newV2Ops(caseSensitive, ac.cache, defaultSelfInvalidationCleanupInterval)
+	ac.ops = ac.newV2Ops(caseSensitive, ac.cache)
 
 	result.Status = migrationStatusSuccess
 	result.DurationMs = time.Since(start).Milliseconds()
@@ -366,7 +366,7 @@ func (ac *AhoCorasick) RollbackToV1() error {
 	if v2, ok := ac.ops.(*v2Operations); ok {
 		caseSensitive = v2.caseSensitive
 	}
-	ac.ops = ac.newV1Ops(caseSensitive, defaultRollbackTimeout)
+	ac.ops = ac.newV1Ops(caseSensitive)
 
 	return nil
 }

--- a/pkg/acor/migration.go
+++ b/pkg/acor/migration.go
@@ -330,15 +330,7 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 	if v1, ok := ac.ops.(*v1Operations); ok {
 		caseSensitive = v1.caseSensitive
 	}
-	ac.ops = &v2Operations{
-		storage:                         ac.storage,
-		client:                          ac.redisClient,
-		name:                            ac.name,
-		cache:                           ac.cache,
-		logger:                          ac.logger,
-		selfInvalidationCleanupInterval: defaultSelfInvalidationCleanupInterval,
-		caseSensitive:                   caseSensitive,
-	}
+	ac.ops = ac.newV2Ops(caseSensitive, ac.cache, defaultSelfInvalidationCleanupInterval)
 
 	result.Status = migrationStatusSuccess
 	result.DurationMs = time.Since(start).Milliseconds()
@@ -374,14 +366,7 @@ func (ac *AhoCorasick) RollbackToV1() error {
 	if v2, ok := ac.ops.(*v2Operations); ok {
 		caseSensitive = v2.caseSensitive
 	}
-	ac.ops = &v1Operations{
-		storage:         ac.storage,
-		name:            ac.name,
-		logger:          ac.logger,
-		ac:              ac,
-		caseSensitive:   caseSensitive,
-		rollbackTimeout: defaultRollbackTimeout,
-	}
+	ac.ops = ac.newV1Ops(caseSensitive, defaultRollbackTimeout)
 
 	return nil
 }

--- a/pkg/acor/migration.go
+++ b/pkg/acor/migration.go
@@ -324,6 +324,22 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 
 	ac.schemaVersion = SchemaV2
 
+	// Swap ops to v2Operations so the instance uses V2 schema operations
+	// going forward. The cache is already set up if EnableCache was true.
+	var caseSensitive bool
+	if v1, ok := ac.ops.(*v1Operations); ok {
+		caseSensitive = v1.caseSensitive
+	}
+	ac.ops = &v2Operations{
+		storage:                         ac.storage,
+		client:                          ac.redisClient,
+		name:                            ac.name,
+		cache:                           ac.cache,
+		logger:                          ac.logger,
+		selfInvalidationCleanupInterval: defaultSelfInvalidationCleanupInterval,
+		caseSensitive:                   caseSensitive,
+	}
+
 	result.Status = migrationStatusSuccess
 	result.DurationMs = time.Since(start).Milliseconds()
 
@@ -350,6 +366,22 @@ func (ac *AhoCorasick) RollbackToV1() error {
 	}
 
 	ac.schemaVersion = SchemaV1
+
+	// Swap ops to v1Operations so the instance uses V1 schema operations
+	// going forward. Cache is not supported in V1, so set it to nil.
+	ac.cache = nil
+	var caseSensitive bool
+	if v2, ok := ac.ops.(*v2Operations); ok {
+		caseSensitive = v2.caseSensitive
+	}
+	ac.ops = &v1Operations{
+		storage:         ac.storage,
+		name:            ac.name,
+		logger:          ac.logger,
+		ac:              ac,
+		caseSensitive:   caseSensitive,
+		rollbackTimeout: defaultRollbackTimeout,
+	}
 
 	return nil
 }

--- a/pkg/acor/v2_lua.go
+++ b/pkg/acor/v2_lua.go
@@ -51,9 +51,8 @@ var removeV2Script = redis.NewScript(`
 
 	redis.call('HSET', trieKey, 'keywords', keywords, 'prefixes', prefixes, 'suffixes', suffixes, 'version', newVersion)
 
-	redis.call('DEL', outputsKey)
-
 	local outputs = cjson.decode(outputsJson)
+	redis.call('DEL', outputsKey)
 	for state, jsonOuts in pairs(outputs) do
 		redis.call('HSET', outputsKey, state, jsonOuts)
 	end

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -413,7 +413,7 @@ func decodeRequest(w http.ResponseWriter, r *http.Request, v interface{}) bool {
 		var mbe *http.MaxBytesError
 		if errors.As(err, &mbe) {
 			writeJSON(w, http.StatusRequestEntityTooLarge,
-				&ErrorResponse{Error: fmt.Sprintf("request body exceeds %d bytes", maxRequestBodyBytes)})
+				&ErrorResponse{Error: fmt.Sprintf("request body must not be larger than %d bytes", mbe.Limit)})
 		} else {
 			writeJSON(w, http.StatusBadRequest, &ErrorResponse{Error: err.Error()})
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -400,16 +400,15 @@ func (api *API) handleFlush(w http.ResponseWriter, r *http.Request) {
 
 const maxRequestBodyBytes = 1 << 20 // 1MB
 
-func decodeKeywordRequest(w http.ResponseWriter, r *http.Request) (*KeywordRequest, bool) {
+func decodeRequest(w http.ResponseWriter, r *http.Request, v interface{}) bool {
 	if r.Method != http.MethodPost {
 		writeMethodNotAllowed(w)
-		return nil, false
+		return false
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	defer closeReadCloser(r.Body)
 
-	var req KeywordRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
 		var mbe *http.MaxBytesError
 		if errors.As(err, &mbe) {
 			writeJSON(w, http.StatusRequestEntityTooLarge,
@@ -417,28 +416,22 @@ func decodeKeywordRequest(w http.ResponseWriter, r *http.Request) (*KeywordReque
 		} else {
 			writeJSON(w, http.StatusBadRequest, &ErrorResponse{Error: err.Error()})
 		}
+		return false
+	}
+	return true
+}
+
+func decodeKeywordRequest(w http.ResponseWriter, r *http.Request) (*KeywordRequest, bool) {
+	var req KeywordRequest
+	if !decodeRequest(w, r, &req) {
 		return nil, false
 	}
 	return &req, true
 }
 
 func decodeInputRequest(w http.ResponseWriter, r *http.Request) (*InputRequest, bool) {
-	if r.Method != http.MethodPost {
-		writeMethodNotAllowed(w)
-		return nil, false
-	}
-	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
-	defer closeReadCloser(r.Body)
-
 	var req InputRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		var mbe *http.MaxBytesError
-		if errors.As(err, &mbe) {
-			writeJSON(w, http.StatusRequestEntityTooLarge,
-				&ErrorResponse{Error: fmt.Sprintf("request body exceeds %d bytes", maxRequestBodyBytes)})
-		} else {
-			writeJSON(w, http.StatusBadRequest, &ErrorResponse{Error: err.Error()})
-		}
+	if !decodeRequest(w, r, &req) {
 		return nil, false
 	}
 	return &req, true

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -396,11 +396,14 @@ func (api *API) handleFlush(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+const maxRequestBodyBytes = 1 << 20 // 1MB
+
 func decodeKeywordRequest(w http.ResponseWriter, r *http.Request) (*KeywordRequest, bool) {
 	if r.Method != http.MethodPost {
 		writeMethodNotAllowed(w)
 		return nil, false
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	defer closeReadCloser(r.Body)
 
 	var req KeywordRequest
@@ -416,6 +419,7 @@ func decodeInputRequest(w http.ResponseWriter, r *http.Request) (*InputRequest, 
 		writeMethodNotAllowed(w)
 		return nil, false
 	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	defer closeReadCloser(r.Body)
 
 	var req InputRequest

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -408,7 +408,8 @@ func decodeRequest(w http.ResponseWriter, r *http.Request, v interface{}) bool {
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	defer closeReadCloser(r.Body)
 
-	if err := json.NewDecoder(r.Body).Decode(v); err != nil {
+	dec := json.NewDecoder(r.Body)
+	if err := dec.Decode(v); err != nil {
 		var mbe *http.MaxBytesError
 		if errors.As(err, &mbe) {
 			writeJSON(w, http.StatusRequestEntityTooLarge,
@@ -416,6 +417,11 @@ func decodeRequest(w http.ResponseWriter, r *http.Request, v interface{}) bool {
 		} else {
 			writeJSON(w, http.StatusBadRequest, &ErrorResponse{Error: err.Error()})
 		}
+		return false
+	}
+	if err := dec.Decode(new(interface{})); err != io.EOF {
+		writeJSON(w, http.StatusBadRequest,
+			&ErrorResponse{Error: "request body must contain only a single JSON value"})
 		return false
 	}
 	return true

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -408,7 +410,13 @@ func decodeKeywordRequest(w http.ResponseWriter, r *http.Request) (*KeywordReque
 
 	var req KeywordRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, &ErrorResponse{Error: err.Error()})
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			writeJSON(w, http.StatusRequestEntityTooLarge,
+				&ErrorResponse{Error: fmt.Sprintf("request body exceeds %d bytes", maxRequestBodyBytes)})
+		} else {
+			writeJSON(w, http.StatusBadRequest, &ErrorResponse{Error: err.Error()})
+		}
 		return nil, false
 	}
 	return &req, true
@@ -424,7 +432,13 @@ func decodeInputRequest(w http.ResponseWriter, r *http.Request) (*InputRequest, 
 
 	var req InputRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, &ErrorResponse{Error: err.Error()})
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			writeJSON(w, http.StatusRequestEntityTooLarge,
+				&ErrorResponse{Error: fmt.Sprintf("request body exceeds %d bytes", maxRequestBodyBytes)})
+		} else {
+			writeJSON(w, http.StatusBadRequest, &ErrorResponse{Error: err.Error()})
+		}
 		return nil, false
 	}
 	return &req, true


### PR DESCRIPTION
## Summary
- Fix `MigrateV1ToV2`/`RollbackToV1` not swapping `ac.ops` to the target schema version, causing all subsequent operations to use the wrong schema's Redis operations
- Add `http.MaxBytesReader` (1MB) to HTTP request decoders to prevent memory exhaustion from oversized payloads
- Reorder `removeV2Script` Lua DEL after `cjson.decode` for defensive programming
- Replace `context.Background()` with `context.WithCancel` for proper lifecycle management
- Exclude gosec G118 in golangci config (cancel func is stored and called in `Close`, not lost)

## Changes
| File | Description |
|------|-------------|
| `pkg/acor/acor.go` | Add `cancel` field, use `context.WithCancel` in `Create`, call `cancel()` in `Close` |
| `pkg/acor/migration.go` | Swap `ac.ops` to `v2Operations` after migration, to `v1Operations` after rollback (with all required fields) |
| `pkg/acor/v2_lua.go` | Move `DEL outputsKey` after `cjson.decode` to prevent theoretical data loss |
| `pkg/server/server.go` | Wrap `r.Body` with `http.MaxBytesReader` in both decode functions |
| `.golangci.yaml` | Exclude gosec G118 rule (false positive for stored cancel func) |

## Test plan
- [x] Verify `go build ./...` passes
- [x] Verify `go vet ./...` passes
- [x] Verify `go test ./...` passes
- [ ] Manually test `MigrateV1ToV2` followed by `Add`/`Find` operations
- [ ] Manually test `RollbackToV1` followed by `Remove`/`Flush` operations
- [ ] Verify HTTP server rejects payloads > 1MB

## Summary by Sourcery

Address post-review issues for the v0.6.0 release by fixing migration behavior, tightening HTTP request handling, and improving context lifecycle management.

Bug Fixes:
- Ensure schema migrations and rollbacks correctly swap operation implementations so instances use the correct schema-specific Redis operations.
- Prevent potential data loss in the V2 removal Lua script by deferring key deletion until after JSON decoding succeeds.

Enhancements:
- Use cancellable contexts on AhoCorasick instances and invoke cancellation during Close for proper lifecycle management.
- Limit HTTP request body size for keyword and input endpoints to 1MB to guard against oversized payloads.

Build:
- Update golangci-lint configuration to exclude gosec G118 for the stored cancel function use case.

## Summary by Sourcery

Address post-review issues by fixing schema migration behavior, tightening HTTP request handling, and improving context lifecycle management for Aho-Corasick instances.

Bug Fixes:
- Ensure V1↔V2 schema migrations swap the operations implementation so instances use the correct schema-specific Redis operations.
- Prevent potential data loss in the V2 removal Lua script by deleting the outputs key only after JSON decoding succeeds.

Enhancements:
- Introduce cancellable contexts on AhoCorasick instances and invoke cancellation during Close for proper lifecycle management.
- Factor common HTTP request JSON decoding into a helper that enforces method, body size limit, and single-value semantics.

Build:
- Update golangci-lint configuration to allow storing context cancel functions without triggering gosec G118.