### PR TITLE
ci: update branch references from master to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,4 +32,4 @@
 
 ---
 
-By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/master/LICENSE).
+By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: Go
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "**/*.go"
       - "Makefile"
@@ -14,7 +14,7 @@ on:
       - ".golangci.yaml"
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - "**/*.go"
       - "Makefile"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,12 +3,12 @@ name: CodeQL
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "**/*.go"
   pull_request:
     branches:
-      - master
+      - main
     paths:
       - "**/*.go"
   schedule:

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -3,7 +3,7 @@ name: Pages
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - docs/**
       - .github/workflows/pages.yaml

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write


### PR DESCRIPTION
Follow-up to renaming the default branch `master` → `main`. Updates workflow triggers (ci, release-drafter, codeql, pages) and the PR template LICENSE link that still referenced `master`.