### PR TITLE
docs: fix broken code examples (HIGH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,10 +197,13 @@ ac, err := acor.Create(&acor.AhoCorasickArgs{
     Preset:        acor.PresetBalanced,
     CaseSensitive: false,
 })
+if err != nil {
+    panic(err)
+}
 defer ac.Close()
 
-ac.Add(ctx, "hello")
-matches, _ := ac.Find(ctx, "hello world") // 0 RTT on hot path
+ac.Add("hello")
+matches, _ := ac.Find("hello world") // 0 RTT on hot path
 ```
 
 Redis is the source of truth; a local preset-optimized automaton handles reads with no Redis I/O on the hot path. Cross-instance invalidation uses Redis Pub/Sub.
@@ -275,8 +278,8 @@ acor -name mycollection add "keyword1" "keyword2"
 # Find matches
 acor -name mycollection find "sample text"
 
-# List keywords
-acor -name mycollection list
+# Show collection info
+acor -name mycollection info
 ```
 
 ## Documentation

--- a/docs/content/guides/batch-operations.md
+++ b/docs/content/guides/batch-operations.md
@@ -21,7 +21,8 @@ if err != nil {
     panic(err)
 }
 
-fmt.Printf("Added: %d, Failed: %d\n", result.Success, result.Failed)
+fmt.Printf("Added: %d, Failed: %d, Skipped: %d\n",
+    len(result.Added), len(result.Failed), len(result.Skipped))
 ```
 
 ## Batch Modes
@@ -53,6 +54,15 @@ result, err := ac.RemoveMany([]string{"he", "her"})
 if err != nil {
     panic(err)
 }
+fmt.Printf("Removed: %d\n", len(result.Removed))
+```
+
+Use `RemoveManyWithOptions` to control the batch mode:
+
+```go
+result, err := ac.RemoveManyWithOptions([]string{"he", "her"}, &acor.BatchOptions{
+    Mode: acor.BatchModeTransactional,
+})
 ```
 
 ## Finding Matches in Multiple Texts
@@ -73,9 +83,23 @@ for text, matches := range results {
 
 ```go
 type BatchResult struct {
-    Success int          // Number of successful operations
-    Failed  int          // Number of failed operations
-    Errors  []BatchError // Individual errors (BestEffort mode only)
+    Added   []string       // Keywords successfully added
+    Removed []string       // Keywords successfully removed
+    Failed  []KeywordError // Keywords that could not be processed, with their errors
+    Skipped []string       // Keywords skipped (e.g. duplicates in the input)
+}
+
+type KeywordError struct {
+    Keyword string // The keyword that caused the error
+    Error   error  // The error that occurred while processing it
+}
+```
+
+Inspect failures in `BatchModeBestEffort`:
+
+```go
+for _, ke := range result.Failed {
+    fmt.Printf("%q failed: %v\n", ke.Keyword, ke.Error)
 }
 ```
 

--- a/docs/content/operations/deployment.md
+++ b/docs/content/operations/deployment.md
@@ -140,14 +140,37 @@ services:
 
 ## Health Checks
 
-ACOR provides health check endpoints:
+The `server/health` package registers Kubernetes-compatible endpoints on an
+`http.ServeMux`:
+
+- `/healthz` — liveness; always returns `200 OK` while the process is up.
+- `/readyz` — readiness; runs every registered `Checker` and returns `503` if
+  any reports unhealthy.
 
 ```go
-import "github.com/skyoo2003/acor/server/health"
+import (
+    "net/http"
 
-handler := health.NewHandler(ac)
-http.Handle("/healthz", handler.Livez())
-http.Handle("/readyz", handler.Readyz())
+    "github.com/skyoo2003/acor/pkg/acor"
+    "github.com/skyoo2003/acor/server/health"
+)
+
+// A readiness check implements health.Checker.
+type redisChecker struct{ ac *acor.AhoCorasick }
+
+func (c redisChecker) Check() health.CheckResult {
+    if _, err := c.ac.Info(); err != nil {
+        return health.CheckResult{Status: health.StatusUnhealthy, Details: err.Error()}
+    }
+    return health.CheckResult{Status: health.StatusHealthy}
+}
+
+checker := health.NewChecker()
+checker.Register("redis", redisChecker{ac})
+
+mux := http.NewServeMux()
+health.RegisterHTTPHandlers(mux, checker) // registers /healthz and /readyz
+http.ListenAndServe(":8080", mux)
 ```
 
 ## Best Practices

--- a/docs/content/operations/deployment.md
+++ b/docs/content/operations/deployment.md
@@ -145,17 +145,20 @@ The `server/health` package registers Kubernetes-compatible endpoints on an
 
 - `/healthz` — liveness; always returns `200 OK` while the process is up.
 - `/readyz` — readiness; runs every registered `Checker` and returns `503` if
-  any reports unhealthy.
+  any checker reports as unhealthy.
 
 ```go
+package main
+
 import (
+    "log"
     "net/http"
 
     "github.com/skyoo2003/acor/pkg/acor"
     "github.com/skyoo2003/acor/server/health"
 )
 
-// A readiness check implements health.Checker.
+// redisChecker is a readiness check that implements health.Checker.
 type redisChecker struct{ ac *acor.AhoCorasick }
 
 func (c redisChecker) Check() health.CheckResult {
@@ -165,12 +168,22 @@ func (c redisChecker) Check() health.CheckResult {
     return health.CheckResult{Status: health.StatusHealthy}
 }
 
-checker := health.NewChecker()
-checker.Register("redis", redisChecker{ac})
+func main() {
+    ac, err := acor.Create(&acor.AhoCorasickArgs{
+        Addr: "redis:6379",
+        Name: "production",
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
 
-mux := http.NewServeMux()
-health.RegisterHTTPHandlers(mux, checker) // registers /healthz and /readyz
-http.ListenAndServe(":8080", mux)
+    checker := health.NewChecker()
+    checker.Register("redis", redisChecker{ac})
+
+    mux := http.NewServeMux()
+    health.RegisterHTTPHandlers(mux, checker) // registers /healthz and /readyz
+    log.Fatal(http.ListenAndServe(":8080", mux))
+}
 ```
 
 ## Best Practices

--- a/docs/content/operations/monitoring.md
+++ b/docs/content/operations/monitoring.md
@@ -78,22 +78,33 @@ import "github.com/skyoo2003/acor/server/logging"
 ### Structured Logging
 
 `NewLogger` takes an `io.Writer` and a level string (`debug`, `info`, `warn`,
-`error`) and returns a zerolog-based logger that always emits structured JSON:
-
-```go
-logger := logging.NewLogger(os.Stdout, "info")
-
-logger.Info().
-    Str("operation", "Find").
-    Int("duration_ms", 12).
-    Int("matches", 5).
-    Msg("operation completed")
-```
-
+`error`) and returns a zerolog-based logger that always emits structured JSON.
 Attach trace/span IDs with `WithTraceID`:
 
 ```go
-logger.WithTraceID(traceID, spanID).Info().Msg("request handled")
+package main
+
+import (
+    "os"
+
+    "github.com/skyoo2003/acor/server/logging"
+)
+
+func main() {
+    logger := logging.NewLogger(os.Stdout, "info")
+
+    logger.Info().
+        Str("operation", "Find").
+        Int("duration_ms", 12).
+        Int("matches", 5).
+        Msg("operation completed")
+
+    // traceID/spanID usually come from an OpenTelemetry span context;
+    // any hex strings work here.
+    traceID := "4bf92f3577b34da6a3ce929d0e0e4736"
+    spanID := "00f067aa0ba902b7"
+    logger.WithTraceID(traceID, spanID).Info().Msg("request handled")
+}
 ```
 
 ### Log Levels

--- a/docs/content/operations/monitoring.md
+++ b/docs/content/operations/monitoring.md
@@ -77,17 +77,23 @@ import "github.com/skyoo2003/acor/server/logging"
 
 ### Structured Logging
 
-```go
-logger := logging.NewLogger(logging.Config{
-    Level:  "info",
-    Format: "json",
-})
+`NewLogger` takes an `io.Writer` and a level string (`debug`, `info`, `warn`,
+`error`) and returns a zerolog-based logger that always emits structured JSON:
 
-logger.Info("operation completed",
-    "operation", "Find",
-    "duration_ms", 12,
-    "matches", 5,
-)
+```go
+logger := logging.NewLogger(os.Stdout, "info")
+
+logger.Info().
+    Str("operation", "Find").
+    Int("duration_ms", 12).
+    Int("matches", 5).
+    Msg("operation completed")
+```
+
+Attach trace/span IDs with `WithTraceID`:
+
+```go
+logger.WithTraceID(traceID, spanID).Info().Msg("request handled")
 ```
 
 ### Log Levels


### PR DESCRIPTION
## Summary

code examples that did not compile or referenced non-existent APIs. Every changed snippet was compiled against the real packages (`pkg/acor` and the `server` module) before committing.

## Changes

- **README** — preset example used context-taking `Add(ctx, …)`/`Find(ctx, …)`, but `Create()` returns a context-free `*AhoCorasick`. Also fixed the CLI `list` command (does not exist) → `info`.
- **guides/batch-operations** — documented `BatchResult` fields were fictional (`Success`/`Failed` as ints, a `BatchError` type). Replaced with the real `Added` / `Removed` / `Failed []KeywordError` / `Skipped`; documented `RemoveManyWithOptions`.
- **operations/deployment** — `health.NewHandler(ac)` / `.Livez()` / `.Readyz()` do not exist. Replaced with `health.NewChecker()` + `Register` + `RegisterHTTPHandlers`.
- **operations/monitoring** — `logging.NewLogger(logging.Config{…})` does not exist. Replaced with `NewLogger(io.Writer, level string)` using zerolog chaining, plus `WithTraceID`.

## Verification

Extracted each snippet into a throwaway `main` package and ran `go build` against both modules — all compile. Temp files removed; only doc files changed.

## Follow-ups (planned)

- PR ② — MEDIUM+LOW cleanups (PresetUltimate/#138 wording, preset defaults & capability matrix, `FindMany` return type, "auto span" claim, wrong error symbol names, custom-storage interfaces, Go 1.24→1.25, schema wording, stale `server/go.mod`, local-cache plan/spec status).
- PR ③ — CI guard that compiles doc code blocks to prevent regressions.