### PR TITLE
docs: fix stale descriptions & cross-cutting drift (MED+LOW)

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,21 @@ acor -name mycollection add "keyword1" "keyword2"
 # Find matches
 acor -name mycollection find "sample text"
 
+# Find matches with their positions
+acor -name mycollection find-index "sample text"
+
+# Suggest keywords by prefix
+acor -name mycollection suggest "sam"
+
 # Show collection info
 acor -name mycollection info
+
+# Migrate / roll back / check schema version
+acor -name mycollection migrate --dry-run
+acor -name mycollection schema-version
 ```
+
+Run `acor` with no arguments to see all commands (also: `remove`, `suggest-index`, `flush`, `migrate-rollback`).
 
 ## Documentation
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -6,7 +6,7 @@ hero_text: ACOR is a Go library and CLI for storing and querying Aho-Corasick pa
 
 ## Getting Started
 
-ACOR requires Go 1.24 or newer and Redis 3.0 or newer.
+ACOR requires Go 1.25 or newer and Redis 3.0 or newer.
 
 ```sh
 go get -u github.com/skyoo2003/acor

--- a/docs/content/extending/custom-storage.md
+++ b/docs/content/extending/custom-storage.md
@@ -5,7 +5,7 @@ weight: 1
 
 # Custom Storage
 
-The `KVStorage` interface that abstracts ACOR's storage operations.
+`KVStorage` abstracts ACOR's storage operations.
 
 > **Not yet pluggable.** `Create()` always builds ACOR's built-in Redis storage;
 > there is currently no public constructor that accepts a custom `KVStorage`.
@@ -52,6 +52,11 @@ type KVStorage interface {
     Close() error
 }
 ```
+
+The `Z`, `StringMapResult`, and `Subscription` types referenced above are
+defined alongside `KVStorage` in
+[`pkg/acor/interfaces.go`](https://github.com/skyoo2003/acor/blob/main/pkg/acor/interfaces.go)
+and documented in [Helper Types](#helper-types) below.
 
 ## Example: In-Memory Storage
 
@@ -177,13 +182,35 @@ type Pipeliner interface {
 }
 ```
 
-## Z Type
+## Helper Types
 
-The sorted set member type:
+These types are referenced by `KVStorage` and `Pipeliner` and are defined in
+[`pkg/acor/interfaces.go`](https://github.com/skyoo2003/acor/blob/main/pkg/acor/interfaces.go).
+
+`Z` — a sorted set member (score + value):
 
 ```go
 type Z struct {
     Score  float64
     Member string
+}
+```
+
+`StringMapResult` — a deferred result from a pipelined `HGetAll`; call `Val()`
+after the pipeline's `Exec`:
+
+```go
+type StringMapResult interface {
+    Val() map[string]string
+}
+```
+
+`Subscription` — a pub/sub subscription returned by `Subscribe`:
+
+```go
+type Subscription interface {
+    Receive(ctx context.Context) error
+    Channel() <-chan PubSubMessage
+    Close() error
 }
 ```

--- a/docs/content/extending/custom-storage.md
+++ b/docs/content/extending/custom-storage.md
@@ -5,11 +5,19 @@ weight: 1
 
 # Custom Storage
 
-Implement custom storage backends for ACOR.
+The `KVStorage` interface that abstracts ACOR's storage operations.
+
+> **Not yet pluggable.** `Create()` always builds ACOR's built-in Redis storage;
+> there is currently no public constructor that accepts a custom `KVStorage`.
+> The interface is exported for mocking/testing, and pluggable backends are
+> planned for a future release. This page documents the interface you would
+> implement once that lands. For an in-memory Redis in tests today, use
+> miniredis (see below).
 
 ## Overview
 
-ACOR uses the `KVStorage` interface to abstract storage operations. You can implement custom backends for:
+ACOR uses the `KVStorage` interface to abstract storage operations. Once
+pluggable backends are supported, this abstraction will allow custom backends for:
 
 - In-memory storage (testing)
 - Alternative databases
@@ -37,6 +45,10 @@ type KVStorage interface {
     Del(ctx context.Context, keys ...string) error
     Exists(ctx context.Context, keys ...string) (int64, error)
     TxPipelined(ctx context.Context, fn func(Pipeliner) error) error
+    SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) (bool, error)
+    Pipeline() Pipeliner
+    Publish(ctx context.Context, channel string, message interface{}) error
+    Subscribe(ctx context.Context, channels ...string) Subscription
     Close() error
 }
 ```
@@ -131,7 +143,7 @@ For testing, use miniredis which provides a Redis-compatible in-memory implement
 import (
     "testing"
     "github.com/alicebob/miniredis/v2"
-    "github.com/redis/go-redis/v9"
+    "github.com/go-redis/redis/v8"
 )
 
 func TestWithMiniredis(t *testing.T) {
@@ -158,8 +170,10 @@ For transaction support, implement `Pipeliner`:
 type Pipeliner interface {
     SAdd(ctx context.Context, key string, members ...interface{}) error
     HSet(ctx context.Context, key string, values ...interface{}) error
+    HGetAll(ctx context.Context, key string) StringMapResult
     ZAdd(ctx context.Context, key string, members ...*Z) error
     Del(ctx context.Context, keys ...string) error
+    Exec(ctx context.Context) error
 }
 ```
 

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -9,7 +9,7 @@ This section covers everything you need to start using ACOR.
 
 ## Prerequisites
 
-- Go >= 1.24
+- Go >= 1.25
 - Redis >= 3.0
 
 ## Installation

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -7,7 +7,7 @@ weight: 1
 
 ## Prerequisites
 
-- **Go**: Version 1.24 or later
+- **Go**: Version 1.25 or later
 - **Redis**: Version 3.0 or later
 
 ## Install the Package

--- a/docs/content/guides/preset-engine.md
+++ b/docs/content/guides/preset-engine.md
@@ -57,7 +57,11 @@ Each preset optimizes for a different trade-off between speed, memory, and featu
 | `PresetSpeed` | Full DFA + flat array trie + compact alphabet mapping | Real-time packet inspection, high-speed log scanning, latency-critical paths | Higher memory proportional to states x alphabet size |
 | `PresetBalanced` | Double-Array Trie + Banded DFA + output link compression | General-purpose backend keyword filtering, search engines | Balanced speed and memory |
 | `PresetMemoryEfficient` | Map-based sparse trie + Bloom filter pre-filtering + standard NFA | Large-scale domain blocking, malware signature matching, millions of patterns | Slower search due to failure link traversal and map lookups |
-| `PresetUltimate` | SIMD-aware byte scanning pre-filter + Double-Array Trie + Banded DFA + deferred bit-set output collection | Production systems needing highest throughput | Reasonable memory with highest speed |
+| `PresetUltimate` | Balanced architecture (Double-Array Trie + Banded DFA) + root-state first-rune Bloom pre-filter | Production systems needing highest throughput | Highest speed at Balanced-level memory |
+
+> Since v0.8.0 `PresetUltimate` shares the `PresetBalanced` engine, adding only a
+> first-rune Bloom pre-filter that skips characters which cannot start any
+> keyword. Match results are identical to `PresetBalanced`.
 
 ### Choosing a Preset
 

--- a/docs/content/guides/redis-backed-engine.md
+++ b/docs/content/guides/redis-backed-engine.md
@@ -97,6 +97,10 @@ The same [architecture presets](preset-engine/#architecture-presets) are availab
 | `PresetMemoryEfficient` | Millions of patterns, memory constrained |
 | `PresetUltimate` | Maximum throughput production systems |
 
+If the `Preset` field is left unset, it defaults to `PresetNone`, which runs the
+original `AhoCorasick` mode (not the preset-optimized engine). You must set
+`Preset` explicitly (e.g. `PresetBalanced`) to enable this engine.
+
 ## API Reference
 
 ```go

--- a/docs/content/guides/redis-backed-engine.md
+++ b/docs/content/guides/redis-backed-engine.md
@@ -78,7 +78,7 @@ The `AhoCorasickArgs` struct includes a `Preset` field for selecting the local e
 ```go
 type AhoCorasickArgs struct {
     // ... Addr, Addrs, RingAddrs, Password, DB, Name ...
-    Preset         Preset       // Architecture preset (default: PresetBalanced)
+    Preset         Preset       // Architecture preset; zero value is PresetNone (original mode). Set it (e.g. PresetBalanced) to enable preset mode
     CaseSensitive   bool         // Enable case-sensitive matching (default: false)
     // ... other fields ...
 }
@@ -132,9 +132,9 @@ err := ac.Close()
 | Cross-instance sync | Pub/Sub cache invalidation | Pub/Sub engine rebuild |
 | Schema | V1 or V2 | V2 only |
 | Presets | N/A | Speed, Balanced, MemoryEfficient, Ultimate |
-| Suggest/SuggestIndex | Yes | No |
-| Batch operations | Yes | No |
-| Parallel matching | Yes | No |
+| Suggest/SuggestIndex | Yes | No (`ErrSuggestRequiresRedis`) |
+| Batch operations | Yes | Yes |
+| Parallel matching | Yes | Yes |
 
 Use a `Preset`-optimized `AhoCorasick` when you need the fastest possible reads in a distributed setup and can accept the V2-only constraint.
 

--- a/docs/content/operations/monitoring.md
+++ b/docs/content/operations/monitoring.md
@@ -139,12 +139,14 @@ defer tracer.Shutdown()
 
 ### Spans
 
-ACOR automatically creates spans for:
+The core `pkg/acor` library does not emit its own spans. Request spans are
+created by the `server/tracing` middleware for incoming traffic:
 
-- `acor.Add`
-- `acor.Find`
-- `acor.Remove`
-- Redis operations
+- HTTP requests — via `tracing.HTTPMiddleware`
+- gRPC calls — via the `tracing` unary interceptor
+
+To trace individual `Add`/`Find`/`Remove` calls, wrap them in your own spans
+using the OpenTelemetry API.
 
 ## Dashboards
 

--- a/docs/content/operations/troubleshooting.md
+++ b/docs/content/operations/troubleshooting.md
@@ -9,7 +9,7 @@ Common issues and their solutions.
 
 ## Common Errors
 
-### ErrConflictingTopology
+### ErrRedisConflictingTopology
 
 **Cause:** Multiple Redis topologies specified simultaneously.
 
@@ -65,33 +65,7 @@ opts := &acor.ParallelOptions{
 }
 ```
 
-### ErrInvalidWorkerCount
-
-**Cause:** Negative worker count in parallel matching.
-
-**Solution:** Use non-negative values. Zero defaults to runtime.NumCPU():
-
-```go
-opts := &acor.ParallelOptions{
-    Workers: 0, // Defaults to runtime.NumCPU()
-}
-```
-
-### ErrNoBoundariesFound
-
-**Cause:** Text cannot be split for parallel matching.
-
-**Solution:** Use smaller chunk size or different boundary type:
-
-```go
-opts := &acor.ParallelOptions{
-    Workers:       4,
-    Boundary: acor.ChunkBoundaryWord,
-    ChunkSize:     100, // Smaller chunks
-}
-```
-
-### ErrRedisClosed
+### ErrRedisAlreadyClosed
 
 **Cause:** Operation on closed AhoCorasick instance.
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -106,7 +106,7 @@ Find matches in multiple texts.
 
 ```go
 matches, err := ac.FindMany([]string{"text1", "text2"})
-// Returns: [][]string
+// Returns: map[string][]string{"text1": {"kw", ...}, ...} (keyed by input text)
 ```
 
 ### FindParallel
@@ -171,7 +171,7 @@ const (
     PresetSpeed                         // Full DFA + flat array — max speed, higher memory
     PresetBalanced                      // Double-Array Trie + Banded DFA — best speed-to-memory ratio
     PresetMemoryEfficient               // Map-based + Bloom filter — min memory, slower search
-    PresetUltimate                      // SIMD + Double-Array + Banded DFA — max throughput
+    PresetUltimate                      // Balanced engine + first-rune Bloom pre-filter — high throughput
     PresetDefault         Preset = -1   // Internal sentinel; not user-selectable
 )
 ```

--- a/docs/content/reference/schema-v1.md
+++ b/docs/content/reference/schema-v1.md
@@ -13,7 +13,7 @@ V1 creates approximately 5 keys per 100 keywords:
 
 | Key Pattern | Purpose |
 |-------------|---------|
-| `{name}:keyword` | Sorted set of keywords |
+| `{name}:keyword` | Set of keywords |
 | `{name}:prefix` | Trie prefix edges |
 | `{name}:suffix` | Trie suffix links |
 | `{name}:output:{state}` | Output keywords per state |

--- a/docs/content/reference/schema-v2.md
+++ b/docs/content/reference/schema-v2.md
@@ -101,11 +101,12 @@ Stores output keywords per trie state as a hash:
 
 ### nodes key
 
-Stores node-level metadata:
+A hash mapping each keyword to a JSON array of its trie state strings. It is
+populated only by V1→V2 migration (fresh V2 collections do not write it):
 
 ```text
-{collection}:nodes
-  keyword1 -> {"count": 1, "depth": 3}
+{collection}:nodes  (hash)
+  keyword1 -> ["s0","s1","s2"]
 ```
 
 ## Recommendation

--- a/server/go.mod
+++ b/server/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1
-	github.com/skyoo2003/acor v0.7.0
+	github.com/skyoo2003/acor v0.8.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0


### PR DESCRIPTION
## Summary

Doc-currency pass **PR ② of 3** — MEDIUM + LOW cleanups. Reconciles the docs with the current code (v0.8.0), verified against `pkg/acor`, `cmd/acor`, and the `server` module. Both modules build.

> **Stacked on #147** (base = `docs/currency-pr1-high`). Merge #147 first, or GitHub will auto-retarget this to `main` when #147 merges. Review only this PR's incremental diff.

## MEDIUM

- **PresetUltimate** is no longer a distinct "SIMD/bit-set" engine (#138) — it is the Balanced engine + a root-state first-rune Bloom pre-filter. Fixed `preset-engine`, `api.md`, README wording.
- **redis-backed-engine** — `Preset` default is `PresetNone` (original mode), not `PresetBalanced`; batch and parallel matching **do** work in preset mode (only `Suggest`/`SuggestIndex` return `ErrSuggestRequiresRedis`).
- **api.md** — `FindMany` returns `map[string][]string`, not `[][]string`.
- **monitoring** — core `pkg/acor` emits no spans; spans come from `server/tracing` HTTP/gRPC middleware only.
- **troubleshooting** — dropped `ErrInvalidWorkerCount` (does not exist; `Workers<=0` → `runtime.NumCPU()`) and `ErrNoBoundariesFound` (defined but never returned).
- **custom-storage** — completed `KVStorage` (`SetNX`/`Pipeline`/`Publish`/`Subscribe`) and `Pipeliner` (`HGetAll`/`Exec`); flagged that custom backends are not yet pluggable.
- **README** — documented `find-index`/`suggest`/`suggest-index`/`migrate` CLI commands.

## LOW

- Go 1.24 → 1.25 (matches `go.mod`).
- `ErrConflictingTopology` → `ErrRedisConflictingTopology`; `ErrRedisClosed` → `ErrRedisAlreadyClosed`.
- `go-redis/v9` → `go-redis/redis/v8`.
- schema-v1: `{name}:keyword` is a plain SET, not a sorted set.
- schema-v2: `nodes` is a migration-only hash of keyword → JSON state array.
- `server/go.mod` requires `acor v0.8.0`.

## Notes

- `docs/plans/` and `docs/specs/` are gitignored (local-only design docs), so the stale local-cache plan/spec is out of scope for the repo — no change needed there.

## Verification

`go build ./...` passes for both the main and `server` modules.

## Follow-up

- PR ③ — CI guard that compiles doc code blocks to prevent regressions.