### PR TITLE
chore: add changelog fragments for #147, #148, #149, #151

### DIFF
--- a/changes/unreleased/Changed-20260720-062140.yaml
+++ b/changes/unreleased/Changed-20260720-062140.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: 'Reorganize internals: extract the Aho-Corasick engines into internal/engine and storage into internal/storage, leaving the public API in pkg/acor unchanged'
+time: 2026-07-20T06:21:40.425041+09:00
+custom:
+    Issue: "151"

--- a/changes/unreleased/Documentation-20260720-062140.yaml
+++ b/changes/unreleased/Documentation-20260720-062140.yaml
@@ -1,0 +1,5 @@
+kind: Documentation
+body: Add a CI guard that compiles the documented Go examples to keep them from drifting
+time: 2026-07-20T06:21:40.443032+09:00
+custom:
+    Issue: "149"

--- a/changes/unreleased/Documentation-20260720-062203.yaml
+++ b/changes/unreleased/Documentation-20260720-062203.yaml
@@ -1,0 +1,5 @@
+kind: Documentation
+body: Fix broken Go code examples in the documentation
+time: 2026-07-20T06:22:03.161543+09:00
+custom:
+    Issue: "147"

--- a/changes/unreleased/Documentation-20260720-062208.yaml
+++ b/changes/unreleased/Documentation-20260720-062208.yaml
@@ -1,0 +1,5 @@
+kind: Documentation
+body: Fix stale descriptions and cross-cutting drift across the documentation
+time: 2026-07-20T06:22:08.956705+09:00
+custom:
+    Issue: "148"


### PR DESCRIPTION
## Summary

Backfill changie fragments for merged PRs since v0.8.0 that were missing changelog entries.

| PR | Kind | Body |
|---|---|---|
| #151 | Changed | Reorganize internals: extract engines into `internal/engine` and storage into `internal/storage`, public API in `pkg/acor` unchanged (non-breaking) |
| #147 | Documentation | Fix broken Go code examples in the documentation |
| #148 | Documentation | Fix stale descriptions and cross-cutting drift across the documentation |
| #149 | Documentation | Add a CI guard that compiles the documented Go examples |

Skipped as non-user-facing: #146 (release-process docs), #145 (release-drafter removal chore).

## Test plan

- [x] `changie new` fragments validate against `.changie.yaml` schema
- [x] pre-commit hooks pass