### PR TITLE
chore: improve Changie config (spacing, multi-line body)

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -1,13 +1,30 @@
+# Changie configuration — https://changie.dev/config/
+# Source of truth for release notes; see RELEASE.md for the release workflow.
+
 changesDir: changes
 unreleasedDir: unreleased
 headerPath: header.tpl.md
 changelogPath: CHANGELOG.md
 versionExt: md
+
+# --- Templates -------------------------------------------------------------
 versionFormat: '## [{{ .Version }}](https://github.com/skyoo2003/acor/releases/tag/{{ .Version }}) - {{ .Time.Format "2006-01-02" }}'
+kindFormat: '### {{ .Kind }}'
+changeFormat: '* {{ .Body }} ([#{{ .Custom.Issue }}](https://github.com/skyoo2003/acor/issues/{{ .Custom.Issue }}))'
 
+# --- Spacing (Keep a Changelog / markdownlint-friendly) --------------------
+# Applied on `changie merge`, so the whole CHANGELOG re-flows cleanly.
+newlines:
+  beforeChangelogVersion: 1   # blank line after the header and between versions
+  beforeKind: 1               # blank line before each "### Kind" header
+  afterKind: 1                # blank line after each "### Kind" header
 
-kindFormat: "### {{ .Kind }}"
-changeFormat: "* {{ .Body }} ([#{{ .Custom.Issue }}](https://github.com/skyoo2003/acor/issues/{{ .Custom.Issue }}))"
+# --- Change body prompt ----------------------------------------------------
+body:
+  block: true                 # allow multi-line bodies (entries here run long)
+  minLength: 5
+
+# --- Kinds -----------------------------------------------------------------
 kinds:
   - label: Added
   - label: Changed
@@ -16,6 +33,8 @@ kinds:
   - label: Fixed
   - label: Security
   - label: Documentation
+
+# --- Prompted custom fields ------------------------------------------------
 custom:
   - key: Issue
     label: Issue Number


### PR DESCRIPTION
## Description

Improve `.changie.yaml` per the [Changie config docs](https://changie.dev/config/):

- **`newlines`** — the merged `CHANGELOG.md` had no blank lines around the header, versions, or `### Kind` sections (cramped, markdownlint-unfriendly). Adds blank lines after the header, between versions, and around each kind heading so `changie merge` re-flows the whole changelog cleanly.
- **`body.block: true` + `minLength`** — change entries here run long/multi-sentence, so multi-line input in `changie new` is nicer.
- Doc header + section comments for maintainability.

Deliberately skipped: `auto` semver bump (bump level isn't derivable from kind — a refactor `Changed` shipped as patch `v0.6.1`, a breaking `Changed` as minor `v0.8.0`; RELEASE.md pins the version manually) and `replacements` (no version constant/file to sync — goreleaser injects via ldflags).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [ ] Tests pass (`make test`) — N/A, config-only change (no Go files touched)
- [ ] Vet/`make vet` — N/A, config-only change
- [ ] Linting passes (`make lint`) — N/A, config-only change
- [ ] Build succeeds (`make build`) — N/A, config-only change
- [x] Documentation updated if needed (doc header + inline comments added to config)
- [x] Changelog fragment added (`changie new`) — skipped: internal tooling change, per [RELEASE.md](../RELEASE.md)
- [x] Commit messages follow guidelines

## Additional Notes

Validated with `changie v1.25.0` via `changie batch --dry-run` and `changie merge --dry-run` (no files touched): single blank lines after the header and between versions (no doubles), and new versions render with internal spacing around each `### Kind`.

Existing version files' internal spacing is baked in at batch time and won't change retroactively; merge-level version separation applies to all versions on the next merge.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).