### PR TITLE
feat(acor): match-span/Contains/streaming APIs, preset batch coalescing, and invalidation safety net

### DIFF
--- a/changes/unreleased/Added-20260720-234149.yaml
+++ b/changes/unreleased/Added-20260720-234149.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Add FindMatches, Contains, and FindStream matching APIs (plus Context variants). FindMatches returns matches in scan order with rune-offset spans and takes MatchKind (overlapping default, or non-overlapping leftmost-longest) and WholeWord options; Contains is an early-exit containment gate; FindStream scans an io.Reader without buffering the whole input. Available in preset, V2, and V1 modes with matching semantics identical to Find/FindIndex.
+time: 2026-07-20T23:41:49.45952+09:00
+custom:
+    Issue: "158"

--- a/changes/unreleased/Added-20260721-052046.yaml
+++ b/changes/unreleased/Added-20260721-052046.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: 'Add AhoCorasickArgs.InvalidationPollInterval: an opt-in background safety net for Preset mode that reloads when the collection''s stored version changes, bounding staleness from a dropped best-effort Pub/Sub invalidation. Add MatchOptions.WordRune to override whole-word boundary detection for scripts the default misclassifies (e.g. CJK). The Preset commit path also retries the invalidation publish a few times on transient failure.'
+time: 2026-07-21T05:20:46.758804+09:00
+custom:
+    Issue: "158"

--- a/changes/unreleased/Changed-20260720-234149.yaml
+++ b/changes/unreleased/Changed-20260720-234149.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Coalesce the preset-mode local automaton rebuild and pub/sub invalidation across AddMany/RemoveMany, so a batch of N writes triggers one rebuild instead of one per keyword (O(N^2) to O(N) bulk-load). The Redis-backed engine now swaps in a freshly built automaton on each rebuild, making local match snapshots immutable and scannable lock-free.
+time: 2026-07-20T23:41:49.469596+09:00
+custom:
+    Issue: "158"

--- a/changes/unreleased/Fixed-20260721-054513.yaml
+++ b/changes/unreleased/Fixed-20260721-054513.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: 'RemoveMany and RemoveManyWithOptions no longer report keywords that were not present as removed: an absent keyword is now recorded in BatchResult.Skipped instead of BatchResult.Removed, matching AddMany and single Remove. In Preset mode this also prevents a no-op RemoveMany from triggering an unnecessary cluster-wide cache reload.'
+time: 2026-07-21T05:45:13.672811+09:00
+custom:
+    Issue: "158"

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -61,6 +61,15 @@ func (p Preset) String() string {
 	}
 }
 
+// Match is a single keyword occurrence in the searched text. Start and End are
+// rune offsets (half-open [Start, End)), consistent with FindIndex's rune-based
+// offsets. Matches are reported in scan order (by end position).
+type Match struct {
+	Keyword string
+	Start   int
+	End     int
+}
+
 // InMemoryInfo contains statistics about an in-memory Aho-Corasick engine.
 type InMemoryInfo struct {
 	// Keywords is the number of keywords in the automaton.
@@ -81,5 +90,11 @@ type matchEngine interface {
 	buildFromKeywords(keywords map[string]struct{})
 	find(text string) []string
 	findIndex(text string) map[string][]int
+	// matchStream pulls runes from next until it returns ok=false, emitting every
+	// match (overlaps included) to emit in scan order. It stops early if emit
+	// returns false. This is the shared traversal behind FindMatches, Contains,
+	// and streaming; find/findIndex keep their own tight loops to avoid the
+	// per-rune closure overhead on those hot paths.
+	matchStream(next func() (rune, bool), emit func(Match) bool)
 	info() *InMemoryInfo
 }

--- a/internal/engine/engine_banded_dfa.go
+++ b/internal/engine/engine_banded_dfa.go
@@ -173,6 +173,59 @@ func (e *balancedEngine) findIndex(text string) map[string][]int {
 	return matched
 }
 
+func (e *balancedEngine) matchStream(next func() (rune, bool), emit func(Match) bool) {
+	dat := e.banded.dat
+	if dat.size <= datRootPos+1 {
+		return
+	}
+	band := e.banded.dfaBand
+	bloom := e.bloom
+
+	state := datRootPos
+	runeIndex := 0
+
+	for {
+		ch, ok := next()
+		if !ok {
+			return
+		}
+		if bloom != nil && bloom.skipAtRoot(state == datRootPos, ch) {
+			runeIndex++
+			continue
+		}
+
+		code, ok := dat.code(ch)
+		if !ok {
+			state = datRootPos
+			runeIndex++
+			continue
+		}
+
+		if band[state] != nil {
+			state = band[state][code]
+		} else {
+			if nx := dat.gotoStateByCode(state, code); nx != 0 {
+				state = nx
+			} else {
+				state = dat.followFailByCode(state, code)
+			}
+		}
+		if state == 0 {
+			state = datRootPos
+		}
+
+		runeIndex++
+		if state < len(dat.output) {
+			for _, out := range dat.output[state] {
+				start := runeIndex - utf8.RuneCountInString(out)
+				if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
+					return
+				}
+			}
+		}
+	}
+}
+
 func (e *balancedEngine) info() *InMemoryInfo {
 	dat := e.banded.dat
 	if dat.size <= datRootPos+1 {

--- a/internal/engine/engine_flat.go
+++ b/internal/engine/engine_flat.go
@@ -220,6 +220,36 @@ func (e *speedEngine) findIndex(text string) map[string][]int {
 	return matched
 }
 
+func (e *speedEngine) matchStream(next func() (rune, bool), emit func(Match) bool) {
+	if e.dfa == nil {
+		return
+	}
+
+	state := 0
+	runeIndex := 0
+
+	for {
+		ch, ok := next()
+		if !ok {
+			return
+		}
+		ai, ok := e.code(ch)
+		if !ok {
+			state = 0
+			runeIndex++
+			continue
+		}
+		state = e.dfa[state][ai]
+		runeIndex++
+		for _, out := range e.outputMap[state] {
+			start := runeIndex - utf8.RuneCountInString(out)
+			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
+				return
+			}
+		}
+	}
+}
+
 func (e *speedEngine) info() *InMemoryInfo {
 	if e.dfa == nil {
 		return &InMemoryInfo{Preset: e.preset}

--- a/internal/engine/engine_handle.go
+++ b/internal/engine/engine_handle.go
@@ -2,7 +2,7 @@
 
 package engine
 
-import "unicode/utf8"
+import "strings"
 
 // Engine is the exported handle to an in-memory Aho-Corasick match engine.
 // It wraps the preset-selected internal implementation so callers outside this
@@ -61,15 +61,15 @@ func (e *Engine) Stream(next func() (rune, bool), emit func(Match) bool) {
 }
 
 // stringRuneSource adapts a string to the rune-pull source matchStream expects.
-// It decodes runes exactly like a range loop (invalid UTF-8 yields RuneError).
+// strings.Reader.ReadRune decodes exactly like a range loop (invalid UTF-8
+// yields RuneError).
 func stringRuneSource(s string) func() (rune, bool) {
-	i := 0
+	rd := strings.NewReader(s)
 	return func() (rune, bool) {
-		if i >= len(s) {
+		r, _, err := rd.ReadRune()
+		if err != nil {
 			return 0, false
 		}
-		r, size := utf8.DecodeRuneInString(s[i:])
-		i += size
 		return r, true
 	}
 }

--- a/internal/engine/engine_handle.go
+++ b/internal/engine/engine_handle.go
@@ -2,6 +2,8 @@
 
 package engine
 
+import "unicode/utf8"
+
 // Engine is the exported handle to an in-memory Aho-Corasick match engine.
 // It wraps the preset-selected internal implementation so callers outside this
 // package can build and query the automaton without depending on the concrete
@@ -28,6 +30,48 @@ func (e *Engine) Find(text string) []string {
 // FindIndex returns matched keywords mapped to their start offsets in text.
 func (e *Engine) FindIndex(text string) map[string][]int {
 	return e.impl.findIndex(text)
+}
+
+// FindMatches returns every match (overlaps included) in text, in scan order,
+// each carrying its keyword and rune-offset span.
+func (e *Engine) FindMatches(text string) []Match {
+	out := make([]Match, 0)
+	e.impl.matchStream(stringRuneSource(text), func(m Match) bool {
+		out = append(out, m)
+		return true
+	})
+	return out
+}
+
+// Contains reports whether text contains any keyword, stopping at the first hit.
+func (e *Engine) Contains(text string) bool {
+	found := false
+	e.impl.matchStream(stringRuneSource(text), func(Match) bool {
+		found = true
+		return false
+	})
+	return found
+}
+
+// Stream pulls runes from next (rune-global offsets accumulate across calls) and
+// reports every match to emit until next is exhausted or emit returns false.
+// It lets callers scan an io.Reader without materializing the whole input.
+func (e *Engine) Stream(next func() (rune, bool), emit func(Match) bool) {
+	e.impl.matchStream(next, emit)
+}
+
+// stringRuneSource adapts a string to the rune-pull source matchStream expects.
+// It decodes runes exactly like a range loop (invalid UTF-8 yields RuneError).
+func stringRuneSource(s string) func() (rune, bool) {
+	i := 0
+	return func() (rune, bool) {
+		if i >= len(s) {
+			return 0, false
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		i += size
+		return r, true
+	}
 }
 
 // Info returns statistics about the built automaton.

--- a/internal/engine/engine_map.go
+++ b/internal/engine/engine_map.go
@@ -167,6 +167,45 @@ func (e *memEfficientEngine) findIndex(text string) map[string][]int {
 	return matched
 }
 
+func (e *memEfficientEngine) matchStream(next func() (rune, bool), emit func(Match) bool) {
+	if len(e.trie.nodes) <= 1 {
+		return
+	}
+
+	state := 0
+	runeIndex := 0
+
+	for {
+		ch, ok := next()
+		if !ok {
+			return
+		}
+		if e.bloom.skipAtRoot(state == 0, ch) {
+			runeIndex++
+			continue
+		}
+
+		for {
+			if nx, ok := e.trie.nodes[state].children[ch]; ok {
+				state = nx
+				break
+			}
+			if state == 0 {
+				break
+			}
+			state = e.trie.nodes[state].fail
+		}
+
+		runeIndex++
+		for _, out := range e.trie.nodes[state].output {
+			start := runeIndex - utf8.RuneCountInString(out)
+			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
+				return
+			}
+		}
+	}
+}
+
 func (e *memEfficientEngine) info() *InMemoryInfo {
 	return &InMemoryInfo{
 		Keywords:    countUniqueOutputs(e.trie.nodes),

--- a/internal/engine/engine_matches_test.go
+++ b/internal/engine/engine_matches_test.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package engine
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"unicode/utf8"
+)
+
+// startsByKeyword collapses matches into brute-comparable start-offset lists and
+// checks each span is [start, start+runeLen(keyword)).
+func startsByKeyword(t *testing.T, matches []Match) map[string][]int {
+	t.Helper()
+	got := make(map[string][]int)
+	for _, m := range matches {
+		if want := m.Start + utf8.RuneCountInString(m.Keyword); m.End != want {
+			t.Errorf("match %q span [%d,%d): End should be %d", m.Keyword, m.Start, m.End, want)
+		}
+		got[m.Keyword] = append(got[m.Keyword], m.Start)
+	}
+	for _, s := range got {
+		sort.Ints(s)
+	}
+	return got
+}
+
+func TestFindMatches_MatchesBruteForce(t *testing.T) {
+	cases := []struct {
+		keywords []string
+		text     string
+	}{
+		{[]string{"he", "her", "him", "she", "hers"}, "she said he hid hers with him"},
+		{[]string{"a", "aa", "aaa"}, "aaaa"},
+		{[]string{"안녕", "녕하", "하세요"}, "안녕하세요 안녕"},
+		{[]string{"ab", "bc", "abc"}, "xabcx"},
+	}
+	for _, tc := range cases {
+		kws := keywordSet(tc.keywords...)
+		want := bruteFindIndex(kws, tc.text)
+		for _, p := range allPresets {
+			e := New(p)
+			e.Build(kws)
+			got := startsByKeyword(t, e.FindMatches(tc.text))
+			// bruteFindIndex omits keywords with no occurrence; drop empty entries.
+			for k, v := range got {
+				if len(v) == 0 {
+					delete(got, k)
+				}
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("preset %v text %q: FindMatches starts = %v, want %v", p, tc.text, got, want)
+			}
+		}
+	}
+}
+
+func TestContains(t *testing.T) {
+	kws := keywordSet("he", "she", "his")
+	for _, p := range allPresets {
+		e := New(p)
+		e.Build(kws)
+		if !e.Contains("this is here") {
+			t.Errorf("preset %v: Contains should be true (matches 'he'/'his')", p)
+		}
+		if e.Contains("no match at all") {
+			t.Errorf("preset %v: Contains should be false", p)
+		}
+		if e.Contains("") {
+			t.Errorf("preset %v: Contains(\"\") should be false", p)
+		}
+	}
+}
+
+func TestStream_EarlyStop(t *testing.T) {
+	kws := keywordSet("ab")
+	for _, p := range allPresets {
+		e := New(p)
+		e.Build(kws)
+		count := 0
+		e.Stream(stringRuneSource("abababab"), func(Match) bool {
+			count++
+			return false // stop after the first
+		})
+		if count != 1 {
+			t.Errorf("preset %v: early-stop Stream emitted %d matches, want 1", p, count)
+		}
+	}
+}
+
+func TestFindMatches_Empty(t *testing.T) {
+	for _, p := range allPresets {
+		e := New(p)
+		e.Build(keywordSet())
+		if got := e.FindMatches("anything"); len(got) != 0 {
+			t.Errorf("preset %v: empty automaton FindMatches = %v, want none", p, got)
+		}
+	}
+}

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -262,6 +262,17 @@ type AhoCorasickArgs struct {
 	// for fast reads. Forces V2 schema.
 	// When unset (zero), the original Aho-Corasick engine is used.
 	Preset Preset
+
+	// InvalidationPollInterval enables a background safety net for the Preset
+	// engine: every interval it compares the collection's stored version against
+	// the local one and reloads if they differ. Cross-instance invalidation is
+	// normally driven by best-effort Redis Pub/Sub, which has no delivery
+	// guarantee — a dropped message leaves a node serving stale data until the
+	// next local write. This poll bounds that staleness to the interval.
+	//
+	// Disabled by default (zero). Recommended for multi-instance deployments
+	// (e.g. 30 * time.Second). Only applies to Preset mode; ignored otherwise.
+	InvalidationPollInterval time.Duration
 }
 
 // AhoCorasick represents an Aho-Corasick automaton backed by Redis.

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -9,6 +9,18 @@ import (
 	"sync"
 )
 
+// batchWriter is implemented by modes (preset) that can coalesce the local
+// automaton rebuild and pub/sub invalidation across a batch of writes. When
+// ac.ops satisfies it, AddMany/RemoveMany write each keyword with the rebuild
+// deferred and then commit a single rebuild + publish, turning N per-keyword
+// automaton rebuilds into one. Modes without a per-write local rebuild (V1, V2)
+// do not implement it and fall back to the plain per-keyword path.
+type batchWriter interface {
+	addDeferred(ctx context.Context, keyword string) (int, error)
+	removeDeferred(ctx context.Context, keyword string) (int, error)
+	commitBatch(ctx context.Context)
+}
+
 // AddMany adds multiple keywords to the Aho-Corasick automaton in batch mode.
 // This is more efficient than calling Add repeatedly for large keyword sets.
 //
@@ -32,6 +44,12 @@ func (ac *AhoCorasick) AddMany(keywords []string, opts *BatchOptions) (*BatchRes
 func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
 	seen := make(map[string]bool)
 
+	bw, batched := ac.ops.(batchWriter)
+	add := ac.ops.add
+	if batched {
+		add = bw.addDeferred
+	}
+
 	for _, keyword := range keywords {
 		keyword = strings.TrimSpace(keyword)
 		if keyword == "" {
@@ -48,7 +66,7 @@ func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string,
 		}
 		seen[keyword] = true
 
-		count, err := ac.ops.add(ctx, keyword)
+		count, err := add(ctx, keyword)
 		if err != nil {
 			result.Failed = append(result.Failed, KeywordError{
 				Keyword: keyword,
@@ -64,12 +82,22 @@ func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string,
 		}
 	}
 
+	if batched && len(result.Added) > 0 {
+		bw.commitBatch(ctx)
+	}
+
 	return result, nil
 }
 
 func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
 	added := make([]string, 0)
 	seen := make(map[string]bool)
+
+	bw, batched := ac.ops.(batchWriter)
+	add := ac.ops.add
+	if batched {
+		add = bw.addDeferred
+	}
 
 	rollbackCtx := context.WithoutCancel(ctx)
 	for _, keyword := range keywords {
@@ -85,8 +113,10 @@ func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []stri
 		}
 		seen[keyword] = true
 
-		count, err := ac.ops.add(ctx, keyword)
+		count, err := add(ctx, keyword)
 		if err != nil {
+			// rollbackAdded uses regular (rebuilding) removes, so it also repairs
+			// the deferred, not-yet-rebuilt local engine before returning.
 			ac.rollbackAdded(rollbackCtx, added)
 			return nil, fmt.Errorf("batch add failed at keyword %q: %w", keyword, err)
 		}
@@ -96,6 +126,10 @@ func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []stri
 		} else {
 			result.Skipped = append(result.Skipped, keyword)
 		}
+	}
+
+	if batched && len(added) > 0 {
+		bw.commitBatch(ctx)
 	}
 
 	result.Added = added
@@ -159,6 +193,12 @@ func (ac *AhoCorasick) RemoveManyWithOptions(keywords []string, opts *BatchOptio
 func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
 	seen := make(map[string]bool)
 
+	bw, batched := ac.ops.(batchWriter)
+	remove := ac.ops.remove
+	if batched {
+		remove = bw.removeDeferred
+	}
+
 	for _, keyword := range keywords {
 		keyword = strings.TrimSpace(keyword)
 		if keyword == "" {
@@ -175,7 +215,7 @@ func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []stri
 		}
 		seen[keyword] = true
 
-		_, err := ac.ops.remove(ctx, keyword)
+		_, err := remove(ctx, keyword)
 		if err != nil {
 			result.Failed = append(result.Failed, KeywordError{
 				Keyword: keyword,
@@ -187,12 +227,22 @@ func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []stri
 		result.Removed = append(result.Removed, keyword)
 	}
 
+	if batched && len(result.Removed) > 0 {
+		bw.commitBatch(ctx)
+	}
+
 	return result, nil
 }
 
 func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
 	removed := make([]string, 0)
 	seen := make(map[string]bool)
+
+	bw, batched := ac.ops.(batchWriter)
+	remove := ac.ops.remove
+	if batched {
+		remove = bw.removeDeferred
+	}
 
 	rollbackCtx := context.WithoutCancel(ctx)
 	for _, keyword := range keywords {
@@ -208,13 +258,19 @@ func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []s
 		}
 		seen[keyword] = true
 
-		_, err := ac.ops.remove(ctx, keyword)
+		_, err := remove(ctx, keyword)
 		if err != nil {
+			// rollbackRemoved re-adds via regular (rebuilding) adds, repairing the
+			// deferred local engine before returning.
 			ac.rollbackRemoved(rollbackCtx, removed)
 			return nil, fmt.Errorf("batch remove failed at keyword %q: %w", keyword, err)
 		}
 
 		removed = append(removed, keyword)
+	}
+
+	if batched && len(removed) > 0 {
+		bw.commitBatch(ctx)
 	}
 
 	result.Removed = removed

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -21,6 +21,26 @@ type batchWriter interface {
 	commitBatch(ctx context.Context)
 }
 
+// batchAddFns returns the per-keyword add function and a commit function for a
+// batch. In a batchWriter mode (preset) the add is deferred and commit runs the
+// single coalesced rebuild+publish; otherwise add is the plain per-keyword add
+// (which already rebuilt+published) and commit is a no-op. Callers gate commit on
+// whether anything actually changed, so no-op batches never trigger a rebuild.
+func (ac *AhoCorasick) batchAddFns() (add func(context.Context, string) (int, error), commit func(context.Context)) {
+	if bw, ok := ac.ops.(batchWriter); ok {
+		return bw.addDeferred, bw.commitBatch
+	}
+	return ac.ops.add, func(context.Context) {}
+}
+
+// batchRemoveFns is batchAddFns for the remove side.
+func (ac *AhoCorasick) batchRemoveFns() (remove func(context.Context, string) (int, error), commit func(context.Context)) {
+	if bw, ok := ac.ops.(batchWriter); ok {
+		return bw.removeDeferred, bw.commitBatch
+	}
+	return ac.ops.remove, func(context.Context) {}
+}
+
 // AddMany adds multiple keywords to the Aho-Corasick automaton in batch mode.
 // This is more efficient than calling Add repeatedly for large keyword sets.
 //
@@ -43,12 +63,7 @@ func (ac *AhoCorasick) AddMany(keywords []string, opts *BatchOptions) (*BatchRes
 
 func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
 	seen := make(map[string]bool)
-
-	bw, batched := ac.ops.(batchWriter)
-	add := ac.ops.add
-	if batched {
-		add = bw.addDeferred
-	}
+	add, commit := ac.batchAddFns()
 
 	for _, keyword := range keywords {
 		keyword = strings.TrimSpace(keyword)
@@ -82,8 +97,8 @@ func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string,
 		}
 	}
 
-	if batched && len(result.Added) > 0 {
-		bw.commitBatch(ctx)
+	if len(result.Added) > 0 {
+		commit(ctx)
 	}
 
 	return result, nil
@@ -92,12 +107,7 @@ func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string,
 func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
 	added := make([]string, 0)
 	seen := make(map[string]bool)
-
-	bw, batched := ac.ops.(batchWriter)
-	add := ac.ops.add
-	if batched {
-		add = bw.addDeferred
-	}
+	add, commit := ac.batchAddFns()
 
 	rollbackCtx := context.WithoutCancel(ctx)
 	for _, keyword := range keywords {
@@ -115,8 +125,8 @@ func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []stri
 
 		count, err := add(ctx, keyword)
 		if err != nil {
-			// rollbackAdded uses regular (rebuilding) removes, so it also repairs
-			// the deferred, not-yet-rebuilt local engine before returning.
+			// rollbackAdded also repairs the deferred, not-yet-committed local
+			// engine (it ends with its own commit) before returning.
 			ac.rollbackAdded(rollbackCtx, added)
 			return nil, fmt.Errorf("batch add failed at keyword %q: %w", keyword, err)
 		}
@@ -128,8 +138,8 @@ func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []stri
 		}
 	}
 
-	if batched && len(added) > 0 {
-		bw.commitBatch(ctx)
+	if len(added) > 0 {
+		commit(ctx)
 	}
 
 	result.Added = added
@@ -140,6 +150,11 @@ func (ac *AhoCorasick) rollbackAdded(ctx context.Context, keywords []string) {
 	if len(keywords) == 0 {
 		return
 	}
+
+	// Use the deferred write + single commit so a failed batch triggers one
+	// rebuild/publish, not one per rolled-back keyword (commit is a no-op outside
+	// batchWriter modes, where each remove already rebuilt/published).
+	remove, commit := ac.batchRemoveFns()
 
 	maxWorkers := 10
 	if len(keywords) < maxWorkers {
@@ -154,6 +169,7 @@ func (ac *AhoCorasick) rollbackAdded(ctx context.Context, keywords []string) {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
 			wg.Wait()
+			commit(ctx)
 			return
 		}
 		wg.Add(1)
@@ -162,12 +178,13 @@ func (ac *AhoCorasick) rollbackAdded(ctx context.Context, keywords []string) {
 				<-sem
 				wg.Done()
 			}()
-			if _, err := ac.ops.remove(ctx, k); err != nil && ac.logger != nil {
+			if _, err := remove(ctx, k); err != nil && ac.logger != nil {
 				ac.logger.Printf("rollback: failed to remove %q: %v", k, err)
 			}
 		}(keyword)
 	}
 	wg.Wait()
+	commit(ctx)
 }
 
 // RemoveMany removes multiple keywords from the Aho-Corasick automaton.
@@ -192,12 +209,7 @@ func (ac *AhoCorasick) RemoveManyWithOptions(keywords []string, opts *BatchOptio
 
 func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
 	seen := make(map[string]bool)
-
-	bw, batched := ac.ops.(batchWriter)
-	remove := ac.ops.remove
-	if batched {
-		remove = bw.removeDeferred
-	}
+	remove, commit := ac.batchRemoveFns()
 
 	for _, keyword := range keywords {
 		keyword = strings.TrimSpace(keyword)
@@ -215,7 +227,7 @@ func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []stri
 		}
 		seen[keyword] = true
 
-		_, err := remove(ctx, keyword)
+		count, err := remove(ctx, keyword)
 		if err != nil {
 			result.Failed = append(result.Failed, KeywordError{
 				Keyword: keyword,
@@ -224,11 +236,18 @@ func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []stri
 			continue
 		}
 
-		result.Removed = append(result.Removed, keyword)
+		// Only count as removed when a keyword was actually present (count > 0),
+		// matching AddMany and single Remove. This keeps a no-op RemoveMany from
+		// reporting phantom removals and from firing a needless cluster-wide commit.
+		if count > 0 {
+			result.Removed = append(result.Removed, keyword)
+		} else {
+			result.Skipped = append(result.Skipped, keyword)
+		}
 	}
 
-	if batched && len(result.Removed) > 0 {
-		bw.commitBatch(ctx)
+	if len(result.Removed) > 0 {
+		commit(ctx)
 	}
 
 	return result, nil
@@ -237,12 +256,7 @@ func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []stri
 func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
 	removed := make([]string, 0)
 	seen := make(map[string]bool)
-
-	bw, batched := ac.ops.(batchWriter)
-	remove := ac.ops.remove
-	if batched {
-		remove = bw.removeDeferred
-	}
+	remove, commit := ac.batchRemoveFns()
 
 	rollbackCtx := context.WithoutCancel(ctx)
 	for _, keyword := range keywords {
@@ -258,19 +272,25 @@ func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []s
 		}
 		seen[keyword] = true
 
-		_, err := remove(ctx, keyword)
+		count, err := remove(ctx, keyword)
 		if err != nil {
-			// rollbackRemoved re-adds via regular (rebuilding) adds, repairing the
-			// deferred local engine before returning.
+			// rollbackRemoved re-adds the actually-removed keywords and ends with its
+			// own commit, repairing the deferred local engine before returning.
 			ac.rollbackRemoved(rollbackCtx, removed)
 			return nil, fmt.Errorf("batch remove failed at keyword %q: %w", keyword, err)
 		}
 
-		removed = append(removed, keyword)
+		// Track only keywords that were present, so rollback re-adds exactly those
+		// and a no-op transactional RemoveMany does not fire a commit.
+		if count > 0 {
+			removed = append(removed, keyword)
+		} else {
+			result.Skipped = append(result.Skipped, keyword)
+		}
 	}
 
-	if batched && len(removed) > 0 {
-		bw.commitBatch(ctx)
+	if len(removed) > 0 {
+		commit(ctx)
 	}
 
 	result.Removed = removed
@@ -281,6 +301,9 @@ func (ac *AhoCorasick) rollbackRemoved(ctx context.Context, keywords []string) {
 	if len(keywords) == 0 {
 		return
 	}
+
+	// Deferred write + single commit, mirroring rollbackAdded.
+	add, commit := ac.batchAddFns()
 
 	maxWorkers := 10
 	if len(keywords) < maxWorkers {
@@ -295,6 +318,7 @@ func (ac *AhoCorasick) rollbackRemoved(ctx context.Context, keywords []string) {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
 			wg.Wait()
+			commit(ctx)
 			return
 		}
 		wg.Add(1)
@@ -303,12 +327,13 @@ func (ac *AhoCorasick) rollbackRemoved(ctx context.Context, keywords []string) {
 				<-sem
 				wg.Done()
 			}()
-			if _, err := ac.ops.add(ctx, k); err != nil && ac.logger != nil {
+			if _, err := add(ctx, k); err != nil && ac.logger != nil {
 				ac.logger.Printf("rollback: failed to re-add %q: %v", k, err)
 			}
 		}(keyword)
 	}
 	wg.Wait()
+	commit(ctx)
 }
 
 // FindMany searches for keywords in multiple texts and returns a map of text to matches.

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -169,7 +169,6 @@ func (ac *AhoCorasick) rollbackAdded(ctx context.Context, keywords []string) {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
 			wg.Wait()
-			commit(ctx)
 			return
 		}
 		wg.Add(1)
@@ -318,7 +317,6 @@ func (ac *AhoCorasick) rollbackRemoved(ctx context.Context, keywords []string) {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
 			wg.Wait()
-			commit(ctx)
 			return
 		}
 		wg.Add(1)

--- a/pkg/acor/batch_coalesce_test.go
+++ b/pkg/acor/batch_coalesce_test.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+	redis "github.com/redis/go-redis/v9"
+)
+
+func createPresetAC(t *testing.T) (*AhoCorasick, *miniredis.Miniredis) {
+	t.Helper()
+	mr := createTestRedisServer(t)
+	ac, err := Create(&AhoCorasickArgs{
+		Addr:   mr.Addr(),
+		Name:   "test",
+		Preset: PresetBalanced,
+	})
+	if err != nil {
+		mr.Close()
+		t.Fatal(err)
+	}
+	return ac, mr
+}
+
+// countInvalidations subscribes to the collection's invalidation channel and
+// returns how many messages arrive within a short drain window. One message per
+// commitBatch is the observable proof that a batch coalesces to a single rebuild.
+func countInvalidations(t *testing.T, mr *miniredis.Miniredis, name string, during func()) int {
+	t.Helper()
+	ctx := context.Background()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	sub := client.Subscribe(ctx, invalidateChannelPrefix+name)
+	defer sub.Close()
+	if _, err := sub.Receive(ctx); err != nil { // confirm subscription is live
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	during()
+
+	count := 0
+	for {
+		msg, err := sub.ReceiveTimeout(ctx, 300*time.Millisecond)
+		if err != nil {
+			break // timeout: no more messages
+		}
+		if _, ok := msg.(*redis.Message); ok {
+			count++
+		}
+	}
+	return count
+}
+
+func TestAddMany_CoalescesRebuild(t *testing.T) {
+	ac, mr := createPresetAC(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	keywords := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"}
+
+	var result *BatchResult
+	n := countInvalidations(t, mr, "test", func() {
+		var err error
+		result, err = ac.AddMany(keywords, nil)
+		if err != nil {
+			t.Fatalf("AddMany: %v", err)
+		}
+	})
+
+	if len(result.Added) != len(keywords) {
+		t.Fatalf("added %d, want %d", len(result.Added), len(keywords))
+	}
+	// The whole batch must publish exactly one invalidation, not one per keyword.
+	if n != 1 {
+		t.Errorf("AddMany of %d keywords published %d invalidations, want 1 (coalesced)", len(keywords), n)
+	}
+
+	// Correctness: every keyword is findable after the coalesced commit.
+	for _, kw := range keywords {
+		if ok, err := ac.Contains(kw); err != nil || !ok {
+			t.Errorf("Contains(%q) = %v, %v; want true", kw, ok, err)
+		}
+	}
+	matches, err := ac.FindMatches("alpha beta gamma", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := make(map[string]bool)
+	for _, m := range matches {
+		seen[m.Keyword] = true
+	}
+	for _, kw := range []string{"alpha", "beta", "gamma"} {
+		if !seen[kw] {
+			t.Errorf("FindMatches after AddMany missing %q (got %v)", kw, matches)
+		}
+	}
+}
+
+func TestRemoveMany_CoalescesRebuild(t *testing.T) {
+	ac, mr := createPresetAC(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	keywords := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
+	if _, err := ac.AddMany(keywords, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	toRemove := []string{"beta", "delta"}
+	var result *BatchResult
+	n := countInvalidations(t, mr, "test", func() {
+		var err error
+		result, err = ac.RemoveMany(toRemove)
+		if err != nil {
+			t.Fatalf("RemoveMany: %v", err)
+		}
+	})
+
+	if len(result.Removed) != len(toRemove) {
+		t.Fatalf("removed %d, want %d", len(result.Removed), len(toRemove))
+	}
+	if n != 1 {
+		t.Errorf("RemoveMany published %d invalidations, want 1 (coalesced)", n)
+	}
+
+	// beta/delta gone; the rest remain.
+	for kw, want := range map[string]bool{
+		"beta": false, "delta": false, "alpha": true, "gamma": true, "epsilon": true,
+	} {
+		ok, err := ac.Contains(kw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok != want {
+			t.Errorf("after RemoveMany Contains(%q) = %v, want %v", kw, ok, want)
+		}
+	}
+}
+
+func TestAddMany_Transactional_Coalesces(t *testing.T) {
+	ac, mr := createPresetAC(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	keywords := []string{"one", "two", "three", "four"}
+	n := countInvalidations(t, mr, "test", func() {
+		if _, err := ac.AddMany(keywords, &BatchOptions{Mode: BatchModeTransactional}); err != nil {
+			t.Fatalf("transactional AddMany: %v", err)
+		}
+	})
+	if n != 1 {
+		t.Errorf("transactional AddMany published %d invalidations, want 1", n)
+	}
+	for _, kw := range keywords {
+		if ok, _ := ac.Contains(kw); !ok {
+			t.Errorf("Contains(%q) = false after transactional AddMany", kw)
+		}
+	}
+}

--- a/pkg/acor/batch_coalesce_test.go
+++ b/pkg/acor/batch_coalesce_test.go
@@ -26,16 +26,16 @@ func createPresetAC(t *testing.T) (*AhoCorasick, *miniredis.Miniredis) {
 	return ac, mr
 }
 
-// countInvalidations subscribes to the collection's invalidation channel and
-// returns how many messages arrive within a short drain window. One message per
-// commitBatch is the observable proof that a batch coalesces to a single rebuild.
-func countInvalidations(t *testing.T, mr *miniredis.Miniredis, name string, during func()) int {
+// countInvalidations subscribes to the "test" collection's invalidation channel
+// and returns how many messages arrive within a short drain window. One message
+// per commitBatch is the observable proof that a batch coalesces to a single rebuild.
+func countInvalidations(t *testing.T, mr *miniredis.Miniredis, during func()) int {
 	t.Helper()
 	ctx := context.Background()
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	defer client.Close()
 
-	sub := client.Subscribe(ctx, invalidateChannelPrefix+name)
+	sub := client.Subscribe(ctx, invalidateChannelPrefix+"test")
 	defer sub.Close()
 	if _, err := sub.Receive(ctx); err != nil { // confirm subscription is live
 		t.Fatalf("subscribe: %v", err)
@@ -64,7 +64,7 @@ func TestAddMany_CoalescesRebuild(t *testing.T) {
 	keywords := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"}
 
 	var result *BatchResult
-	n := countInvalidations(t, mr, "test", func() {
+	n := countInvalidations(t, mr, func() {
 		var err error
 		result, err = ac.AddMany(keywords, nil)
 		if err != nil {
@@ -113,7 +113,7 @@ func TestRemoveMany_CoalescesRebuild(t *testing.T) {
 
 	toRemove := []string{"beta", "delta"}
 	var result *BatchResult
-	n := countInvalidations(t, mr, "test", func() {
+	n := countInvalidations(t, mr, func() {
 		var err error
 		result, err = ac.RemoveMany(toRemove)
 		if err != nil {
@@ -155,7 +155,7 @@ func TestRemoveMany_NoOpDoesNotCommit(t *testing.T) {
 	}
 
 	var result *BatchResult
-	n := countInvalidations(t, mr, "test", func() {
+	n := countInvalidations(t, mr, func() {
 		var err error
 		result, err = ac.RemoveMany([]string{"absent1", "absent2"})
 		if err != nil {
@@ -229,7 +229,7 @@ func TestAddMany_Transactional_Coalesces(t *testing.T) {
 	defer ac.Close()
 
 	keywords := []string{"one", "two", "three", "four"}
-	n := countInvalidations(t, mr, "test", func() {
+	n := countInvalidations(t, mr, func() {
 		if _, err := ac.AddMany(keywords, &BatchOptions{Mode: BatchModeTransactional}); err != nil {
 			t.Fatalf("transactional AddMany: %v", err)
 		}

--- a/pkg/acor/batch_coalesce_test.go
+++ b/pkg/acor/batch_coalesce_test.go
@@ -142,6 +142,38 @@ func TestRemoveMany_CoalescesRebuild(t *testing.T) {
 	}
 }
 
+// TestRemoveMany_NoOpDoesNotCommit guards against the reload storm: removing
+// keywords that are not present must not publish an invalidation or report them
+// as removed.
+func TestRemoveMany_NoOpDoesNotCommit(t *testing.T) {
+	ac, mr := createPresetAC(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	if _, err := ac.AddMany([]string{"alpha", "beta"}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	var result *BatchResult
+	n := countInvalidations(t, mr, "test", func() {
+		var err error
+		result, err = ac.RemoveMany([]string{"absent1", "absent2"})
+		if err != nil {
+			t.Fatalf("RemoveMany: %v", err)
+		}
+	})
+
+	if n != 0 {
+		t.Errorf("no-op RemoveMany published %d invalidations, want 0", n)
+	}
+	if len(result.Removed) != 0 {
+		t.Errorf("no-op RemoveMany reported %v as removed, want none", result.Removed)
+	}
+	if len(result.Skipped) != 2 {
+		t.Errorf("no-op RemoveMany skipped %d, want 2 (%v)", len(result.Skipped), result.Skipped)
+	}
+}
+
 func TestAddMany_Transactional_Coalesces(t *testing.T) {
 	ac, mr := createPresetAC(t)
 	defer mr.Close()

--- a/pkg/acor/batch_coalesce_test.go
+++ b/pkg/acor/batch_coalesce_test.go
@@ -174,6 +174,55 @@ func TestRemoveMany_NoOpDoesNotCommit(t *testing.T) {
 	}
 }
 
+// TestInvalidationPoll_DetectsMissedWrite proves the version-poll safety net:
+// after a remote write whose Pub/Sub invalidation was lost, the poller marks the
+// engine stale and the next read reloads.
+func TestInvalidationPoll_DetectsMissedWrite(t *testing.T) {
+	mr := createTestRedisServer(t)
+	defer mr.Close()
+	ac, err := Create(&AhoCorasickArgs{
+		Addr:                     mr.Addr(),
+		Name:                     "test",
+		Preset:                   PresetBalanced,
+		InvalidationPollInterval: 40 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ac.Close()
+
+	if ok, _ := ac.Contains("zeta"); ok {
+		t.Fatal("precondition: 'zeta' should be absent")
+	}
+
+	// Simulate a write on another node whose invalidation never arrived: write a
+	// valid trie state directly to Redis with a distinct version and DO NOT publish.
+	raw := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer raw.Close()
+	ctx := context.Background()
+	if err := raw.HSet(ctx, trieKey("test"), map[string]interface{}{
+		"keywords": `["zeta"]`,
+		"version":  int64(1), // differs from the init timestamp version
+	}).Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	// The 40ms poller should detect the version change and mark stale; the next
+	// Contains reloads and sees 'zeta'. Poll with a deadline to avoid flakiness.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if ok, err := ac.Contains("zeta"); err != nil {
+			t.Fatal(err)
+		} else if ok {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("poller did not pick up the out-of-band write within the deadline")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
 func TestAddMany_Transactional_Coalesces(t *testing.T) {
 	ac, mr := createPresetAC(t)
 	defer mr.Close()

--- a/pkg/acor/batch_v2_error_test.go
+++ b/pkg/acor/batch_v2_error_test.go
@@ -132,9 +132,9 @@ func TestV2GetOrLoadEngineError(t *testing.T) {
 	}
 	defer func() { _ = ops.client.Close() }()
 
-	_, err := ops.getOrLoadEngine(context.Background())
+	_, err := ops.loadEngine(context.Background())
 	if err == nil {
-		t.Fatal("expected error from closed Redis in getOrLoadEngine")
+		t.Fatal("expected error from closed Redis in loadEngine")
 	}
 }
 

--- a/pkg/acor/matches.go
+++ b/pkg/acor/matches.go
@@ -5,6 +5,7 @@ package acor
 import (
 	"bufio"
 	"context"
+	"errors"
 	"io"
 	"sort"
 	"unicode"
@@ -38,9 +39,15 @@ type MatchOptions struct {
 	// Kind selects overlapping (default) or leftmost-longest non-overlapping.
 	Kind MatchKind
 	// WholeWord, when true, drops matches whose neighboring runes are word
-	// characters (letters, digits, or underscore) — e.g. it stops "class" from
-	// matching inside "classic". Boundaries are the string start/end or any
-	// non-word rune.
+	// characters (letters, digits, combining marks, or underscore) — e.g. it stops
+	// "class" from matching inside "classic". Boundaries are the string start/end
+	// or any non-word rune.
+	//
+	// WholeWord assumes a script that delimits words with spaces or punctuation.
+	// Scripts written without inter-word boundaries (CJK, Thai, …) classify every
+	// adjacent character as a word rune, so a WholeWord match there is almost
+	// always treated as mid-word and dropped; use FindMatches without WholeWord
+	// for such text.
 	WholeWord bool
 }
 
@@ -74,7 +81,10 @@ func (ac *AhoCorasick) FindMatchesContext(ctx context.Context, text string, opts
 
 	matches := eng.FindMatches(norm)
 	if opts != nil {
-		if opts.WholeWord {
+		// Guard the []rune conversion: on the common zero-match path (a clean doc
+		// through a WholeWord gate) there is nothing to filter and the rune slice
+		// would be a wasted large allocation.
+		if opts.WholeWord && len(matches) > 0 {
 			matches = filterWholeWord(matches, []rune(norm))
 		}
 		if opts.Kind == MatchKindLeftmostLongest {
@@ -151,7 +161,9 @@ func (ac *AhoCorasick) FindStreamContext(ctx context.Context, r io.Reader, onMat
 		}
 		ru, _, e := br.ReadRune()
 		if e != nil {
-			if e != io.EOF {
+			// errors.Is, not ==: a decorator reader may return a wrapped io.EOF at
+			// end of input, which is a normal completion, not a scan failure.
+			if !errors.Is(e, io.EOF) {
 				scanErr = e
 			}
 			return 0, false
@@ -209,5 +221,8 @@ func filterWholeWord(ms []Match, runes []rune) []Match {
 }
 
 func isWordRune(r rune) bool {
-	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+	// unicode.Mark: a combining mark (e.g. U+0301) belongs to the base letter it
+	// decorates, so a match ending right before one (decomposed/NFD text like
+	// "cafe"+combining-acute) is mid-word, not a whole word.
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.Is(unicode.Mark, r) || r == '_'
 }

--- a/pkg/acor/matches.go
+++ b/pkg/acor/matches.go
@@ -81,9 +81,6 @@ func (ac *AhoCorasick) FindMatchesContext(ctx context.Context, text string, opts
 			matches = leftmostLongest(matches)
 		}
 	}
-	if matches == nil {
-		matches = []Match{}
-	}
 	return matches, nil
 }
 

--- a/pkg/acor/matches.go
+++ b/pkg/acor/matches.go
@@ -46,9 +46,16 @@ type MatchOptions struct {
 	// WholeWord assumes a script that delimits words with spaces or punctuation.
 	// Scripts written without inter-word boundaries (CJK, Thai, …) classify every
 	// adjacent character as a word rune, so a WholeWord match there is almost
-	// always treated as mid-word and dropped; use FindMatches without WholeWord
-	// for such text.
+	// always treated as mid-word and dropped; use FindMatches without WholeWord,
+	// or supply WordRune, for such text.
 	WholeWord bool
+	// WordRune overrides which runes count as part of a word when WholeWord is
+	// set. A match is whole-word only when the runes immediately before its start
+	// and at its end are not word runes. nil uses the default (letters, digits,
+	// combining marks, underscore). Supply a predicate for scripts the default
+	// misclassifies — e.g. return false for CJK ideographs so a CJK term bounded
+	// by spaces or ASCII is reported. Ignored unless WholeWord is true.
+	WordRune func(rune) bool
 }
 
 // FindMatches searches text and returns matches carrying each keyword and its
@@ -85,7 +92,11 @@ func (ac *AhoCorasick) FindMatchesContext(ctx context.Context, text string, opts
 		// through a WholeWord gate) there is nothing to filter and the rune slice
 		// would be a wasted large allocation.
 		if opts.WholeWord && len(matches) > 0 {
-			matches = filterWholeWord(matches, []rune(norm))
+			isWord := isWordRune
+			if opts.WordRune != nil {
+				isWord = opts.WordRune
+			}
+			matches = filterWholeWord(matches, []rune(norm), isWord)
 		}
 		if opts.Kind == MatchKindLeftmostLongest {
 			matches = leftmostLongest(matches)
@@ -206,13 +217,13 @@ func leftmostLongest(ms []Match) []Match {
 }
 
 // filterWholeWord keeps only matches bounded by non-word runes (or the text
-// edges). runes is the searched text as a rune slice, so Match rune offsets index
-// directly into it.
-func filterWholeWord(ms []Match, runes []rune) []Match {
+// edges), per the isWord predicate. runes is the searched text as a rune slice,
+// so Match rune offsets index directly into it.
+func filterWholeWord(ms []Match, runes []rune, isWord func(rune) bool) []Match {
 	out := make([]Match, 0, len(ms))
 	for _, m := range ms {
-		beforeOK := m.Start == 0 || !isWordRune(runes[m.Start-1])
-		afterOK := m.End >= len(runes) || !isWordRune(runes[m.End])
+		beforeOK := m.Start == 0 || !isWord(runes[m.Start-1])
+		afterOK := m.End >= len(runes) || !isWord(runes[m.End])
 		if beforeOK && afterOK {
 			out = append(out, m)
 		}

--- a/pkg/acor/matches.go
+++ b/pkg/acor/matches.go
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"sort"
+	"unicode"
+
+	matchengine "github.com/skyoo2003/acor/internal/engine"
+)
+
+// Match is a single keyword occurrence in the searched text. Start and End are
+// rune offsets forming the half-open span [Start, End), consistent with
+// FindIndex's rune-based offsets. Re-exported from the internal engine package so
+// callers depend only on the public acor API.
+type Match = matchengine.Match
+
+// MatchKind selects how overlapping matches are reported by FindMatches.
+type MatchKind int
+
+const (
+	// MatchKindOverlapping reports every match, including overlapping and nested
+	// ones, in scan order. This is the classic Aho-Corasick behavior and matches
+	// what Find/FindIndex return. It is the default.
+	MatchKindOverlapping MatchKind = iota
+	// MatchKindLeftmostLongest reports only non-overlapping matches, preferring
+	// the leftmost start and, among matches at the same start, the longest
+	// keyword. Best for tokenization, redaction, and replace-the-match workflows.
+	MatchKindLeftmostLongest
+)
+
+// MatchOptions tunes FindMatches. A nil *MatchOptions means overlapping matches
+// with no whole-word constraint (identical to the raw automaton output).
+type MatchOptions struct {
+	// Kind selects overlapping (default) or leftmost-longest non-overlapping.
+	Kind MatchKind
+	// WholeWord, when true, drops matches whose neighboring runes are word
+	// characters (letters, digits, or underscore) — e.g. it stops "class" from
+	// matching inside "classic". Boundaries are the string start/end or any
+	// non-word rune.
+	WholeWord bool
+}
+
+// FindMatches searches text and returns matches carrying each keyword and its
+// rune-offset span, in scan order. Unlike FindIndex (which groups start offsets
+// by keyword and loses ordering and end positions), this preserves match order
+// and end offsets — useful for highlighting and replacement.
+//
+// opts controls overlap handling and whole-word filtering; nil yields raw
+// overlapping matches.
+func (ac *AhoCorasick) FindMatches(text string, opts *MatchOptions) ([]Match, error) {
+	return ac.FindMatchesContext(ac.ctx, text, opts)
+}
+
+// FindMatchesContext is FindMatches with an explicit context for cancellation.
+func (ac *AhoCorasick) FindMatchesContext(ctx context.Context, text string, opts *MatchOptions) ([]Match, error) {
+	if text == "" {
+		return []Match{}, nil
+	}
+	norm := normalizeText(text, ac.caseSensitive)
+
+	eng, err := ac.ops.loadEngine(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// Honor an already-canceled ctx at the match boundary; the in-memory scan
+	// itself isn't ctx-threaded (mirrors find/findIndex).
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	matches := eng.FindMatches(norm)
+	if opts != nil {
+		if opts.WholeWord {
+			matches = filterWholeWord(matches, []rune(norm))
+		}
+		if opts.Kind == MatchKindLeftmostLongest {
+			matches = leftmostLongest(matches)
+		}
+	}
+	if matches == nil {
+		matches = []Match{}
+	}
+	return matches, nil
+}
+
+// Contains reports whether text contains any keyword. It stops at the first
+// match instead of collecting them all, so it is cheaper than len(Find()) > 0
+// for gate-style checks (e.g. "does this text contain a banned word?").
+func (ac *AhoCorasick) Contains(text string) (bool, error) {
+	return ac.ContainsContext(ac.ctx, text)
+}
+
+// ContainsContext is Contains with an explicit context for cancellation.
+func (ac *AhoCorasick) ContainsContext(ctx context.Context, text string) (bool, error) {
+	if text == "" {
+		return false, nil
+	}
+	norm := normalizeText(text, ac.caseSensitive)
+
+	eng, err := ac.ops.loadEngine(ctx)
+	if err != nil {
+		return false, err
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	return eng.Contains(norm), nil
+}
+
+// FindStream scans an io.Reader without loading the whole input into memory,
+// invoking onMatch for every match (overlaps included) in scan order. Match
+// offsets are rune positions from the start of the stream. Return false from
+// onMatch to stop early.
+//
+// Unlike FindParallel, which can miss a keyword longer than the chunk overlap at
+// a chunk boundary, streaming keeps a single automaton state across the whole
+// input, so no match is ever split.
+//
+// Whole-word and leftmost-longest options are not applied here: both need
+// buffering that defeats streaming. Use FindMatches on a bounded string for
+// those. Only modes with a local engine (Preset or a V2/V1 collection) are
+// supported.
+func (ac *AhoCorasick) FindStream(r io.Reader, onMatch func(Match) bool) error {
+	return ac.FindStreamContext(ac.ctx, r, onMatch)
+}
+
+// FindStreamContext is FindStream with an explicit context. The context is
+// checked between runes, so a canceled context stops the scan and returns
+// ctx.Err().
+func (ac *AhoCorasick) FindStreamContext(ctx context.Context, r io.Reader, onMatch func(Match) bool) error {
+	if r == nil || onMatch == nil {
+		return nil
+	}
+
+	eng, err := ac.ops.loadEngine(ctx)
+	if err != nil {
+		return err
+	}
+
+	br := bufio.NewReader(r)
+	caseInsensitive := !ac.caseSensitive
+	var scanErr error
+
+	// bufio.Reader.ReadRune handles runes split across buffer refills, so the
+	// stream is decoded exactly like a range loop over the full string.
+	next := func() (rune, bool) {
+		if err := ctx.Err(); err != nil {
+			scanErr = err
+			return 0, false
+		}
+		ru, _, e := br.ReadRune()
+		if e != nil {
+			if e != io.EOF {
+				scanErr = e
+			}
+			return 0, false
+		}
+		if caseInsensitive {
+			// Per-rune lowering is the streaming equivalent of strings.ToLower;
+			// they agree on ASCII (the common case). ponytail: per-rune fold, use
+			// x/text/cases if locale-correct multi-rune folding is ever needed.
+			ru = unicode.ToLower(ru)
+		}
+		return ru, true
+	}
+
+	eng.Stream(next, onMatch)
+	return scanErr
+}
+
+// leftmostLongest reduces overlapping matches to the non-overlapping
+// leftmost-longest set: sort by start ascending then end descending, then greedily
+// keep a match whenever its start is at or past the previous kept match's end.
+func leftmostLongest(ms []Match) []Match {
+	if len(ms) <= 1 {
+		return ms
+	}
+	sort.Slice(ms, func(i, j int) bool {
+		if ms[i].Start != ms[j].Start {
+			return ms[i].Start < ms[j].Start
+		}
+		return ms[i].End > ms[j].End
+	})
+	out := make([]Match, 0, len(ms))
+	lastEnd := 0
+	for _, m := range ms {
+		if m.Start >= lastEnd {
+			out = append(out, m)
+			lastEnd = m.End
+		}
+	}
+	return out
+}
+
+// filterWholeWord keeps only matches bounded by non-word runes (or the text
+// edges). runes is the searched text as a rune slice, so Match rune offsets index
+// directly into it.
+func filterWholeWord(ms []Match, runes []rune) []Match {
+	out := make([]Match, 0, len(ms))
+	for _, m := range ms {
+		beforeOK := m.Start == 0 || !isWordRune(runes[m.Start-1])
+		afterOK := m.End >= len(runes) || !isWordRune(runes[m.End])
+		if beforeOK && afterOK {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+func isWordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+}

--- a/pkg/acor/matches_test.go
+++ b/pkg/acor/matches_test.go
@@ -3,6 +3,8 @@
 package acor
 
 import (
+	"fmt"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -71,6 +73,67 @@ func TestFindMatches_WholeWord(t *testing.T) {
 		t.Fatal(err)
 	} else if len(got) != 1 || got[0].Keyword != "class" {
 		t.Errorf("whole-word should match standalone 'class', got %v", got)
+	}
+}
+
+// TestFindMatches_WholeWord_CombiningMark guards against a false positive on
+// decomposed (NFD) text: "cafe" must not be reported as a whole word inside
+// "café" written as "cafe" + U+0301 (combining acute), because the combining
+// mark belongs to the preceding letter.
+func TestFindMatches_WholeWord_CombiningMark(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	addAll(t, ac, "cafe")
+	decomposed := "café" // café in NFD
+	if got, err := ac.FindMatches(decomposed, &MatchOptions{WholeWord: true}); err != nil {
+		t.Fatal(err)
+	} else if len(got) != 0 {
+		t.Errorf("whole-word should reject 'cafe' before a combining mark, got %v", got)
+	}
+	// Control: a real standalone "cafe" still matches.
+	if got, err := ac.FindMatches("the cafe opens", &MatchOptions{WholeWord: true}); err != nil {
+		t.Fatal(err)
+	} else if len(got) != 1 {
+		t.Errorf("whole-word should match standalone 'cafe', got %v", got)
+	}
+}
+
+// wrappedEOFReader returns its data, then a wrapped io.EOF (not the bare
+// sentinel) — as some decorator/decompressor readers do.
+type wrappedEOFReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *wrappedEOFReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, fmt.Errorf("stream done: %w", io.EOF)
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+// TestFindStream_WrappedEOF confirms a wrapped io.EOF at end of input is treated
+// as normal completion, not a scan error.
+func TestFindStream_WrappedEOF(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	addAll(t, ac, "abc")
+	var found []Match
+	err := ac.FindStream(&wrappedEOFReader{data: []byte("xabcx")}, func(m Match) bool {
+		found = append(found, m)
+		return true
+	})
+	if err != nil {
+		t.Errorf("wrapped io.EOF should be normal completion, got err %v", err)
+	}
+	if len(found) != 1 || found[0].Keyword != "abc" {
+		t.Errorf("FindStream over wrapped-EOF reader = %v, want single abc", found)
 	}
 }
 

--- a/pkg/acor/matches_test.go
+++ b/pkg/acor/matches_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func addAll(t *testing.T, ac *AhoCorasick, kws ...string) {
+	t.Helper()
+	for _, k := range kws {
+		if _, err := ac.Add(k); err != nil {
+			t.Fatalf("Add(%q): %v", k, err)
+		}
+	}
+}
+
+func TestFindMatches_Overlapping(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	addAll(t, ac, "he", "her", "hers")
+	got, err := ac.FindMatches("hers", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []Match{
+		{Keyword: "he", Start: 0, End: 2},
+		{Keyword: "her", Start: 0, End: 3},
+		{Keyword: "hers", Start: 0, End: 4},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindMatches = %v, want %v", got, want)
+	}
+}
+
+func TestFindMatches_LeftmostLongest(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	addAll(t, ac, "he", "her", "hers", "she")
+	// Overlapping would report he/her/hers/she all at start 0-1; leftmost-longest
+	// keeps only the longest non-overlapping run: "she"(0-3) then nothing left.
+	got, err := ac.FindMatches("shers", &MatchOptions{Kind: MatchKindLeftmostLongest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// "shers": she@0-3, then from index 3 "rs" has no match. hers@1-5 overlaps she.
+	want := []Match{{Keyword: "she", Start: 0, End: 3}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("leftmost-longest = %v, want %v", got, want)
+	}
+}
+
+func TestFindMatches_WholeWord(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	addAll(t, ac, "class")
+	if got, err := ac.FindMatches("classic classroom", &MatchOptions{WholeWord: true}); err != nil {
+		t.Fatal(err)
+	} else if len(got) != 0 {
+		t.Errorf("whole-word should reject 'class' inside 'classic'/'classroom', got %v", got)
+	}
+	if got, err := ac.FindMatches("the class ended", &MatchOptions{WholeWord: true}); err != nil {
+		t.Fatal(err)
+	} else if len(got) != 1 || got[0].Keyword != "class" {
+		t.Errorf("whole-word should match standalone 'class', got %v", got)
+	}
+}
+
+func TestContains_EndToEnd(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	addAll(t, ac, "banned", "forbidden")
+	if ok, err := ac.Contains("this text is banned here"); err != nil || !ok {
+		t.Errorf("Contains = %v, %v; want true, nil", ok, err)
+	}
+	if ok, err := ac.Contains("this text is clean"); err != nil || ok {
+		t.Errorf("Contains = %v, %v; want false, nil", ok, err)
+	}
+}
+
+// TestFindStream_NoBoundaryLoss guards the motivating bug: a keyword longer than
+// the parallel chunk overlap must still be found when it straddles buffer refills.
+func TestFindStream_NoBoundaryLoss(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	needle := "supercalifragilistic" // 20 runes, longer than DefaultOverlap(50)? no — but longer than a small buffer
+	addAll(t, ac, needle)
+
+	// Bury the needle deep in a long stream so it spans bufio refills.
+	text := strings.Repeat("x", 10000) + needle + strings.Repeat("y", 10000)
+
+	var found []Match
+	err := ac.FindStream(strings.NewReader(text), func(m Match) bool {
+		found = append(found, m)
+		return true
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(found) != 1 || found[0].Keyword != needle {
+		t.Fatalf("FindStream found %v, want single %q", found, needle)
+	}
+	if got := found[0].Start; got != 10000 {
+		t.Errorf("stream match Start = %d, want 10000", got)
+	}
+}
+
+func TestFindStream_EarlyStop(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	addAll(t, ac, "ab")
+	count := 0
+	err := ac.FindStream(strings.NewReader("abababab"), func(Match) bool {
+		count++
+		return false
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("early-stop stream emitted %d, want 1", count)
+	}
+}
+
+func TestFindMatches_V1(t *testing.T) {
+	ac, mr := createAhoCorasickV1(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	addAll(t, ac, "he", "her")
+	got, err := ac.FindMatches("her", nil)
+	if err != nil {
+		t.Fatalf("V1 FindMatches: %v", err)
+	}
+	want := []Match{
+		{Keyword: "he", Start: 0, End: 2},
+		{Keyword: "her", Start: 0, End: 3},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("V1 FindMatches = %v, want %v", got, want)
+	}
+}
+
+func TestLeftmostLongest_Unit(t *testing.T) {
+	in := []Match{
+		{Keyword: "he", Start: 0, End: 2},
+		{Keyword: "her", Start: 0, End: 3},
+		{Keyword: "is", Start: 4, End: 6},
+	}
+	got := leftmostLongest(in)
+	want := []Match{
+		{Keyword: "her", Start: 0, End: 3},
+		{Keyword: "is", Start: 4, End: 6},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("leftmostLongest = %v, want %v", got, want)
+	}
+}

--- a/pkg/acor/matches_test.go
+++ b/pkg/acor/matches_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unicode"
 )
 
 func addAll(t *testing.T, ac *AhoCorasick, kws ...string) {
@@ -97,6 +98,34 @@ func TestFindMatches_WholeWord_CombiningMark(t *testing.T) {
 		t.Fatal(err)
 	} else if len(got) != 1 {
 		t.Errorf("whole-word should match standalone 'cafe', got %v", got)
+	}
+}
+
+// TestFindMatches_WholeWord_CustomWordRune shows the WordRune override making
+// WholeWord usable for a script the default misclassifies (CJK): the default
+// drops the match, a Han-aware predicate keeps it.
+func TestFindMatches_WholeWord_CustomWordRune(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	addAll(t, ac, "違禁")
+
+	// Default WholeWord drops it: the following '詞' is a letter (word rune).
+	if got, err := ac.FindMatches("違禁詞", &MatchOptions{WholeWord: true}); err != nil {
+		t.Fatal(err)
+	} else if len(got) != 0 {
+		t.Errorf("default WholeWord should drop the CJK-adjacent match, got %v", got)
+	}
+
+	// Treat Han ideographs as non-word so a term bounded by other Han still counts.
+	nonHan := func(r rune) bool { return isWordRune(r) && !unicode.Is(unicode.Han, r) }
+	got, err := ac.FindMatches("違禁詞", &MatchOptions{WholeWord: true, WordRune: nonHan})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Keyword != "違禁" {
+		t.Errorf("custom WordRune should match the CJK term, got %v", got)
 	}
 }
 

--- a/pkg/acor/operations.go
+++ b/pkg/acor/operations.go
@@ -2,7 +2,11 @@
 
 package acor
 
-import "context"
+import (
+	"context"
+
+	matchengine "github.com/skyoo2003/acor/internal/engine"
+)
 
 // operations defines the core Aho-Corasick methods shared by V1 and V2
 // implementations. This unexported interface is the Strategy pattern
@@ -22,4 +26,8 @@ type operations interface {
 	suggestIndex(ctx context.Context, input string) (map[string][]int, error)
 	flush(ctx context.Context) error
 	info(ctx context.Context) (*AhoCorasickInfo, error)
+	// loadEngine returns an immutable in-memory match engine snapshot for the
+	// current keyword set. FindMatches, Contains, and FindStream all scan through
+	// it, so match semantics stay identical to find/findIndex across every mode.
+	loadEngine(ctx context.Context) (*matchengine.Engine, error)
 }

--- a/pkg/acor/preset_redis_ops.go
+++ b/pkg/acor/preset_redis_ops.go
@@ -4,10 +4,15 @@ package acor
 
 import (
 	"context"
+
+	matchengine "github.com/skyoo2003/acor/internal/engine"
 )
 
-// Compile-time check.
-var _ operations = (*presetRedisOps)(nil)
+// Compile-time checks.
+var (
+	_ operations  = (*presetRedisOps)(nil)
+	_ batchWriter = (*presetRedisOps)(nil)
+)
 
 // presetRedisOps adapts a redisBackedAC to satisfy the operations interface
 // used by AhoCorasick. Suggest/SuggestIndex are not supported in preset mode.
@@ -33,6 +38,24 @@ func (o *presetRedisOps) find(ctx context.Context, text string) ([]string, error
 
 func (o *presetRedisOps) findIndex(ctx context.Context, text string) (map[string][]int, error) {
 	return o.ac.FindIndex(ctx, text)
+}
+
+func (o *presetRedisOps) loadEngine(ctx context.Context) (*matchengine.Engine, error) {
+	return o.ac.loadEngine(ctx)
+}
+
+// batchWriter: coalesce the local rebuild + invalidation across a batch.
+
+func (o *presetRedisOps) addDeferred(ctx context.Context, keyword string) (int, error) {
+	return o.ac.addDeferred(ctx, keyword)
+}
+
+func (o *presetRedisOps) removeDeferred(ctx context.Context, keyword string) (int, error) {
+	return o.ac.removeDeferred(ctx, keyword)
+}
+
+func (o *presetRedisOps) commitBatch(ctx context.Context) {
+	o.ac.commitBatch(ctx)
 }
 
 func (o *presetRedisOps) suggest(_ context.Context, _ string) ([]string, error) {

--- a/pkg/acor/redis_backed.go
+++ b/pkg/acor/redis_backed.go
@@ -141,15 +141,39 @@ func (ac *redisBackedAC) initTrie(ctx context.Context) error {
 	return nil
 }
 
+// buildEngine returns a freshly built engine for the given keyword set. The
+// engine is replaced (not mutated in place) on every rebuild so that a pointer
+// obtained under RLock stays immutable after the lock is released — this is what
+// makes lock-free scanning (loadEngine) and long-running streaming safe.
+func buildEngine(preset Preset, keywordSet map[string]struct{}) *matchengine.Engine {
+	e := matchengine.New(preset)
+	e.Build(keywordSet)
+	return e
+}
+
 func (ac *redisBackedAC) applyReload(snap *trieSnapshot) {
 	keywordSet := make(map[string]struct{}, len(snap.Keywords))
 	for _, kw := range snap.Keywords {
 		keywordSet[kw] = struct{}{}
 	}
 	ac.keywordSet = keywordSet
-	ac.engine.Build(keywordSet)
+	ac.engine = buildEngine(ac.preset, keywordSet)
 	ac.localVersion = snap.Version
 	ac.stale = false
+}
+
+// loadEngine returns an immutable engine snapshot for the current keyword set,
+// refreshing from Redis first if the local copy is stale. The returned engine is
+// never mutated after this point (rebuilds swap in a new one), so the caller may
+// scan it without holding ac.mu.
+func (ac *redisBackedAC) loadEngine(ctx context.Context) (*matchengine.Engine, error) {
+	if err := ac.ensureValid(ctx); err != nil {
+		return nil, err
+	}
+	ac.mu.RLock()
+	e := ac.engine
+	ac.mu.RUnlock()
+	return e, nil
 }
 
 func (ac *redisBackedAC) reloadFromRedis(ctx context.Context) error {

--- a/pkg/acor/redis_backed.go
+++ b/pkg/acor/redis_backed.go
@@ -37,6 +37,7 @@ type redisBackedAC struct {
 	keywordSet   map[string]struct{}
 	localVersion int64
 	stale        bool
+	pollInterval time.Duration
 
 	selfSkip      sync.Map
 	selfSkipCount uint64
@@ -78,6 +79,7 @@ func newRedisBacked(ctx context.Context, args *AhoCorasickArgs) (*redisBackedAC,
 		storage:       storage,
 		redisClient:   redisClient,
 		keywordSet:    make(map[string]struct{}),
+		pollInterval:  args.InvalidationPollInterval,
 		ctx:           acCtx,
 		cancel:        acCancel,
 	}
@@ -98,6 +100,10 @@ func newRedisBacked(ctx context.Context, args *AhoCorasickArgs) (*redisBackedAC,
 		acCancel()
 		_ = storage.Close()
 		return nil, fmt.Errorf("pub/sub setup failed: %w", err)
+	}
+
+	if ac.pollInterval > 0 {
+		ac.startPoller()
 	}
 
 	return ac, nil
@@ -224,6 +230,15 @@ func (ac *redisBackedAC) ensureValid(ctx context.Context) error {
 
 const selfInvalTTL = 30 * time.Second
 
+// publishRetryAttempts / publishRetryBackoff give the fire-and-forget invalidation
+// PUBLISH a few tries before giving up, so a single transient blip does not drop a
+// whole batch's cross-node notification. The version poller (InvalidationPollInterval)
+// is the durable safety net; this just narrows the transient-failure window.
+const (
+	publishRetryAttempts = 3
+	publishRetryBackoff  = 10 * time.Millisecond
+)
+
 func (ac *redisBackedAC) startListener() error {
 	channel := invalidateChannelPrefix + ac.name
 	pubsub := ac.storage.Subscribe(ac.ctx, channel)
@@ -264,6 +279,42 @@ func (ac *redisBackedAC) handleInvalidation(payload string) {
 	ac.markStale()
 }
 
+// startPoller runs a background safety net for missed Pub/Sub invalidations:
+// every pollInterval it compares the stored collection version against the local
+// one and marks the engine stale on any difference, so a dropped invalidation
+// self-heals within one interval instead of persisting until the next local write.
+func (ac *redisBackedAC) startPoller() {
+	go func() {
+		ticker := time.NewTicker(ac.pollInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				ac.pollVersion()
+			case <-ac.stopCh:
+				return
+			case <-ac.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// pollVersion marks the engine stale if Redis holds a version other than the one
+// last loaded locally. A transient read error is ignored; the next tick retries.
+func (ac *redisBackedAC) pollVersion() {
+	snap, err := readTrieSnapshot(ac.ctx, ac.storage, ac.name)
+	if err != nil {
+		return
+	}
+	ac.mu.RLock()
+	changed := snap.Version != ac.localVersion
+	ac.mu.RUnlock()
+	if changed {
+		ac.markStale()
+	}
+}
+
 func (ac *redisBackedAC) skipSelfSet(id string) {
 	ac.selfSkip.Store(id, time.Now())
 }
@@ -294,7 +345,22 @@ func (ac *redisBackedAC) publishInvalidate(ctx context.Context) {
 		ac.cleanupExpiredSelfSkips()
 	}
 
-	err := ac.storage.Publish(ctx, channel, payload)
+	var err error
+	for attempt := 0; attempt < publishRetryAttempts; attempt++ {
+		if err = ac.storage.Publish(ctx, channel, payload); err == nil {
+			break
+		}
+		if attempt == publishRetryAttempts-1 {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			// Undelivered: drop the self-skip entry so it does not linger, then stop.
+			ac.selfSkip.Delete(msgID)
+			return
+		case <-time.After(publishRetryBackoff):
+		}
+	}
 	if err != nil {
 		ac.selfSkip.Delete(msgID)
 	}

--- a/pkg/acor/redis_backed_ops.go
+++ b/pkg/acor/redis_backed_ops.go
@@ -18,6 +18,19 @@ const redisBackedRetryBackoff = 10 * time.Millisecond
 // to Redis via a V2 Lua script (optimistic locking), then the local automaton
 // is rebuilt and an invalidation is published.
 func (ac *redisBackedAC) Add(ctx context.Context, keyword string) (int, error) {
+	return ac.addWith(ctx, keyword, true)
+}
+
+// addDeferred writes a keyword but skips the local rebuild and pub/sub publish;
+// commitBatch performs both once for the whole batch. This turns AddMany's N
+// per-keyword automaton rebuilds into a single rebuild.
+func (ac *redisBackedAC) addDeferred(ctx context.Context, keyword string) (int, error) {
+	return ac.addWith(ctx, keyword, false)
+}
+
+// addWith is the shared Add path. rebuild=true rebuilds the local engine and
+// publishes on success (single Add); rebuild=false defers both (batch writes).
+func (ac *redisBackedAC) addWith(ctx context.Context, keyword string, rebuild bool) (int, error) {
 	keyword = normalizeKeyword(keyword, ac.caseSensitive)
 	if keyword == "" {
 		return 0, nil
@@ -26,7 +39,7 @@ func (ac *redisBackedAC) Add(ctx context.Context, keyword string) (int, error) {
 	v2 := &redisBackedV2{client: ac.redisClient}
 
 	for attempt := 0; attempt < redisBackedMaxRetries; attempt++ {
-		added, err := ac.tryAdd(ctx, keyword, v2)
+		added, err := ac.tryAdd(ctx, keyword, v2, rebuild)
 		if errors.Is(err, ErrConcurrencyConflict) {
 			backoff := time.Duration(attempt+1) * redisBackedRetryBackoff
 			select {
@@ -36,12 +49,15 @@ func (ac *redisBackedAC) Add(ctx context.Context, keyword string) (int, error) {
 			}
 			continue
 		}
+		if err == nil && added == 1 && rebuild {
+			ac.publishInvalidate(ctx)
+		}
 		return added, err
 	}
 	return 0, ErrConcurrencyConflict
 }
 
-func (ac *redisBackedAC) tryAdd(ctx context.Context, keyword string, v2 *redisBackedV2) (int, error) { //nolint:gocyclo,funlen
+func (ac *redisBackedAC) tryAdd(ctx context.Context, keyword string, v2 *redisBackedV2, rebuild bool) (int, error) { //nolint:gocyclo,funlen
 	snap, err := readTrieSnapshot(ctx, ac.storage, ac.name)
 	if err != nil {
 		return 0, err
@@ -124,19 +140,54 @@ func (ac *redisBackedAC) tryAdd(ctx context.Context, keyword string, v2 *redisBa
 		return 0, ErrConcurrencyConflict
 	}
 
+	ac.applyLocalWrite(keyword, true, newVersion, rebuild)
+	return 1, nil
+}
+
+// applyLocalWrite applies a committed Redis write to the local state under lock.
+// add selects insertion vs deletion of keyword in the keyword set. rebuild=true
+// rebuilds the engine now and clears the stale flag; rebuild=false marks the
+// engine stale so a concurrent Find reloads from Redis until commitBatch rebuilds.
+func (ac *redisBackedAC) applyLocalWrite(keyword string, add bool, newVersion int64, rebuild bool) {
 	ac.mu.Lock()
-	ac.keywordSet[keyword] = struct{}{}
-	ac.engine.Build(ac.keywordSet)
+	if add {
+		ac.keywordSet[keyword] = struct{}{}
+	} else {
+		delete(ac.keywordSet, keyword)
+	}
 	ac.localVersion = newVersion
+	if rebuild {
+		ac.engine = buildEngine(ac.preset, ac.keywordSet)
+		ac.stale = false
+	} else {
+		ac.stale = true
+	}
+	ac.mu.Unlock()
+}
+
+// commitBatch rebuilds the local engine once from the current keyword set and
+// publishes a single invalidation, collapsing the rebuild/publish that
+// addDeferred/removeDeferred skipped during a batch.
+func (ac *redisBackedAC) commitBatch(ctx context.Context) {
+	ac.mu.Lock()
+	ac.engine = buildEngine(ac.preset, ac.keywordSet)
 	ac.stale = false
 	ac.mu.Unlock()
-
 	ac.publishInvalidate(ctx)
-	return 1, nil
 }
 
 // Remove deletes a keyword from the automaton.
 func (ac *redisBackedAC) Remove(ctx context.Context, keyword string) (int, error) {
+	return ac.removeWith(ctx, keyword, true)
+}
+
+// removeDeferred is Remove with the local rebuild and publish deferred to
+// commitBatch; see addDeferred.
+func (ac *redisBackedAC) removeDeferred(ctx context.Context, keyword string) (int, error) {
+	return ac.removeWith(ctx, keyword, false)
+}
+
+func (ac *redisBackedAC) removeWith(ctx context.Context, keyword string, rebuild bool) (int, error) {
 	keyword = normalizeKeyword(keyword, ac.caseSensitive)
 	if keyword == "" {
 		return 0, nil
@@ -145,7 +196,7 @@ func (ac *redisBackedAC) Remove(ctx context.Context, keyword string) (int, error
 	v2 := &redisBackedV2{client: ac.redisClient}
 
 	for attempt := 0; attempt < redisBackedMaxRetries; attempt++ {
-		removed, err := ac.tryRemove(ctx, keyword, v2)
+		removed, err := ac.tryRemove(ctx, keyword, v2, rebuild)
 		if errors.Is(err, ErrConcurrencyConflict) {
 			backoff := time.Duration(attempt+1) * redisBackedRetryBackoff
 			select {
@@ -155,12 +206,15 @@ func (ac *redisBackedAC) Remove(ctx context.Context, keyword string) (int, error
 			}
 			continue
 		}
+		if err == nil && removed == 1 && rebuild {
+			ac.publishInvalidate(ctx)
+		}
 		return removed, err
 	}
 	return 0, ErrConcurrencyConflict
 }
 
-func (ac *redisBackedAC) tryRemove(ctx context.Context, keyword string, v2 *redisBackedV2) (int, error) { //nolint:gocyclo,funlen
+func (ac *redisBackedAC) tryRemove(ctx context.Context, keyword string, v2 *redisBackedV2, rebuild bool) (int, error) { //nolint:gocyclo,funlen
 	snap, err := readTrieSnapshot(ctx, ac.storage, ac.name)
 	if err != nil {
 		return 0, err
@@ -254,14 +308,7 @@ func (ac *redisBackedAC) tryRemove(ctx context.Context, keyword string, v2 *redi
 		return 0, ErrConcurrencyConflict
 	}
 
-	ac.mu.Lock()
-	delete(ac.keywordSet, keyword)
-	ac.engine.Build(ac.keywordSet)
-	ac.localVersion = newVersion
-	ac.stale = false
-	ac.mu.Unlock()
-
-	ac.publishInvalidate(ctx)
+	ac.applyLocalWrite(keyword, false, newVersion, rebuild)
 	return 1, nil
 }
 
@@ -272,13 +319,11 @@ func (ac *redisBackedAC) Find(ctx context.Context, text string) ([]string, error
 	}
 	text = normalizeText(text, ac.caseSensitive)
 
-	if err := ac.ensureValid(ctx); err != nil {
+	e, err := ac.loadEngine(ctx)
+	if err != nil {
 		return nil, err
 	}
-
-	ac.mu.RLock()
-	defer ac.mu.RUnlock()
-	return ac.engine.Find(text), nil
+	return e.Find(text), nil
 }
 
 // FindIndex searches the text for all keywords and returns their start indices.
@@ -288,13 +333,11 @@ func (ac *redisBackedAC) FindIndex(ctx context.Context, text string) (map[string
 	}
 	text = normalizeText(text, ac.caseSensitive)
 
-	if err := ac.ensureValid(ctx); err != nil {
+	e, err := ac.loadEngine(ctx)
+	if err != nil {
 		return nil, err
 	}
-
-	ac.mu.RLock()
-	defer ac.mu.RUnlock()
-	return ac.engine.FindIndex(text), nil
+	return e.FindIndex(text), nil
 }
 
 // Flush removes all keywords from the automaton.
@@ -322,7 +365,7 @@ func (ac *redisBackedAC) Flush(ctx context.Context) error {
 
 	ac.mu.Lock()
 	ac.keywordSet = make(map[string]struct{})
-	ac.engine.Build(ac.keywordSet)
+	ac.engine = buildEngine(ac.preset, ac.keywordSet)
 	ac.stale = false
 	ac.mu.Unlock()
 

--- a/pkg/acor/redis_backed_ops.go
+++ b/pkg/acor/redis_backed_ops.go
@@ -165,14 +165,20 @@ func (ac *redisBackedAC) applyLocalWrite(keyword string, add bool, newVersion in
 	ac.mu.Unlock()
 }
 
-// commitBatch rebuilds the local engine once from the current keyword set and
-// publishes a single invalidation, collapsing the rebuild/publish that
-// addDeferred/removeDeferred skipped during a batch.
+// commitBatch refreshes the local engine once and publishes a single
+// invalidation, collapsing the rebuild/publish that addDeferred/removeDeferred
+// skipped during a batch.
+//
+// It reloads from Redis (the source of truth) rather than rebuilding from the
+// local keyword set: that set is only incrementally maintained, so it can miss a
+// keyword another node wrote concurrently, and a remote invalidation received
+// during the batch must not be silently cleared by setting stale=false against a
+// stale local view. On reload failure the deferred writes left the engine stale,
+// so the next Find retries the reload.
 func (ac *redisBackedAC) commitBatch(ctx context.Context) {
-	ac.mu.Lock()
-	ac.engine = buildEngine(ac.preset, ac.keywordSet)
-	ac.stale = false
-	ac.mu.Unlock()
+	if err := ac.reloadFromRedis(ctx); err != nil {
+		ac.markStale()
+	}
 	ac.publishInvalidate(ctx)
 }
 

--- a/pkg/acor/v1_ops.go
+++ b/pkg/acor/v1_ops.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	redis "github.com/redis/go-redis/v9"
+
+	matchengine "github.com/skyoo2003/acor/internal/engine"
 )
 
 // Compile-time check that v1Operations satisfies the operations interface.
@@ -225,6 +227,24 @@ func (o *v1Operations) findIndex(ctx context.Context, text string) (map[string][
 	o.logger.Println(fmt.Sprintf("FindIndex(%s) > Matched(%v) : Count(%d)", text, matched, len(matched)))
 
 	return matched, nil
+}
+
+// loadEngine builds a fresh in-memory automaton from the V1 keyword set. V1
+// stores keywords already normalized (lowercased when !caseSensitive), so no
+// re-normalization is needed here. Unlike V2 there is no cache, so this is an
+// O(keywords) build per call — acceptable for the legacy schema.
+func (o *v1Operations) loadEngine(ctx context.Context) (*matchengine.Engine, error) {
+	kws, err := o.storage.SMembers(ctx, keywordKey(o.name))
+	if err != nil {
+		return nil, newRedisError("SMEMBERS", keywordKey(o.name), err)
+	}
+	set := make(map[string]struct{}, len(kws))
+	for _, k := range kws {
+		set[k] = struct{}{}
+	}
+	e := matchengine.New(PresetBalanced)
+	e.Build(set)
+	return e, nil
 }
 
 func (o *v1Operations) flush(_ context.Context) error {

--- a/pkg/acor/v2_cache_test.go
+++ b/pkg/acor/v2_cache_test.go
@@ -35,9 +35,9 @@ func TestV2GetOrLoadEngineNoCache(t *testing.T) {
 		"he": `["he"]`,
 	})
 
-	engine, err := ops.getOrLoadEngine(context.Background())
+	engine, err := ops.loadEngine(context.Background())
 	if err != nil {
-		t.Fatalf("getOrLoadEngine() error: %v", err)
+		t.Fatalf("loadEngine() error: %v", err)
 	}
 	if got := engine.Find("she"); len(got) != 1 || got[0] != "he" {
 		t.Errorf("engine.find(\"she\") = %v, want [he]", got)
@@ -179,18 +179,18 @@ func TestV2GetOrLoadEngineDoubleCheck(t *testing.T) {
 		logger:  &testLogger{},
 	}
 
-	engine, err := ops.getOrLoadEngine(context.Background())
+	engine, err := ops.loadEngine(context.Background())
 	if err != nil {
-		t.Fatalf("getOrLoadEngine() error: %v", err)
+		t.Fatalf("loadEngine() error: %v", err)
 	}
 	if got := engine.Find("he"); len(got) != 1 || got[0] != "he" {
 		t.Errorf("engine.find(\"he\") = %v, want [he]", got)
 	}
 
 	// Second call must be a cache hit returning the same engine instance.
-	engine2, err := ops.getOrLoadEngine(context.Background())
+	engine2, err := ops.loadEngine(context.Background())
 	if err != nil {
-		t.Fatalf("second getOrLoadEngine() error: %v", err)
+		t.Fatalf("second loadEngine() error: %v", err)
 	}
 	if engine2 != engine {
 		t.Errorf("second call rebuilt the engine; want cached instance")

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -327,6 +327,11 @@ func (o *v2Operations) getOrLoadEngine(ctx context.Context) (*matchengine.Engine
 	return engine, nil
 }
 
+// loadEngine returns the cached (or per-call throwaway) match engine snapshot.
+func (o *v2Operations) loadEngine(ctx context.Context) (*matchengine.Engine, error) {
+	return o.getOrLoadEngine(ctx)
+}
+
 // --- publishInvalidate ---
 
 // publishInvalidate invalidates the local cache and publishes an invalidation

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -55,7 +55,7 @@ func (o *v2Operations) find(ctx context.Context, text string) ([]string, error) 
 		text = strings.ToLower(text)
 	}
 
-	engine, err := o.getOrLoadEngine(ctx)
+	engine, err := o.loadEngine(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (o *v2Operations) findIndex(ctx context.Context, text string) (map[string][
 		text = strings.ToLower(text)
 	}
 
-	engine, err := o.getOrLoadEngine(ctx)
+	engine, err := o.loadEngine(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -290,15 +290,15 @@ func (o *v2Operations) loadCache(ctx context.Context) error {
 	return nil
 }
 
-// getOrLoadEngine returns the locally cached Aho-Corasick match engine, loading
-// it from storage on a cache miss. The engine is built once per cache load
-// (see trieCache.set) and reused across Find calls with no Redis I/O.
+// loadEngine returns the locally cached Aho-Corasick match engine, loading it
+// from storage on a cache miss. The engine is built once per cache load (see
+// trieCache.set) and reused across Find calls with no Redis I/O.
 //
 // When caching is disabled (cache == nil) it fetches the trie from Redis and
 // builds a throwaway engine per call. Redis I/O dominates that path, so the
 // extra automaton build is negligible; enabling the cache is the way to avoid
 // both, not per-call engine caching.
-func (o *v2Operations) getOrLoadEngine(ctx context.Context) (*matchengine.Engine, error) {
+func (o *v2Operations) loadEngine(ctx context.Context) (*matchengine.Engine, error) {
 	if o.cache == nil {
 		_, outputs, err := o.fetchTrieData(ctx)
 		if err != nil {
@@ -325,11 +325,6 @@ func (o *v2Operations) getOrLoadEngine(ctx context.Context) (*matchengine.Engine
 
 	engine, _ := o.cache.getEngine()
 	return engine, nil
-}
-
-// loadEngine returns the cached (or per-call throwaway) match engine snapshot.
-func (o *v2Operations) loadEngine(ctx context.Context) (*matchengine.Engine, error) {
-	return o.getOrLoadEngine(ctx)
 }
 
 // --- publishInvalidate ---


### PR DESCRIPTION
# Pull Request

## Description

Advances the Aho-Corasick pattern-matching feature: new match APIs, preset-mode
bulk-write performance, and cross-node invalidation robustness. All new matching
is built on a single engine `matchStream` primitive, so results stay identical to
`Find`/`FindIndex` across every backend mode (Preset, V2 cached/uncached, V1).

### New match APIs

- **`FindMatches(text, *MatchOptions) ([]Match, error)`** — matches in scan order,
  each a `{Keyword, Start, End}` rune-offset span. Unlike `FindIndex` (which groups
  start offsets by keyword and loses order + end positions), this preserves both —
  useful for highlighting and replacement.
- **`MatchKind`** — `MatchKindOverlapping` (default, classic AC) or
  `MatchKindLeftmostLongest` (non-overlapping, greedy) for tokenization / redaction.
- **`WholeWord`** — drops matches whose neighboring runes are word characters
  (letters, digits, combining marks, underscore), e.g. `class` inside `classic`.
- **`WordRune`** — override the word-rune predicate so `WholeWord` works for scripts
  the default misclassifies (e.g. treat CJK ideographs as non-word).
- **`Contains(text) (bool, error)`** — early-exit gate ("any banned word?"),
  cheaper than `len(Find()) > 0`.
- **`FindStream(io.Reader, func(Match) bool) error`** — scan a reader without
  buffering the whole input; stream-global rune offsets, return `false` to stop
  early. Also avoids the `FindParallel` chunk-boundary miss for keywords longer
  than the chunk overlap.
- `*Context` variants for each.

The Redis-backed engine now swaps in a fresh automaton on each rebuild instead of
mutating in place, so match snapshots are immutable and can be scanned lock-free
(this is what makes long-running streaming safe).

### Performance — batch rebuild coalescing (Preset mode)

`Add`/`Remove` rebuilt the entire local automaton per call, so `AddMany`/`RemoveMany`
of N keywords did N full rebuilds (O(N²) bulk-load) and N Pub/Sub publishes. Batch
writes now defer the local rebuild + publish and commit once at the end — O(N), one
invalidation per batch. V1/V2 are unaffected via an optional `batchWriter` interface
with automatic fallback. Transactional rollback is coalesced the same way.

### Robustness — cross-node invalidation

- Cross-instance invalidation is best-effort Redis Pub/Sub (no delivery guarantee).
  New opt-in **`AhoCorasickArgs.InvalidationPollInterval`** runs a background version
  poll for the Preset engine: it reloads when the collection's stored version differs
  from the local one, bounding staleness from a dropped invalidation to one interval.
  Disabled by default (`0`); recommended for multi-instance deployments.
- `commitBatch` reloads from Redis (source of truth) instead of rebuilding from the
  local keyword set, so a remote write during a batch is no longer missed and a
  concurrent invalidation is not silently cleared.
- The invalidation publish retries a few times on transient failure.

### Correctness / cleanup fixes (self-review + code-review)

- No-op `RemoveMany` no longer fires a cluster-wide commit/reload storm; only
  actually-present keywords count as removed (see behavior note below).
- `WholeWord` treats combining marks as word runes (fixes a false positive on
  decomposed/NFD text like `cafe` inside `café`).
- `FindStream` uses `errors.Is(e, io.EOF)`, so a wrapped `io.EOF` is normal
  completion, not a scan error.
- Guard the whole-word `[]rune` allocation on the zero-match happy path.
- Extract `batchAddFns`/`batchRemoveFns`, removing copy-pasted batch prelude/commit
  from the four AddMany/RemoveMany variants.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (redis-backed engine pointer-swap, batch coalescing, helper extraction)

## Checklist

- [x] Tests pass (`make test`) — root + server, plus `-race`; CI green across the
      1.25/1.26 × ubuntu/macos matrix and redis + valkey integration
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`) — CI golangci-lint (v2.11.3) is green
- [x] Build succeeds (`make build`)
- [ ] Documentation updated if needed — godoc added for all new exported symbols;
      README/guide prose can follow up
- [x] Changelog fragment added (`changie new`) — 2 × `Added`, 1 × `Changed` (#158)
- [x] Commit messages follow guidelines (Conventional Commits)

## Additional Notes

- **Behavior note:** `RemoveMany` now reports keywords that were not present in
  `BatchResult.Skipped` instead of `Removed`, matching `AddMany` and single `Remove`
  (`Remove` returns 0 for an absent keyword). Callers that treated every input as
  "removed" should read `Removed` as *actually removed*.
- Match offsets are rune-based, half-open `[Start, End)`, consistent with `FindIndex`.
- Streaming intentionally applies neither `WholeWord` nor `LeftmostLongest` (both need
  buffering that defeats streaming); use `FindMatches` on a bounded string for those.
- `InvalidationPollInterval` is opt-in (default off) to avoid changing default runtime
  behavior; can be defaulted-on later if desired.
- Deliberately out of scope: batching the per-keyword Redis snapshot-read + Lua write
  (the N-RTT cost, separate from the local-rebuild cost fixed here); true incremental
  automaton update; regex / wildcard / fuzzy matching; full CJK word segmentation.

New tests cover: engine `matchStream`/`FindMatches`/`Contains` vs. brute force across
all presets; overlapping / leftmost-longest / whole-word / combining-mark / custom
`WordRune` / streaming (incl. boundary-loss and wrapped-EOF); batch-coalescing proof
(one invalidation per batch, none on no-op); and the version-poll safety net.
