### PR TITLE
fix: robustness fixes for parallel matching, coder, and dead errors

### DIFF
--- a/changes/unreleased/Documentation-20260724-212644.yaml
+++ b/changes/unreleased/Documentation-20260724-212644.yaml
@@ -1,0 +1,5 @@
+kind: Documentation
+body: Documented on FindParallel and FindIndexParallel that a keyword longer than opts.Overlap straddling a chunk boundary can be missed, and to set Overlap to at least the longest expected keyword length.
+time: 2026-07-24T21:26:44.278338+09:00
+custom:
+    Issue: "159"

--- a/changes/unreleased/Fixed-20260724-212644.yaml
+++ b/changes/unreleased/Fixed-20260724-212644.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: The internal match engine no longer panics on an invalid (negative) rune supplied to Engine.Stream; such runes are treated as not in the alphabet, matching any other out-of-alphabet character.
+time: 2026-07-24T21:26:44.266844+09:00
+custom:
+    Issue: "159"

--- a/changes/unreleased/Fixed-20260724-212702.yaml
+++ b/changes/unreleased/Fixed-20260724-212702.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: FindParallel/FindIndexParallel now clamp a negative ParallelOptions.Overlap to 0. A negative overlap previously pushed each chunk's start past the previous boundary, dropping the runes in between and silently losing any match there.
+time: 2026-07-24T21:27:02.887904+09:00
+custom:
+    Issue: "159"

--- a/changes/unreleased/Fixed-20260724-212703.yaml
+++ b/changes/unreleased/Fixed-20260724-212703.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: FindParallel now returns a deduplicated result set regardless of text size. The single-chunk fast path previously returned Find's per-occurrence multiplicity, contradicting the documented dedup contract that the multi-chunk path already followed.
+time: 2026-07-24T21:27:03.915714+09:00
+custom:
+    Issue: "159"

--- a/changes/unreleased/Removed-20260724-212644.yaml
+++ b/changes/unreleased/Removed-20260724-212644.yaml
@@ -1,0 +1,5 @@
+kind: Removed
+body: Removed the unused exported errors ErrNoBoundariesFound and ErrStreamInterrupted, which were declared but never returned by any operation.
+time: 2026-07-24T21:26:44.272496+09:00
+custom:
+    Issue: "159"

--- a/internal/engine/coder.go
+++ b/internal/engine/coder.go
@@ -31,7 +31,10 @@ func (c *alphabetCoder) build(runes []rune) {
 // code resolves a rune to its alphabet index via the ASCII fast path, falling
 // back to the map for non-ASCII runes. ok is false if ch is not in the alphabet.
 func (c *alphabetCoder) code(ch rune) (int, bool) {
-	if ch < utf8.RuneSelf {
+	// ch >= 0 guards the ASCII fast path: a negative rune (e.g. an invalid rune
+	// from a caller-supplied Engine.Stream source) also passes ch < RuneSelf and
+	// would index asciiCode out of bounds. Treat it as not in the alphabet.
+	if ch >= 0 && ch < utf8.RuneSelf {
 		x := c.asciiCode[ch]
 		return int(x) - 1, x != 0
 	}

--- a/internal/engine/coder_test.go
+++ b/internal/engine/coder_test.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package engine
+
+import "testing"
+
+// A negative rune (an invalid rune reachable via a caller-supplied Engine.Stream
+// source) also passes the ch < utf8.RuneSelf ASCII fast-path test and used to
+// index asciiCode out of bounds. It must instead be reported as not in the
+// alphabet, without panicking.
+func TestAlphabetCoderNegativeRune(t *testing.T) {
+	var c alphabetCoder
+	c.build([]rune{'a', 'b', 'c'})
+
+	if idx, ok := c.code(-1); ok {
+		t.Errorf("code(-1) = (%d, true); want not-in-alphabet", idx)
+	}
+	if _, ok := c.code('a'); !ok {
+		t.Error("code('a') should be in alphabet")
+	}
+	if _, ok := c.code('z'); ok {
+		t.Error("code('z') should not be in alphabet")
+	}
+}

--- a/pkg/acor/errors.go
+++ b/pkg/acor/errors.go
@@ -12,12 +12,6 @@ var (
 	ErrEmptyKeyword = errors.New("keyword cannot be empty")
 	// ErrInvalidChunkSize is returned when ParallelOptions.ChunkSize is <= 0.
 	ErrInvalidChunkSize = errors.New("chunk size must be positive")
-	// ErrNoBoundariesFound is returned when parallel processing cannot find
-	// suitable chunk boundaries in the text.
-	ErrNoBoundariesFound = errors.New("could not find suitable chunk boundaries")
-	// ErrStreamInterrupted is returned when stream processing is interrupted
-	// before completion.
-	ErrStreamInterrupted = errors.New("stream processing was interrupted")
 	// ErrCacheRequiresV2 is returned when cache is enabled with V1 schema.
 	// Cache functionality requires V2 schema for Pub/Sub invalidation support.
 	ErrCacheRequiresV2 = errors.New("local cache requires V2 schema")

--- a/pkg/acor/parallel.go
+++ b/pkg/acor/parallel.go
@@ -92,7 +92,27 @@ func normalizeParallelOptions(opts *ParallelOptions) *ParallelOptions {
 	if opts.Workers <= 0 {
 		opts.Workers = runtime.NumCPU()
 	}
+	if opts.Overlap < 0 {
+		// A negative overlap would push the next chunk's start past the current
+		// boundary, dropping the runes in between and silently losing any match
+		// there. Clamp to 0 (no overlap) rather than error, matching how Workers
+		// is corrected above.
+		opts.Overlap = 0
+	}
 	return opts
+}
+
+// dedupPreservingOrder returns in with duplicates removed, keeping first-seen order.
+func dedupPreservingOrder(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 //nolint:gocritic // Returns channels for concurrent result collection
@@ -140,7 +160,9 @@ func runStringWorkersCtx(ctx context.Context, ac *AhoCorasick, chunks []chunk, w
 	return results, errors
 }
 
-// collectOrderedStringResults collects matches preserving chunk order and multiplicity.
+// collectOrderedStringResults collects matches preserving chunk order and
+// deduplicating across chunks (a keyword appears at most once), matching the
+// FindParallel contract.
 func collectOrderedStringResults(results <-chan indexedStringResult, errors <-chan error) ([]string, error) {
 	var allChunkResults []indexedStringResult
 	var firstErr error
@@ -170,18 +192,12 @@ func collectOrderedStringResults(results <-chan indexedStringResult, errors <-ch
 		return allChunkResults[i].chunkIndex < allChunkResults[j].chunkIndex
 	})
 
-	seen := make(map[string]struct{})
 	var allMatches []string
 	for _, r := range allChunkResults {
-		for _, m := range r.matches {
-			if _, ok := seen[m]; !ok {
-				seen[m] = struct{}{}
-				allMatches = append(allMatches, m)
-			}
-		}
+		allMatches = append(allMatches, r.matches...)
 	}
 
-	return allMatches, firstErr
+	return dedupPreservingOrder(allMatches), firstErr
 }
 
 // FindParallel searches for keywords in text using parallel processing.
@@ -192,7 +208,14 @@ func collectOrderedStringResults(results <-chan indexedStringResult, errors <-ch
 // within a single chunk, this method delegates to Find without parallelization.
 //
 // Note: Due to chunk overlap for boundary handling, duplicate matches are
-// automatically deduplicated in the returned slice.
+// automatically deduplicated in the returned slice, so each keyword appears at
+// most once regardless of how many times or in how many chunks it occurs. (Find
+// reports every occurrence; FindParallel reports a set.)
+//
+// Limitation: a keyword longer than opts.Overlap that straddles a chunk boundary
+// can be missed, since it fits in no single chunk. Set Overlap to at least your
+// longest expected keyword length, or use FindStream (which never splits a match)
+// when this matters.
 //
 // Example:
 //
@@ -213,7 +236,13 @@ func (ac *AhoCorasick) FindParallel(text string, opts *ParallelOptions) ([]strin
 		return []string{}, nil
 	}
 	if len(chunks) == 1 {
-		return ac.Find(text)
+		// Match the multi-chunk contract: dedup so the result set doesn't depend
+		// on whether the text fit in one chunk.
+		matches, err := ac.Find(text)
+		if err != nil {
+			return nil, err
+		}
+		return dedupPreservingOrder(matches), nil
 	}
 
 	results, errors := runStringWorkers(ac, chunks, opts.Workers)
@@ -323,6 +352,10 @@ func collectIndexResults(results <-chan indexedResult, errors <-chan error) (map
 // The returned map has keywords as keys and sorted slices of unique start indices.
 // Due to chunk overlap, matches at chunk boundaries may have duplicate indices
 // that are automatically deduplicated.
+//
+// Limitation: like FindParallel, a keyword longer than opts.Overlap that straddles
+// a chunk boundary can be missed. Set Overlap to at least your longest expected
+// keyword length.
 //
 // Example:
 //

--- a/pkg/acor/parallel_test.go
+++ b/pkg/acor/parallel_test.go
@@ -166,6 +166,87 @@ func TestBatchAddAndParallelFind(t *testing.T) {
 	}
 }
 
+func stringSet(in []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(in))
+	for _, s := range in {
+		m[s] = struct{}{}
+	}
+	return m
+}
+
+// A negative Overlap used to push each chunk's start past the previous boundary,
+// dropping the runes in the gap and silently losing matches there. It must now be
+// clamped to 0, so the result set matches a plain Find (no whole-word keyword,
+// which cannot straddle a word boundary, is lost).
+func TestFindParallelNegativeOverlapNoDrop(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer func() { _ = ac.Close() }()
+	defer func() { _ = ac.Flush() }()
+
+	keywords := []string{"apple", "banana", "cherry", "date"}
+	for _, k := range keywords {
+		if _, err := ac.Add(k); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	text := "apple banana cherry date apple banana cherry date apple"
+	opts := &ParallelOptions{
+		Workers:   2,
+		ChunkSize: 10,
+		Boundary:  ChunkBoundaryWord,
+		Overlap:   -10,
+	}
+
+	got, err := ac.FindParallel(text, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := ac.Find(text)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if g, w := stringSet(got), stringSet(want); !reflect.DeepEqual(g, w) {
+		t.Errorf("negative overlap dropped matches: got %v, want %v", g, w)
+	}
+}
+
+// FindParallel deduplicates its result set, so the same text must return the same
+// set whether it fits in one chunk (fast path) or spans several. Previously the
+// single-chunk path returned Find's per-occurrence multiplicity, contradicting the
+// documented contract.
+func TestFindParallelDedupConsistentAcrossChunkSizes(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer func() { _ = ac.Close() }()
+	defer func() { _ = ac.Flush() }()
+
+	for _, k := range []string{"test", "run"} {
+		if _, err := ac.Add(k); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	text := "test run test run test" // repeated keywords
+
+	single, err := ac.FindParallel(text, &ParallelOptions{ChunkSize: 1000, Boundary: ChunkBoundaryWord})
+	if err != nil {
+		t.Fatal(err)
+	}
+	multi, err := ac.FindParallel(text, &ParallelOptions{ChunkSize: 8, Boundary: ChunkBoundaryWord, Overlap: 4})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(single) != len(stringSet(single)) {
+		t.Errorf("single-chunk path returned duplicates: %v", single)
+	}
+	if !reflect.DeepEqual(stringSet(single), stringSet(multi)) {
+		t.Errorf("single-chunk %v != multi-chunk %v", single, multi)
+	}
+}
+
 func TestFindIndexParallel(t *testing.T) {
 	ac, mr := createAhoCorasick(t)
 	defer mr.Close()


### PR DESCRIPTION
# Pull Request

## Description

`acor` is already a mature, robust library. This PR is a focused set of **root-cause fixes** for latent bugs and misleading API surfaced by a robustness audit — not a rework.

- **Negative `ParallelOptions.Overlap` silently dropped matches.** A negative overlap made each chunk's start jump *past* the previous boundary (`nextStart := boundary - opts.Overlap`), so runes in the gap landed in no chunk. Now clamped to `0` in `normalizeParallelOptions`, covering both `FindParallel` and `FindIndexParallel` from one guard.
- **`FindParallel` result multiplicity depended on text size.** The multi-chunk path deduplicates (the documented contract), but the single-chunk fast path returned `Find`'s per-occurrence results. Both paths now dedup via a shared `dedupPreservingOrder`; the contradictory internal comment is fixed.
- **`alphabetCoder.code` panicked on a negative rune.** A negative rune passed the `ch < utf8.RuneSelf` ASCII fast-path test and indexed `asciiCode` out of bounds — reachable via a caller-supplied `Engine.Stream` source. Guarded with `ch >= 0`.
- **Removed dead exported errors** `ErrNoBoundariesFound` and `ErrStreamInterrupted` (declared but never returned by any operation).
- **Docs:** `FindParallel`/`FindIndexParallel` now document that a keyword longer than `Overlap` straddling a chunk boundary can be missed.

Out of scope (deliberately, YAGNI): input-size caps and goroutine panic isolation — only relevant for untrusted-input deployments.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

<!-- Breaking: removes exported ErrNoBoundariesFound/ErrStreamInterrupted, and FindParallel's single-chunk path now returns a deduplicated set (was per-occurrence). Pre-1.0. -->

## Checklist

- [x] Tests pass (`make test`) — full suite green with `-race`
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`) — changed files are lint-clean; `make lint` locally reports only pre-existing `goconst` debt in unrelated files (schema.go, v2_ops.go, v2_transaction.go, …). CI golangci v2.11.3 is the gate.
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) — 3× Fixed, 1× Removed, 1× Documentation
- [x] Commit messages follow guidelines