### PR TITLE
chore: extract goconst constants, loosen config, pin golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,8 +34,8 @@ linters:
       lines: 100
       statements: 50
     goconst:
-      min-len: 2
-      min-occurrences: 2
+      min-len: 3
+      min-occurrences: 3
     gocritic:
       disabled-checks:
         - dupImport

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 .PHONY: all setup clean build test lint lint-fix coverage vet fuzz race docs-verify proto
 
+# Pin golangci-lint so local `make lint` matches CI (see .github/workflows/ci.yaml).
+# Run via `go run` so the installed binary's version can't drift from CI.
+GOLANGCI_LINT_VERSION ?= v2.11.3
+GOLANGCI_LINT ?= go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+
 all: vet lint test build docs-verify
 
 setup:
@@ -27,8 +32,8 @@ proto:
 		server/proto/acor/v1/acor.proto
 
 lint:
-	@golangci-lint run ./...
-	@cd server && golangci-lint run ./...
+	@$(GOLANGCI_LINT) run ./...
+	@cd server && $(GOLANGCI_LINT) run ./...
 
 coverage:
 	@go test ./... -coverpkg=./... -coverprofile=coverage.out -covermode=atomic
@@ -40,8 +45,8 @@ vet:
 	@cd server && go vet ./...
 
 lint-fix:
-	@golangci-lint run --fix ./...
-	@cd server && golangci-lint run --fix ./...
+	@$(GOLANGCI_LINT) run --fix ./...
+	@cd server && $(GOLANGCI_LINT) run --fix ./...
 
 fuzz:
 	@go test -fuzz=FuzzFind -fuzztime=30s ./pkg/acor

--- a/changes/unreleased/Changed-20260724-231757.yaml
+++ b/changes/unreleased/Changed-20260724-231757.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: Pinned golangci-lint to the CI version via `go run` in the Makefile and relaxed the `goconst` config to upstream defaults, so local `make lint` no longer diverges from CI. Repeated string literals (Redis field names, CLI commands, JSON keys) were extracted into named constants — no functional changes.
+time: 2026-07-24T23:17:57.819714+09:00
+custom:
+    Issue: "160"

--- a/cmd/acor/main.go
+++ b/cmd/acor/main.go
@@ -61,6 +61,26 @@ Migrate options:
 `
 )
 
+const (
+	commandAdd             = "add"
+	commandRemove          = "remove"
+	commandFind            = "find"
+	commandFindIndex       = "find-index"
+	commandSuggest         = "suggest"
+	commandSuggestIndex    = "suggest-index"
+	commandInfo            = "info"
+	commandFlush           = "flush"
+	commandMigrate         = "migrate"
+	commandMigrateRollback = "migrate-rollback"
+	commandSchemaVersion   = "schema-version"
+
+	defaultCollectionName = "default"
+
+	jsonKeyCount   = "count"
+	jsonKeyMatches = "matches"
+	jsonKeyStatus  = "status"
+)
+
 type service interface {
 	Add(string) (int, error)
 	Remove(string) (int, error)
@@ -155,7 +175,7 @@ func parseArgs(args []string) (*acor.AhoCorasickArgs, *migrateOptions, []string,
 	fs.StringVar(&config.ringAddrs, "ring-addrs", "", "comma-separated shard=addr pairs")
 	fs.StringVar(&config.password, "password", "", "redis password")
 	fs.IntVar(&config.db, "db", 0, "redis db number")
-	fs.StringVar(&config.name, "name", "default", "pattern collection name")
+	fs.StringVar(&config.name, "name", defaultCollectionName, "pattern collection name")
 	fs.BoolVar(&config.debug, "debug", false, "enable debug logging")
 	fs.BoolVar(&config.dryRun, "dry-run", false, "preview migration without making changes")
 	fs.BoolVar(&config.keepOldKeys, "keep-old-keys", false, "keep V1 keys after migration")
@@ -170,7 +190,7 @@ func parseArgs(args []string) (*acor.AhoCorasickArgs, *migrateOptions, []string,
 
 	config.name = strings.TrimSpace(config.name)
 	if config.name == "" {
-		config.name = "default"
+		config.name = defaultCollectionName
 	}
 
 	ringAddrs, err := parseRingAddrs(config.ringAddrs)
@@ -245,27 +265,27 @@ func parseRingAddrs(raw string) (map[string]string, error) {
 
 func commandHandler(command string) (commandRunner, bool, error) {
 	switch command {
-	case "add":
+	case commandAdd:
 		return runAdd, true, nil
-	case "remove":
+	case commandRemove:
 		return runRemove, true, nil
-	case "find":
+	case commandFind:
 		return runFind, true, nil
-	case "find-index":
+	case commandFindIndex:
 		return runFindIndex, true, nil
-	case "suggest":
+	case commandSuggest:
 		return runSuggest, true, nil
-	case "suggest-index":
+	case commandSuggestIndex:
 		return runSuggestIndex, true, nil
-	case "info":
+	case commandInfo:
 		return runInfo, false, nil
-	case "flush":
+	case commandFlush:
 		return runFlush, false, nil
-	case "migrate":
+	case commandMigrate:
 		return runMigrate, false, nil
-	case "migrate-rollback":
+	case commandMigrateRollback:
 		return runMigrateRollback, false, nil
-	case "schema-version":
+	case commandSchemaVersion:
 		return runSchemaVersion, false, nil
 	default:
 		return nil, false, fmt.Errorf("unknown command %q", command)
@@ -295,7 +315,7 @@ func runAdd(stdout io.Writer, ac service, input string, _ *migrateOptions) error
 	if err != nil {
 		return err
 	}
-	return writeJSON(stdout, map[string]int{"count": count})
+	return writeJSON(stdout, map[string]int{jsonKeyCount: count})
 }
 
 func runRemove(stdout io.Writer, ac service, input string, _ *migrateOptions) error {
@@ -303,7 +323,7 @@ func runRemove(stdout io.Writer, ac service, input string, _ *migrateOptions) er
 	if err != nil {
 		return err
 	}
-	return writeJSON(stdout, map[string]int{"count": count})
+	return writeJSON(stdout, map[string]int{jsonKeyCount: count})
 }
 
 func runFind(stdout io.Writer, ac service, input string, _ *migrateOptions) error {
@@ -311,7 +331,7 @@ func runFind(stdout io.Writer, ac service, input string, _ *migrateOptions) erro
 	if err != nil {
 		return err
 	}
-	return writeJSON(stdout, map[string][]string{"matches": matches})
+	return writeJSON(stdout, map[string][]string{jsonKeyMatches: matches})
 }
 
 func runFindIndex(stdout io.Writer, ac service, input string, _ *migrateOptions) error {
@@ -319,7 +339,7 @@ func runFindIndex(stdout io.Writer, ac service, input string, _ *migrateOptions)
 	if err != nil {
 		return err
 	}
-	return writeJSON(stdout, map[string]map[string][]int{"matches": matches})
+	return writeJSON(stdout, map[string]map[string][]int{jsonKeyMatches: matches})
 }
 
 func runSuggest(stdout io.Writer, ac service, input string, _ *migrateOptions) error {
@@ -327,7 +347,7 @@ func runSuggest(stdout io.Writer, ac service, input string, _ *migrateOptions) e
 	if err != nil {
 		return err
 	}
-	return writeJSON(stdout, map[string][]string{"matches": matches})
+	return writeJSON(stdout, map[string][]string{jsonKeyMatches: matches})
 }
 
 func runSuggestIndex(stdout io.Writer, ac service, input string, _ *migrateOptions) error {
@@ -335,7 +355,7 @@ func runSuggestIndex(stdout io.Writer, ac service, input string, _ *migrateOptio
 	if err != nil {
 		return err
 	}
-	return writeJSON(stdout, map[string]map[string][]int{"matches": matches})
+	return writeJSON(stdout, map[string]map[string][]int{jsonKeyMatches: matches})
 }
 
 func runInfo(stdout io.Writer, ac service, _ string, _ *migrateOptions) error {
@@ -353,7 +373,7 @@ func runFlush(stdout io.Writer, ac service, _ string, _ *migrateOptions) error {
 	if err := ac.Flush(); err != nil {
 		return err
 	}
-	return writeJSON(stdout, map[string]string{"status": "ok"})
+	return writeJSON(stdout, map[string]string{jsonKeyStatus: "ok"})
 }
 
 func runMigrate(stdout io.Writer, ac service, _ string, opts *migrateOptions) error {
@@ -371,7 +391,7 @@ func runMigrateRollback(stdout io.Writer, ac service, _ string, _ *migrateOption
 	if err := ac.RollbackToV1(); err != nil {
 		return err
 	}
-	return writeJSON(stdout, map[string]string{"status": "rolled_back"})
+	return writeJSON(stdout, map[string]string{jsonKeyStatus: "rolled_back"})
 }
 
 func runSchemaVersion(stdout io.Writer, ac service, _ string, _ *migrateOptions) error {

--- a/cmd/acor/main_test.go
+++ b/cmd/acor/main_test.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	collectionNameSample = "sample"
-	commandFind          = "find"
 	testKeywordHello     = "hello"
 	testKeywordHE        = "he"
 )

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -491,12 +491,7 @@ func (ac *AhoCorasick) init() error {
 			return fmt.Errorf("failed to check trie key: %w", err)
 		}
 		if exists == 0 {
-			err := ac.storage.HSet(ac.ctx, trieKey(ac.name), map[string]interface{}{
-				"keywords": "[]",
-				"prefixes": "[\"\"]",
-				"suffixes": "[\"\"]",
-				"version":  time.Now().UnixNano(),
-			})
+			err := ac.storage.HSet(ac.ctx, trieKey(ac.name), emptyTrieFields())
 			if err != nil {
 				return fmt.Errorf("failed to initialize V2 trie: %w", err)
 			}

--- a/pkg/acor/keys.go
+++ b/pkg/acor/keys.go
@@ -2,7 +2,10 @@
 
 package acor
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // Key format constants define the Redis key patterns used by the V1 schema.
 // These constants use %s as a placeholder for the collection name.
@@ -18,6 +21,24 @@ const (
 	OutputKey = "%s:output"
 	// NodeKey is the format for node set keys: "{name}:node:{keyword}"
 	NodeKey = "%s:node"
+)
+
+// V2 trie-hash field names and the internal arg-map keys passed to the Lua
+// transaction helpers. Kept as constants so a typo can't silently break a
+// Redis read or write.
+const (
+	fieldKeywords = "keywords"
+	fieldPrefixes = "prefixes"
+	fieldSuffixes = "suffixes"
+	fieldVersion  = "version"
+
+	argTrieKey    = "trieKey"
+	argOutputsKey = "outputsKey"
+
+	// emptyKeywordsJSON and emptyStringArrayJSON are the default JSON values
+	// stored in an empty V2 trie hash.
+	emptyKeywordsJSON    = "[]"
+	emptyStringArrayJSON = `[""]`
 )
 
 func keyPrefix(name string) string {
@@ -54,4 +75,15 @@ func outputsKey(name string) string {
 
 func nodesKey(name string) string {
 	return fmt.Sprintf("%s:nodes", keyPrefix(name))
+}
+
+// emptyTrieFields returns the hash fields written to initialize an empty V2
+// trie. The version is stamped fresh on each call.
+func emptyTrieFields() map[string]interface{} {
+	return map[string]interface{}{
+		fieldKeywords: emptyKeywordsJSON,
+		fieldPrefixes: emptyStringArrayJSON,
+		fieldSuffixes: emptyStringArrayJSON,
+		fieldVersion:  time.Now().UnixNano(),
+	}
 }

--- a/pkg/acor/migration.go
+++ b/pkg/acor/migration.go
@@ -231,22 +231,22 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 	}
 
 	trieFields := map[string]interface{}{
-		"version": time.Now().UnixNano(),
+		fieldVersion: time.Now().UnixNano(),
 	}
 	if keywordsJSON, marshalErr := toJSON(keywords); marshalErr != nil {
 		return result, fmt.Errorf("migration: failed to marshal keywords: %w", marshalErr)
 	} else {
-		trieFields["keywords"] = keywordsJSON
+		trieFields[fieldKeywords] = keywordsJSON
 	}
 	if prefixesJSON, marshalErr := toJSON(prefixes); marshalErr != nil {
 		return result, fmt.Errorf("migration: failed to marshal prefixes: %w", marshalErr)
 	} else {
-		trieFields["prefixes"] = prefixesJSON
+		trieFields[fieldPrefixes] = prefixesJSON
 	}
 	if suffixesJSON, marshalErr := toJSON(suffixes); marshalErr != nil {
 		return result, fmt.Errorf("migration: failed to marshal suffixes: %w", marshalErr)
 	} else {
-		trieFields["suffixes"] = suffixesJSON
+		trieFields[fieldSuffixes] = suffixesJSON
 	}
 	if hsetErr := ac.redisClient.HSet(ac.ctx, tempTrieKey, trieFields).Err(); hsetErr != nil {
 		cleanup()

--- a/pkg/acor/redis_backed.go
+++ b/pkg/acor/redis_backed.go
@@ -134,12 +134,7 @@ func (ac *redisBackedAC) initTrie(ctx context.Context) error {
 		return fmt.Errorf("check trie key: %w", err)
 	}
 	if exists == 0 {
-		err := ac.storage.HSet(ctx, trieKey(ac.name), map[string]interface{}{
-			"keywords": "[]",
-			"prefixes": "[\"\"]",
-			"suffixes": "[\"\"]",
-			"version":  time.Now().UnixNano(),
-		})
+		err := ac.storage.HSet(ctx, trieKey(ac.name), emptyTrieFields())
 		if err != nil {
 			return fmt.Errorf("initialize trie: %w", err)
 		}
@@ -388,9 +383,9 @@ func (rb *redisBackedV2) runAddScript(ctx context.Context, args map[string]inter
 		return 0, err
 	}
 	cmd := addV2Script.Run(ctx, rb.client,
-		[]string{args["trieKey"].(string), args["outputsKey"].(string)},
-		args["oldVersion"], args["newVersion"], args["keywords"],
-		args["prefixes"], args["suffixes"], args["outputs"])
+		[]string{args[argTrieKey].(string), args[argOutputsKey].(string)},
+		args["oldVersion"], args["newVersion"], args[fieldKeywords],
+		args[fieldPrefixes], args[fieldSuffixes], args["outputs"])
 	return cmd.Int64()
 }
 
@@ -399,8 +394,8 @@ func (rb *redisBackedV2) runRemoveScript(ctx context.Context, args map[string]in
 		return 0, err
 	}
 	cmd := removeV2Script.Run(ctx, rb.client,
-		[]string{args["trieKey"].(string), args["outputsKey"].(string)},
-		args["oldVersion"], args["newVersion"], args["keywords"],
-		args["prefixes"], args["suffixes"], args["outputs"])
+		[]string{args[argTrieKey].(string), args[argOutputsKey].(string)},
+		args["oldVersion"], args["newVersion"], args[fieldKeywords],
+		args[fieldPrefixes], args[fieldSuffixes], args["outputs"])
 	return cmd.Int64()
 }

--- a/pkg/acor/redis_backed_ops.go
+++ b/pkg/acor/redis_backed_ops.go
@@ -129,8 +129,8 @@ func (ac *redisBackedAC) tryAdd(ctx context.Context, keyword string, v2 *redisBa
 	if marshalErr != nil {
 		return 0, marshalErr
 	}
-	args["trieKey"] = trieKey(ac.name)
-	args["outputsKey"] = outputsKey(ac.name)
+	args[argTrieKey] = trieKey(ac.name)
+	args[argOutputsKey] = outputsKey(ac.name)
 
 	val, err := v2.runAddScript(ctx, args)
 	if err != nil {
@@ -303,8 +303,8 @@ func (ac *redisBackedAC) tryRemove(ctx context.Context, keyword string, v2 *redi
 	if marshalErr != nil {
 		return 0, marshalErr
 	}
-	args["trieKey"] = trieKey(ac.name)
-	args["outputsKey"] = outputsKey(ac.name)
+	args[argTrieKey] = trieKey(ac.name)
+	args[argOutputsKey] = outputsKey(ac.name)
 
 	val, err := v2.runRemoveScript(ctx, args)
 	if err != nil {
@@ -355,12 +355,7 @@ func (ac *redisBackedAC) Flush(ctx context.Context) error {
 		if err := pipe.Del(ctx, oKey, nKey); err != nil {
 			return err
 		}
-		if err := pipe.HSet(ctx, tKey, map[string]interface{}{
-			"keywords": "[]",
-			"prefixes": "[\"\"]",
-			"suffixes": "[\"\"]",
-			"version":  time.Now().UnixNano(),
-		}); err != nil {
+		if err := pipe.HSet(ctx, tKey, emptyTrieFields()); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/acor/schema.go
+++ b/pkg/acor/schema.go
@@ -70,8 +70,8 @@ type MigrationResult struct {
 // Stats returns migration statistics as a map.
 func (r *MigrationResult) Stats() map[string]interface{} {
 	return map[string]interface{}{
-		"keywords":     r.Keywords,
-		"prefixes":     r.Prefixes,
+		fieldKeywords:  r.Keywords,
+		fieldPrefixes:  r.Prefixes,
 		"outputs_keys": r.OutputsKeys,
 		"nodes_keys":   r.NodesKeys,
 		"keys_before":  r.KeysBefore,

--- a/pkg/acor/v2_lua.go
+++ b/pkg/acor/v2_lua.go
@@ -68,11 +68,11 @@ var removeV2Script = redis.NewScript(`
 // for "trieKey" and "outputsKey". Returns an error if either key is missing
 // or not a string.
 func validateScriptArgs(args map[string]interface{}) error {
-	trieKey, ok := args["trieKey"].(string)
+	trieKey, ok := args[argTrieKey].(string)
 	if !ok || trieKey == "" {
 		return fmt.Errorf("validateScriptArgs: missing or invalid trieKey")
 	}
-	outputsKey, ok := args["outputsKey"].(string)
+	outputsKey, ok := args[argOutputsKey].(string)
 	if !ok || outputsKey == "" {
 		return fmt.Errorf("validateScriptArgs: missing or invalid outputsKey")
 	}
@@ -84,9 +84,9 @@ func (o *v2Operations) runAddV2Script(ctx context.Context, client redis.Universa
 		return nil, err
 	}
 	return addV2Script.Run(ctx, client,
-		[]string{args["trieKey"].(string), args["outputsKey"].(string)},
-		args["oldVersion"], args["newVersion"], args["keywords"],
-		args["prefixes"], args["suffixes"], args["outputs"]), nil
+		[]string{args[argTrieKey].(string), args[argOutputsKey].(string)},
+		args["oldVersion"], args["newVersion"], args[fieldKeywords],
+		args[fieldPrefixes], args[fieldSuffixes], args["outputs"]), nil
 }
 
 func (o *v2Operations) runRemoveV2Script(ctx context.Context, client redis.UniversalClient, args map[string]interface{}) (*redis.Cmd, error) {
@@ -94,7 +94,7 @@ func (o *v2Operations) runRemoveV2Script(ctx context.Context, client redis.Unive
 		return nil, err
 	}
 	return removeV2Script.Run(ctx, client,
-		[]string{args["trieKey"].(string), args["outputsKey"].(string)},
-		args["oldVersion"], args["newVersion"], args["keywords"],
-		args["prefixes"], args["suffixes"], args["outputs"]), nil
+		[]string{args[argTrieKey].(string), args[argOutputsKey].(string)},
+		args["oldVersion"], args["newVersion"], args[fieldKeywords],
+		args[fieldPrefixes], args[fieldSuffixes], args["outputs"]), nil
 }

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -160,12 +160,7 @@ func (o *v2Operations) flush(ctx context.Context) error {
 		if err := pipe.Del(ctx, oKey, nKey); err != nil {
 			return err
 		}
-		if err := pipe.HSet(ctx, tKey, map[string]interface{}{
-			"keywords": "[]",
-			"prefixes": "[\"\"]",
-			"suffixes": "[\"\"]",
-			"version":  time.Now().UnixNano(),
-		}); err != nil {
+		if err := pipe.HSet(ctx, tKey, emptyTrieFields()); err != nil {
 			return err
 		}
 		return nil
@@ -186,14 +181,14 @@ func (o *v2Operations) info(ctx context.Context) (*AhoCorasickInfo, error) {
 	}
 
 	var keywords []string
-	if data, ok := result["keywords"]; ok {
+	if data, ok := result[fieldKeywords]; ok {
 		if err := json.Unmarshal([]byte(data), &keywords); err != nil {
 			return nil, newOperationError("unmarshal", SchemaV2, err)
 		}
 	}
 
 	var prefixes []string
-	if data, ok := result["prefixes"]; ok {
+	if data, ok := result[fieldPrefixes]; ok {
 		if err := json.Unmarshal([]byte(data), &prefixes); err != nil {
 			return nil, newOperationError("unmarshal", SchemaV2, err)
 		}
@@ -220,7 +215,7 @@ func (o *v2Operations) suggest(ctx context.Context, input string) ([]string, err
 	}
 
 	var keywords []string
-	if data, ok := result["keywords"]; ok {
+	if data, ok := result[fieldKeywords]; ok {
 		if err := json.Unmarshal([]byte(data), &keywords); err != nil {
 			return nil, newOperationError("unmarshal", SchemaV2, err)
 		}
@@ -261,7 +256,7 @@ func (o *v2Operations) fetchTrieData(ctx context.Context) (prefixes []string, ou
 	}
 
 	trieData := trieResult.Val()
-	if data, ok := trieData["prefixes"]; ok {
+	if data, ok := trieData[fieldPrefixes]; ok {
 		if unmarshalErr := json.Unmarshal([]byte(data), &prefixes); unmarshalErr != nil {
 			return nil, nil, newOperationError("unmarshal", SchemaV2, unmarshalErr)
 		}

--- a/pkg/acor/v2_transaction.go
+++ b/pkg/acor/v2_transaction.go
@@ -54,22 +54,22 @@ func readTrieSnapshot(ctx context.Context, storage KVStorage, name string) (*tri
 
 	snap := &trieSnapshot{}
 
-	if data, ok := trieData["keywords"]; ok {
+	if data, ok := trieData[fieldKeywords]; ok {
 		if err := json.Unmarshal([]byte(data), &snap.Keywords); err != nil {
 			return nil, newOperationError("unmarshal", SchemaV2, err)
 		}
 	}
-	if data, ok := trieData["prefixes"]; ok {
+	if data, ok := trieData[fieldPrefixes]; ok {
 		if err := json.Unmarshal([]byte(data), &snap.Prefixes); err != nil {
 			return nil, newOperationError("unmarshal", SchemaV2, err)
 		}
 	}
-	if data, ok := trieData["suffixes"]; ok {
+	if data, ok := trieData[fieldSuffixes]; ok {
 		if err := json.Unmarshal([]byte(data), &snap.Suffixes); err != nil {
 			return nil, newOperationError("unmarshal", SchemaV2, err)
 		}
 	}
-	if v, ok := trieData["version"]; ok {
+	if v, ok := trieData[fieldVersion]; ok {
 		if err := json.Unmarshal([]byte(v), &snap.Version); err != nil {
 			snap.Version = 0
 		}
@@ -81,19 +81,19 @@ func readTrieSnapshot(ctx context.Context, storage KVStorage, name string) (*tri
 // marshalTrieArgs serializes trie data into the args map for Lua scripts.
 func marshalTrieArgs(snap *trieSnapshot, outputs map[string]string, newVersion int64) (map[string]interface{}, error) {
 	args := map[string]interface{}{
-		"trieKey":    "", // caller must set
-		"outputsKey": "", // caller must set
-		"newVersion": newVersion,
-		"oldVersion": snap.Version,
+		argTrieKey:    "", // caller must set
+		argOutputsKey: "", // caller must set
+		"newVersion":  newVersion,
+		"oldVersion":  snap.Version,
 	}
 	var err error
-	if args["keywords"], err = toJSON(snap.Keywords); err != nil {
+	if args[fieldKeywords], err = toJSON(snap.Keywords); err != nil {
 		return nil, newOperationError("marshal", SchemaV2, err)
 	}
-	if args["prefixes"], err = toJSON(snap.Prefixes); err != nil {
+	if args[fieldPrefixes], err = toJSON(snap.Prefixes); err != nil {
 		return nil, newOperationError("marshal", SchemaV2, err)
 	}
-	if args["suffixes"], err = toJSON(snap.Suffixes); err != nil {
+	if args[fieldSuffixes], err = toJSON(snap.Suffixes); err != nil {
 		return nil, newOperationError("marshal", SchemaV2, err)
 	}
 	if args["outputs"], err = toJSON(outputs); err != nil {
@@ -183,8 +183,8 @@ func (o *v2Operations) tryAddV2(ctx context.Context, keyword string) (int, error
 	if err != nil {
 		return 0, err
 	}
-	args["trieKey"] = trieKey(o.name)
-	args["outputsKey"] = outputsKey(o.name)
+	args[argTrieKey] = trieKey(o.name)
+	args[argOutputsKey] = outputsKey(o.name)
 
 	cmd, err := o.runAddV2Script(ctx, o.client, args)
 	if err != nil {
@@ -292,8 +292,8 @@ func (o *v2Operations) tryRemoveV2(ctx context.Context, keyword string) (int, er
 	if err != nil {
 		return 0, err
 	}
-	args["trieKey"] = trieKey(o.name)
-	args["outputsKey"] = outputsKey(o.name)
+	args[argTrieKey] = trieKey(o.name)
+	args[argOutputsKey] = outputsKey(o.name)
 
 	cmd, err := o.runRemoveV2Script(ctx, o.client, args)
 	if err != nil {


### PR DESCRIPTION
# Pull Request

## Description

`make lint` failed locally with 35 `goconst` issues while CI stayed green — a version skew (local golangci-lint v2.12.x vs CI's pinned v2.11.3) combined with an over-aggressive `goconst` config (`min-len/min-occurrences: 2`). This PR resolves the noise, extracts the genuinely-worthwhile constants hiding in it, and removes the skew so local and CI agree.

**Changes**

1. **Redis field-name constants** — extracted V2 trie-hash field names (`keywords`/`prefixes`/`suffixes`/`version`) and arg-map keys (`trieKey`/`outputsKey`) plus default JSON values into `pkg/acor/keys.go`, replacing magic strings across 8 files. Guards against typos silently breaking a Redis read/write.
2. **`emptyTrieFields()` helper** — the identical 4-line empty-trie `HSet` map literal was duplicated in 4 call sites; collapsed into one helper (behavior unchanged — `time.Now().UnixNano()` is still stamped per call).
3. **CLI command/JSON-key constants** — hoisted command names and JSON response keys into `cmd/acor/main.go`; dropped the duplicate `commandFind` that lived only in `main_test.go`.
4. **`goconst` config** — loosened to upstream defaults (`min-len`/`min-occurrences` `2 → 3`), silencing trivial false positives (`"ok"`, stringer returns) permanently.
5. **Version pin** — `Makefile` now runs golangci-lint via `go run ...@v2.11.3`, so `make lint` uses the same version as CI regardless of the locally installed binary. Overridable with `make lint GOLANGCI_LINT=golangci-lint`.

No functional/behavioral changes. `make lint` is now clean under both v2.11.3 (CI) and v2.12.2 (local).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`) — `go test ./pkg/acor ./cmd/acor` green (~73s; the pre-commit `go-unit-tests` hook's 30s timeout is too short for the suite)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`) — 0 issues on v2.11.3 and v2.12.2
- [x] Build succeeds (`make build`)
- [ ] Documentation updated if needed — N/A
- [x] Changelog fragment added (`changie new`)
- [x] Commit messages follow guidelines

## Additional Notes

The `goconst` config change is intentional: `min-occurrences: 2` flagged any 2-char string appearing twice, which is why CI (older binary) and local disagreed. Pinning the version is the durable fix for the skew.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).