### PR TITLE
feat(acor): expose Redis connection-resilience knobs on AhoCorasickArgs

### DIFF
--- a/changes/unreleased/Added-20260724-233849.yaml
+++ b/changes/unreleased/Added-20260724-233849.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: 'Expose Redis connection-resilience knobs on AhoCorasickArgs: DialTimeout, ReadTimeout, WriteTimeout, MaxRetries, and PoolSize. They pass straight through to go-redis across all topologies (standalone, cluster, sentinel, ring); a zero value keeps the existing go-redis default, so behavior is unchanged unless set.'
+time: 2026-07-24T23:38:49.515892+09:00
+custom:
+    Issue: "161"

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -223,6 +223,23 @@ type AhoCorasickArgs struct {
 	// DB is the Redis database number to select (0-15, default: 0).
 	// Not supported in cluster mode.
 	DB int
+
+	// The following knobs tune connection resilience. They are passed straight
+	// through to go-redis; a zero value means "use the go-redis default"
+	// (DialTimeout 5s, Read/WriteTimeout 3s, MaxRetries 3, PoolSize 10*GOMAXPROCS).
+	// They apply across all topologies (standalone, cluster, sentinel, ring).
+
+	// DialTimeout is the timeout for establishing new connections.
+	DialTimeout time.Duration
+	// ReadTimeout is the timeout for socket reads. Use -1 for no timeout.
+	ReadTimeout time.Duration
+	// WriteTimeout is the timeout for socket writes. Use -1 for no timeout.
+	WriteTimeout time.Duration
+	// MaxRetries is the number of retries before giving up on a command.
+	// Use -1 to disable retries.
+	MaxRetries int
+	// PoolSize is the maximum number of socket connections per node.
+	PoolSize int
 	// Name identifies the pattern collection. All keywords added to this instance
 	// are stored under this namespace in Redis. Required.
 	Name string

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -225,9 +225,10 @@ type AhoCorasickArgs struct {
 	DB int
 
 	// The following knobs tune connection resilience. They are passed straight
-	// through to go-redis; a zero value means "use the go-redis default"
-	// (DialTimeout 5s, Read/WriteTimeout 3s, MaxRetries 3, PoolSize 10*GOMAXPROCS).
-	// They apply across all topologies (standalone, cluster, sentinel, ring).
+	// through to go-redis; a zero value means "use the go-redis default", as
+	// documented in go-redis's Options. They apply across all topologies
+	// (standalone, cluster, sentinel, ring).
+	// See https://pkg.go.dev/github.com/redis/go-redis/v9#Options for details.
 
 	// DialTimeout is the timeout for establishing new connections.
 	DialTimeout time.Duration
@@ -238,7 +239,9 @@ type AhoCorasickArgs struct {
 	// MaxRetries is the number of retries before giving up on a command.
 	// Use -1 to disable retries.
 	MaxRetries int
-	// PoolSize is the maximum number of socket connections per node.
+	// PoolSize is the maximum number of socket connections per server —
+	// per node in cluster mode, per shard in ring mode, and per
+	// master/replica in sentinel mode.
 	PoolSize int
 	// Name identifies the pattern collection. All keywords added to this instance
 	// are stored under this namespace in Redis. Required.

--- a/pkg/acor/client.go
+++ b/pkg/acor/client.go
@@ -70,9 +70,14 @@ func validateRedisTopology(args *AhoCorasickArgs, addrs []string, ringAddrs map[
 
 func newRingRedisClient(args *AhoCorasickArgs, ringAddrs map[string]string) redis.UniversalClient {
 	return redis.NewRing(&redis.RingOptions{
-		Addrs:    ringAddrs,
-		Password: args.Password,
-		DB:       args.DB,
+		Addrs:        ringAddrs,
+		Password:     args.Password,
+		DB:           args.DB,
+		DialTimeout:  args.DialTimeout,
+		ReadTimeout:  args.ReadTimeout,
+		WriteTimeout: args.WriteTimeout,
+		MaxRetries:   args.MaxRetries,
+		PoolSize:     args.PoolSize,
 	})
 }
 
@@ -82,13 +87,23 @@ func newSentinelRedisClient(args *AhoCorasickArgs, addrs []string) redis.Univers
 		MasterName:    strings.TrimSpace(args.MasterName),
 		Password:      args.Password,
 		DB:            args.DB,
+		DialTimeout:   args.DialTimeout,
+		ReadTimeout:   args.ReadTimeout,
+		WriteTimeout:  args.WriteTimeout,
+		MaxRetries:    args.MaxRetries,
+		PoolSize:      args.PoolSize,
 	})
 }
 
 func newClusterRedisClient(args *AhoCorasickArgs, addrs []string) (redis.UniversalClient, error) {
 	client := redis.NewClusterClient(&redis.ClusterOptions{
-		Addrs:    addrs,
-		Password: args.Password,
+		Addrs:        addrs,
+		Password:     args.Password,
+		DialTimeout:  args.DialTimeout,
+		ReadTimeout:  args.ReadTimeout,
+		WriteTimeout: args.WriteTimeout,
+		MaxRetries:   args.MaxRetries,
+		PoolSize:     args.PoolSize,
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), defaultRedisClusterPingTimeout)
 	defer cancel()
@@ -105,9 +120,14 @@ func newStandaloneRedisClient(args *AhoCorasickArgs, addrs []string) redis.Unive
 		addr = addrs[0]
 	}
 	return redis.NewClient(&redis.Options{
-		Addr:     addr,
-		Password: args.Password,
-		DB:       args.DB,
+		Addr:         addr,
+		Password:     args.Password,
+		DB:           args.DB,
+		DialTimeout:  args.DialTimeout,
+		ReadTimeout:  args.ReadTimeout,
+		WriteTimeout: args.WriteTimeout,
+		MaxRetries:   args.MaxRetries,
+		PoolSize:     args.PoolSize,
 	})
 }
 

--- a/pkg/acor/client_resilience_test.go
+++ b/pkg/acor/client_resilience_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import (
+	"testing"
+	"time"
+
+	redis "github.com/redis/go-redis/v9"
+)
+
+// TestRedisResilienceKnobsPassThrough verifies that the connection-tuning
+// fields on AhoCorasickArgs reach the underlying go-redis options.
+func TestRedisResilienceKnobsPassThrough(t *testing.T) {
+	client, err := newRedisClient(&AhoCorasickArgs{
+		Addr:         "localhost:6379",
+		DialTimeout:  7 * time.Second,
+		ReadTimeout:  8 * time.Second,
+		WriteTimeout: 9 * time.Second,
+		MaxRetries:   7,
+		PoolSize:     42,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = client.Close() }()
+
+	opt := client.(*redis.Client).Options()
+	if opt.DialTimeout != 7*time.Second {
+		t.Errorf("DialTimeout = %v, want 7s", opt.DialTimeout)
+	}
+	if opt.ReadTimeout != 8*time.Second {
+		t.Errorf("ReadTimeout = %v, want 8s", opt.ReadTimeout)
+	}
+	if opt.WriteTimeout != 9*time.Second {
+		t.Errorf("WriteTimeout = %v, want 9s", opt.WriteTimeout)
+	}
+	if opt.MaxRetries != 7 {
+		t.Errorf("MaxRetries = %d, want 7", opt.MaxRetries)
+	}
+	if opt.PoolSize != 42 {
+		t.Errorf("PoolSize = %d, want 42", opt.PoolSize)
+	}
+}
+
+// TestRedisResilienceZeroFallsBackToDefaults verifies that leaving the knobs
+// unset yields go-redis's built-in defaults rather than zero timeouts.
+func TestRedisResilienceZeroFallsBackToDefaults(t *testing.T) {
+	client, err := newRedisClient(&AhoCorasickArgs{Addr: "localhost:6379"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = client.Close() }()
+
+	opt := client.(*redis.Client).Options()
+	if opt.MaxRetries != 3 { // go-redis default
+		t.Errorf("MaxRetries = %d, want go-redis default 3", opt.MaxRetries)
+	}
+	if opt.DialTimeout <= 0 {
+		t.Errorf("DialTimeout = %v, want positive go-redis default", opt.DialTimeout)
+	}
+}


### PR DESCRIPTION
## Description

Exposes Redis connection-resilience tuning on `AhoCorasickArgs`. Five knobs are added and passed straight through to go-redis across **all** topologies (standalone, cluster, sentinel, ring):

- `DialTimeout`
- `ReadTimeout`
- `WriteTimeout`
- `MaxRetries`
- `PoolSize`

A zero value keeps the existing go-redis default (DialTimeout 5s, R/W 3s, MaxRetries 3, PoolSize 10×GOMAXPROCS), so behavior is unchanged unless a field is explicitly set. No default-fill logic or extra validation layer is added — go-redis already handles the semantics (e.g. `-1` = disabled).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [ ] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — skip for internal-only changes (CI, tests, refactors); see [RELEASE.md](../RELEASE.md)
- [x] Commit messages follow guidelines

## Additional Notes

- Field additions are godoc-documented on `AhoCorasickArgs`.
- New test `client_resilience_test.go` verifies both pass-through of custom values and zero → go-redis-default fallback.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).