### PR TITLE
docs: refresh documentation for v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![CI Status](https://github.com/skyoo2003/acor/actions/workflows/ci.yaml/badge.svg)](https://github.com/skyoo2003/acor/actions/workflows/ci.yaml)
 [![Docs](https://img.shields.io/badge/docs-github_pages-1b6b57)](https://skyoo2003.github.io/acor/)
 [![Go Reference](https://pkg.go.dev/badge/github.com/skyoo2003/acor/pkg/acor.svg)](https://pkg.go.dev/github.com/skyoo2003/acor/pkg/acor)
-[![Go Report Card](https://goreportcard.com/badge/github.com/skyoo2003/acor)](https://goreportcard.com/report/github.com/skyoo2003/acor)
 [![License](https://img.shields.io/github/license/skyoo2003/acor.svg)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/sponsor-GitHub-pink)](https://github.com/sponsors/skyoo2003)
 

--- a/README.md
+++ b/README.md
@@ -85,22 +85,10 @@ func main() {
 
 ## Match Details and Streaming
 
-`FindMatches` returns occurrences in scan order with half-open rune spans.
-Use `MatchKindLeftmostLongest` for non-overlapping results and `WholeWord` to
-exclude matches embedded in larger words.
-
-<!-- doccheck -->
-```go
-matches, err := ac.FindMatches("classic class", &acor.MatchOptions{
-    Kind:      acor.MatchKindLeftmostLongest,
-    WholeWord: true,
-})
-_ = matches
-_ = err
-```
-
-Use `Contains` for an early-exit presence check and `FindStream` to scan an
-`io.Reader` without loading the entire input.
+Use `FindMatches` for ordered rune spans, `Contains` for an early-exit presence
+check, and `FindStream` for an `io.Reader`. See the
+[matching API reference](docs/content/reference/api.md#findmatches) for options
+and a compiled example.
 
 ## Redis Topologies
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Current Release](https://img.shields.io/github/release/skyoo2003/acor.svg)](https://github.com/skyoo2003/acor/releases/latest)
 [![CI Status](https://github.com/skyoo2003/acor/actions/workflows/ci.yaml/badge.svg)](https://github.com/skyoo2003/acor/actions/workflows/ci.yaml)
 [![Docs](https://img.shields.io/badge/docs-github_pages-1b6b57)](https://skyoo2003.github.io/acor/)
-[![Go Reference](https://pkg.go.dev/badge/github.com/skyoo2003/acor.svg)](https://pkg.go.dev/github.com/skyoo2003/acor)
+[![Go Reference](https://pkg.go.dev/badge/github.com/skyoo2003/acor/pkg/acor.svg)](https://pkg.go.dev/github.com/skyoo2003/acor/pkg/acor)
 [![Go Report Card](https://goreportcard.com/badge/github.com/skyoo2003/acor)](https://goreportcard.com/report/github.com/skyoo2003/acor)
 [![License](https://img.shields.io/github/license/skyoo2003/acor.svg)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/sponsor-GitHub-pink)](https://github.com/sponsors/skyoo2003)
@@ -37,7 +37,7 @@ ACOR talks the standard RESP protocol via [go-redis v9](https://github.com/redis
 ## Installation
 
 ```sh
-go get -u github.com/skyoo2003/acor
+go get github.com/skyoo2003/acor/pkg/acor@latest
 ```
 
 ## Quick Start
@@ -82,6 +82,25 @@ func main() {
  }
 }
 ```
+
+## Match Details and Streaming
+
+`FindMatches` returns occurrences in scan order with half-open rune spans.
+Use `MatchKindLeftmostLongest` for non-overlapping results and `WholeWord` to
+exclude matches embedded in larger words.
+
+<!-- doccheck -->
+```go
+matches, err := ac.FindMatches("classic class", &acor.MatchOptions{
+    Kind:      acor.MatchKindLeftmostLongest,
+    WholeWord: true,
+})
+_ = matches
+_ = err
+```
+
+Use `Contains` for an early-exit presence check and `FindStream` to scan an
+`io.Reader` without loading the entire input.
 
 ## Redis Topologies
 
@@ -161,7 +180,7 @@ result, err := ac.AddMany([]string{"he", "her", "him", "his"}, &acor.BatchOption
 })
 
 // Remove multiple keywords
-result, err = ac.RemoveMany([]string{"he", "her"}, nil)
+result, err = ac.RemoveMany([]string{"he", "her"})
 
 // Find matches in multiple texts
 matches, err := ac.FindMany([]string{"he is him", "this is hers"})
@@ -301,7 +320,7 @@ Run `acor` with no arguments to see all commands (also: `remove`, `suggest-index
 
 Full documentation is available at [GitHub Pages](https://skyoo2003.github.io/acor/).
 
-API reference: [pkg.go.dev](https://pkg.go.dev/github.com/skyoo2003/acor)
+API reference: [pkg.go.dev](https://pkg.go.dev/github.com/skyoo2003/acor/pkg/acor)
 
 ## Contributing
 

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -6,10 +6,10 @@ hero_text: ACOR is a Go library and CLI for storing and querying Aho-Corasick pa
 
 ## Getting Started
 
-ACOR requires Go 1.25 or newer and Redis 3.0 or newer.
+ACOR requires Go 1.25 or newer and Redis 3.0 or newer, or Valkey 7.2 or newer.
 
 ```sh
-go get -u github.com/skyoo2003/acor
+go get github.com/skyoo2003/acor/pkg/acor@latest
 ```
 
 ```go

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -10,12 +10,12 @@ This section covers everything you need to start using ACOR.
 ## Prerequisites
 
 - Go >= 1.25
-- Redis >= 3.0
+- Redis >= 3.0 or Valkey >= 7.2
 
 ## Installation
 
 ```bash
-go get -u github.com/skyoo2003/acor
+go get github.com/skyoo2003/acor/pkg/acor@latest
 ```
 
 ## Next Steps

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -15,7 +15,7 @@ ACOR uses the standard RESP protocol via [go-redis v9](https://github.com/redis/
 ## Install the Package
 
 ```bash
-go get -u github.com/skyoo2003/acor
+go get github.com/skyoo2003/acor/pkg/acor@latest
 ```
 
 ## Verify Installation

--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -49,25 +49,6 @@ func main() {
 }
 ```
 
-## Match Occurrences
-
-Use `FindMatches` when you need occurrence order and both ends of each match.
-Offsets are rune-based and use half-open spans `[Start, End)`.
-
-<!-- doccheck -->
-```go
-matches, err := ac.FindMatches("classic class", &acor.MatchOptions{
-    Kind:      acor.MatchKindLeftmostLongest,
-    WholeWord: true,
-})
-_ = matches
-_ = err
-```
-
-Use `Contains` when only presence matters, or `FindStream` for an `io.Reader`.
-See the [API Reference](../reference/api/) for matching options and streaming
-behavior.
-
 ## Redis Topologies
 
 ACOR supports multiple Redis configurations:
@@ -124,4 +105,5 @@ args := &acor.AhoCorasickArgs{
 - [Batch Operations](../guides/batch-operations/) - Optimize bulk operations
 - [Parallel Matching](../guides/parallel-matching/) - Process large texts efficiently
 - [Redis-Backed Engine](../guides/redis-backed-engine/) - Redis persistence with local speed
+- [Match Details](../reference/api/#findmatches) - Ordered rune spans, matching options, and streaming
 - [API Reference](../reference/api/) - Complete API documentation

--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -9,6 +9,7 @@ This guide walks you through building your first ACOR application.
 
 ## Basic Usage
 
+<!-- doccheck -->
 ```go
 package main
 
@@ -47,6 +48,25 @@ func main() {
     }
 }
 ```
+
+## Match Occurrences
+
+Use `FindMatches` when you need occurrence order and both ends of each match.
+Offsets are rune-based and use half-open spans `[Start, End)`.
+
+<!-- doccheck -->
+```go
+matches, err := ac.FindMatches("classic class", &acor.MatchOptions{
+    Kind:      acor.MatchKindLeftmostLongest,
+    WholeWord: true,
+})
+_ = matches
+_ = err
+```
+
+Use `Contains` when only presence matters, or `FindStream` for an `io.Reader`.
+See the [API Reference](../reference/api/) for matching options and streaming
+behavior.
 
 ## Redis Topologies
 

--- a/docs/content/guides/redis-backed-engine.md
+++ b/docs/content/guides/redis-backed-engine.md
@@ -37,8 +37,29 @@ Instance A ──Find()──▶ local engine (0 RTT)
 - **Invalidation**: Redis Pub/Sub notifies all instances on mutation
 - **Degraded mode**: If reload fails, the last-good engine continues serving reads
 
+## Invalidation Safety
+
+Redis Pub/Sub is best effort. In a multi-instance deployment, set
+`InvalidationPollInterval` to bound how long a dropped invalidation can leave a
+local preset engine stale:
+
+<!-- doccheck -->
+```go
+args := &acor.AhoCorasickArgs{
+    Addr:                     "localhost:6379",
+    Name:                     "my-collection",
+    Preset:                   acor.PresetBalanced,
+    InvalidationPollInterval: 30 * time.Second,
+}
+_ = args
+```
+
+The zero value disables polling. Polling only applies to Preset mode; normal
+invalidation still uses Pub/Sub.
+
 ## Quick Start
 
+<!-- doccheck -->
 ```go
 package main
 
@@ -87,6 +108,11 @@ type AhoCorasickArgs struct {
 ```
 
 All standard Redis topologies are supported (Standalone, Sentinel, Cluster, Ring) via the connection fields on `AhoCorasickArgs`.
+
+Connection resilience can be tuned with `DialTimeout`, `ReadTimeout`,
+`WriteTimeout`, `MaxRetries`, and `PoolSize`. These values pass directly to
+go-redis for every topology; zero keeps the go-redis default. Use `-1` to
+disable read/write timeouts or command retries where supported.
 
 ## Preset Selection
 

--- a/docs/content/operations/troubleshooting.md
+++ b/docs/content/operations/troubleshooting.md
@@ -116,10 +116,43 @@ redis GET on key "...": context deadline exceeded
 ```
 
 **Solutions:**
-1. Increase timeout
+1. Tune `DialTimeout`, `ReadTimeout`, or `WriteTimeout` when measurements show
+   the defaults are too short
 2. Check Redis load
 3. Check network latency
-4. Scale Redis cluster
+4. Set `MaxRetries` for transient failures or adjust `PoolSize` for measured
+   connection contention
+5. Scale Redis cluster
+
+Zero values keep the go-redis defaults across Standalone, Sentinel, Cluster,
+and Ring modes.
+
+<!-- doccheck -->
+```go
+args := &acor.AhoCorasickArgs{
+    Addr:         "localhost:6379",
+    Name:         "my-collection",
+    DialTimeout:  5 * time.Second,
+    ReadTimeout:  3 * time.Second,
+    WriteTimeout: 3 * time.Second,
+    MaxRetries:   3,
+}
+_ = args
+```
+
+### Preset Cache Appears Stale
+
+**Cause:** Preset mode normally reloads through best-effort Redis Pub/Sub. A
+disconnected subscriber can miss an invalidation.
+
+**Solution:** In multi-instance deployments, set
+`InvalidationPollInterval` to the maximum acceptable staleness window:
+
+```go
+args.InvalidationPollInterval = 30 * time.Second
+```
+
+The option is disabled by default and ignored outside Preset mode.
 
 ## Performance Issues
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -5,7 +5,9 @@ weight: 1
 
 # API Reference
 
-Complete API documentation for ACOR.
+Core API documentation for ACOR. See
+[pkg.go.dev](https://pkg.go.dev/github.com/skyoo2003/acor/pkg/acor) for the
+complete generated reference.
 
 ## Core Types
 
@@ -22,6 +24,11 @@ type AhoCorasickArgs struct {
     MasterName                      string            // Sentinel master name
     Password                        string            // Redis password
     DB                              int               // Redis database number (0-15, default: 0)
+    DialTimeout                     time.Duration     // Connection timeout (zero: go-redis default)
+    ReadTimeout                     time.Duration     // Socket read timeout (zero: go-redis default)
+    WriteTimeout                    time.Duration     // Socket write timeout (zero: go-redis default)
+    MaxRetries                      int               // Command retries (zero: go-redis default; -1: disabled)
+    PoolSize                        int               // Connections per server (zero: go-redis default)
     Name                            string            // Collection name (required)
     Debug                           bool              // Enable debug logging to stdout
     Logger                          Logger            // Custom logger (nil disables logging)
@@ -31,6 +38,7 @@ type AhoCorasickArgs struct {
     CaseSensitive                   bool              // Enable case-sensitive matching (default: false)
     RollbackTimeout                 time.Duration     // V1 rollback timeout (default: 10s)
     Preset                           Preset            // Architecture preset (default: PresetNone)
+    InvalidationPollInterval        time.Duration     // Preset version polling (zero: disabled)
 }
 ```
 <!-- AUTO-GENERATED:types:end -->
@@ -80,6 +88,10 @@ Remove multiple keywords in a batch.
 
 ```go
 result, err := ac.RemoveMany([]string{"a", "b"})
+// Use RemoveManyWithOptions when transactional behavior is required.
+result, err = ac.RemoveManyWithOptions([]string{"c", "d"}, &acor.BatchOptions{
+    Mode: acor.BatchModeTransactional,
+})
 ```
 
 ### Find
@@ -100,6 +112,71 @@ positions, err := ac.FindIndex("sample text")
 // Returns: map[string][]int{"keyword": {startPos, ...}, ...}
 ```
 
+### FindMatches
+
+Return every occurrence in scan order with its keyword and half-open rune span
+`[Start, End)`. The default includes overlapping matches; use
+`MatchKindLeftmostLongest` for non-overlapping tokenization or replacement.
+
+<!-- doccheck -->
+```go
+matches, err := ac.FindMatches("classic class", &acor.MatchOptions{
+    Kind:      acor.MatchKindLeftmostLongest,
+    WholeWord: true,
+})
+_ = matches
+_ = err
+```
+
+```go
+type Match struct {
+    Keyword string
+    Start   int // Rune offset, inclusive
+    End     int // Rune offset, exclusive
+}
+
+type MatchOptions struct {
+    Kind      MatchKind
+    WholeWord bool
+    WordRune  func(rune) bool // Optional whole-word predicate
+}
+
+const (
+    MatchKindOverlapping MatchKind = iota // Default
+    MatchKindLeftmostLongest
+)
+```
+
+`WholeWord` uses letters, digits, combining marks, and underscores as word
+runes. Set `WordRune` when those defaults do not fit the input script.
+
+### Contains
+
+Report whether any keyword occurs, stopping at the first match.
+
+```go
+found, err := ac.Contains("sample text")
+```
+
+### FindStream
+
+Scan an `io.Reader` without buffering the whole input. Matches include
+overlaps, retain rune offsets across reads, and arrive in scan order. Returning
+`false` from the callback stops the scan.
+
+<!-- doccheck -->
+```go
+err := ac.FindStream(strings.NewReader("sample text"), func(match acor.Match) bool {
+    _ = match
+    return true
+})
+_ = err
+```
+
+Streaming does not apply whole-word or leftmost-longest filtering because
+those modes require buffering. Use `FindMatches` for bounded strings that need
+those options.
+
 ### FindMany
 
 Find matches in multiple texts.
@@ -118,6 +195,17 @@ matches, err := ac.FindParallel(largeText, &acor.ParallelOptions{
     Workers:   4,
     Boundary:  acor.ChunkBoundaryWord,
 })
+```
+
+Keywords longer than `ParallelOptions.Overlap` can be missed at chunk
+boundaries. Set `Overlap` to at least the longest expected keyword.
+
+### FindIndexParallel
+
+Find start positions using the same parallel chunking options.
+
+```go
+positions, err := ac.FindIndexParallel(largeText, acor.DefaultParallelOptions())
 ```
 
 ### Info
@@ -154,7 +242,7 @@ Statistics about an Aho-Corasick instance.
 type AhoCorasickInfo struct {
     Keywords    int    // Number of keywords
     Nodes       int    // Number of trie nodes (states)
-    Preset      Preset // Architecture preset (zero in original mode)
+    Preset      Preset // Architecture preset (internal default sentinel in original mode)
     MemoryBytes int64  // Estimated memory usage in bytes (zero in original mode)
     TrieDepth   int    // Maximum trie depth (zero in original mode)
 }
@@ -172,7 +260,6 @@ const (
     PresetBalanced                      // Double-Array Trie + Banded DFA — best speed-to-memory ratio
     PresetMemoryEfficient               // Map-based + Bloom filter — min memory, slower search
     PresetUltimate                      // Balanced engine + first-rune Bloom pre-filter — high throughput
-    PresetDefault         Preset = -1   // Internal sentinel; not user-selectable
 )
 ```
 
@@ -219,6 +306,8 @@ removed, err := ac.Remove("keyword") // (int, error)
 // Find (0 RTT on hot path — reads from local engine)
 matches, err := ac.Find("text")       // ([]string, error)
 positions, err := ac.FindIndex("text") // (map[string][]int, error)
+spans, err := ac.FindMatches("text", nil) // ([]Match, error)
+found, err := ac.Contains("text")          // (bool, error)
 
 // Info
 info, err := ac.Info()   // (*AhoCorasickInfo, error)
@@ -228,6 +317,19 @@ err := ac.Flush()
 
 // Close
 err := ac.Close()
+```
+
+## Context Variants
+
+Operations that may perform Redis I/O also accept an explicit
+`context.Context`: `AddContext`, `RemoveContext`, `FindContext`,
+`FindIndexContext`, `FindMatchesContext`, `ContainsContext`,
+`FindStreamContext`, `FlushContext`, `InfoContext`, `SuggestContext`,
+`SuggestIndexContext`, `AddManyContext`, `RemoveManyContext`,
+`FindManyContext`, `FindParallelContext`, and `FindIndexParallelContext`.
+
+```go
+matches, err := ac.FindMatchesContext(ctx, text, nil)
 ```
 
 ## Suggest Methods
@@ -265,7 +367,7 @@ type BatchResult struct {
     Added   []string       // Successfully added keywords
     Removed []string       // Successfully removed keywords
     Failed  []KeywordError // Keywords that failed with their errors
-    Skipped []string       // Keywords that were skipped (e.g., duplicates)
+    Skipped []string       // Duplicate adds or absent removes
 }
 ```
 


### PR DESCRIPTION
# Pull Request

## Description

Refresh the project documentation to match the v0.10.0 public API and current package layout.

- Document `FindMatches`, `Contains`, `FindStream`, match options, context variants, and Redis resilience settings.
- Remove the obsolete `PresetDefault` reference and fix the `RemoveMany` example.
- Correct package installation and pkg.go.dev paths to `pkg/acor`.
- Document preset invalidation polling and connection timeout troubleshooting.
- Expand compiled documentation examples from 6 to 14.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment not required because this documents existing v0.10.0 behavior
- [x] Commit messages follow guidelines

## Additional Notes

- `make docs-verify`: all 14 checked Go examples compile.
- Hugo rendering was not run locally because the `hugo` executable is unavailable.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).