### PR TITLE
docs: improve GitHub Pages usability

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -7,6 +7,12 @@ on:
     paths:
       - docs/**
       - .github/workflows/pages.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - docs/**
+      - .github/workflows/pages.yaml
   workflow_dispatch:
 
 permissions:
@@ -15,7 +21,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -50,6 +56,7 @@ jobs:
           path: docs/public
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -31,158 +31,29 @@ func main() {
   }
   defer ac.Close()
 
-  _, _ = ac.Add("he")
-  _, _ = ac.Add("her")
-  matched, _ := ac.Find("he is her")
+  _, _ = ac.Add("redis")
+  matched, _ := ac.Find("redis-backed matching")
   fmt.Println(matched)
 }
 ```
 
-## Redis Topologies
+## Explore the Documentation
 
-- **Standalone**: use `Addr` for a single Redis server.
-- **Sentinel**: use `Addrs` with `MasterName` for failover-aware access.
-- **Cluster**: use `Addrs` with `DB` left at `0`.
-- **Ring**: use `RingAddrs` with shard-to-address mappings.
-
-```go
-sentinelArgs := &acor.AhoCorasickArgs{
-  Addrs:      []string{"localhost:26379", "localhost:26380"},
-  MasterName: "mymaster",
-  Name:       "sample",
-}
-
-clusterArgs := &acor.AhoCorasickArgs{
-  Addrs: []string{"localhost:7000", "localhost:7001", "localhost:7002"},
-  Name:  "sample",
-}
-
-ringArgs := &acor.AhoCorasickArgs{
-  RingAddrs: map[string]string{
-    "shard-1": "localhost:7000",
-    "shard-2": "localhost:7001",
-  },
-  Name: "sample",
-}
-```
-
-## CLI Commands
-
-<ul>
-  <li><code>add &lt;keyword&gt;</code> inserts a keyword into the collection.</li>
-  <li><code>remove &lt;keyword&gt;</code> removes a keyword and prunes related trie state.</li>
-  <li><code>find &lt;input&gt;</code> and <code>find-index &lt;input&gt;</code> return matches or match offsets.</li>
-  <li><code>suggest &lt;input&gt;</code> and <code>suggest-index &lt;input&gt;</code> return prefix suggestions and their offsets.</li>
-  <li><code>info</code> returns keyword and node counts.</li>
-  <li><code>flush</code> clears stored trie state.</li>
-</ul>
-
-| Flag | Purpose |
-| --- | --- |
-| `-addr` | Standalone Redis server address |
-| `-addrs` | Sentinel or Cluster seed addresses |
-| `-master-name` | Redis Sentinel master name |
-| `-ring-addrs` | Comma-separated `shard=addr` pairs |
-| `-password` | Redis password |
-| `-db` | Redis DB number |
-| `-name` | Pattern collection name, default `default` |
-| `-debug` | Enable debug logging |
-
-## HTTP and gRPC Adapters
-
-The HTTP handler exposes JSON endpoints on `/v1/*` plus `/healthz`.
-
-- `POST /v1/add`
-- `POST /v1/remove`
-- `POST /v1/find`
-- `POST /v1/find-index`
-- `POST /v1/suggest`
-- `POST /v1/suggest-index`
-- `GET /v1/info`
-- `POST /v1/flush`
-
-The gRPC adapter serves the same eight operations as the `acor.server.v1.Acor`
-service, defined in `server/proto/acor/v1/acor.proto` (standard protobuf wire
-format). Start one with `server.NewGRPCServer(service, opts...)` and generate
-clients from the `.proto` with your language's protobuf toolchain. Regenerate
-the Go stubs with `make proto`.
-
-## Batch Operations
-
-For better performance when working with multiple keywords:
-
-```go
-// Add multiple keywords with transactional mode
-result, _ := ac.AddMany([]string{"he", "her", "him"}, &acor.BatchOptions{
-    Mode: acor.BatchModeTransactional,
-})
-
-// Find matches in multiple texts
-matches, _ := ac.FindMany([]string{"he is him", "this is hers"})
-```
-
-## Parallel Matching
-
-Process large texts using multiple goroutines:
-
-```go
-matches, _ := ac.FindParallel(largeText, &acor.ParallelOptions{
-    Workers:       4,
-    Boundary: acor.ChunkBoundaryWord,
-})
-```
-
-## Observability
-
-ACOR provides built-in observability packages in a separate module
-(`go get github.com/skyoo2003/acor/server`), so the core library stays
-dependency-light:
-
-- **Metrics**: Prometheus metrics for HTTP, gRPC, and Redis
-- **Logging**: Structured JSON logging with zerolog
-- **Tracing**: OpenTelemetry distributed tracing
-- **Health**: Kubernetes-compatible health checks
-
-```go
-import (
-    "github.com/skyoo2003/acor/server/metrics"
-    "github.com/skyoo2003/acor/server/logging"
-    "github.com/skyoo2003/acor/server/tracing"
-    "github.com/skyoo2003/acor/server/health"
-)
-```
-
-## In-Memory and Redis-Backed Engines
-
-ACOR also provides a preset-optimized engine variant:
-
-- **Preset-optimized Redis mode** (`Preset: PresetBalanced`): Redis persistence with a local preset-optimized automaton for 0-RTT reads
-
-Both support four presets: Speed, Balanced, MemoryEfficient, and Ultimate.
-
-## Documentation Sections
-
-- [Getting Started][getting-started-link] - Installation and quick start guide
-- [Guides][guides-link] - Usage patterns and advanced features
-- [Reference][reference-link] - API and schema documentation
-- [Operations][operations-link] - Deployment and monitoring
-- [Extending][extending-link] - Custom storage backends
-
-[getting-started-link]: getting-started/
-[guides-link]: guides/
-[reference-link]: reference/
-[operations-link]: operations/
-[extending-link]: extending/
-
-## Development Workflow
-
-Run local checks with:
-
-```sh
-make test
-make build
-```
-
-CI runs on pushes and pull requests against `master`. Releases are tag-based, and the GitHub Pages site is built from the Hugo source in `docs/`.
-
-The source code is licensed under Apache License 2.0. Contributions should include tests when behavior changes.
+<div class="doc-grid">
+  <a class="doc-card" href="getting-started/">
+    <strong>Getting Started</strong>
+    <span>Install ACOR and build your first matcher.</span>
+  </a>
+  <a class="doc-card" href="guides/">
+    <strong>Guides</strong>
+    <span>Use batch, parallel, and Redis-backed engines.</span>
+  </a>
+  <a class="doc-card" href="reference/">
+    <strong>API Reference</strong>
+    <span>Review public APIs and storage schemas.</span>
+  </a>
+  <a class="doc-card" href="operations/">
+    <strong>Operations</strong>
+    <span>Deploy, monitor, and troubleshoot ACOR.</span>
+  </a>
+</div>

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -62,5 +62,5 @@ acor --help
 
 ## Next Steps
 
-- [Quick Start](quick-start/) - Build your first application
-- [Guides](../guides/) - Learn about batch operations and parallel matching
+- [Quick Start](../quick-start/) - Build your first application
+- [Guides](../../guides/) - Learn about batch operations and parallel matching

--- a/docs/content/getting-started/quick-start.md
+++ b/docs/content/getting-started/quick-start.md
@@ -102,8 +102,8 @@ args := &acor.AhoCorasickArgs{
 
 ## Next Steps
 
-- [Batch Operations](../guides/batch-operations/) - Optimize bulk operations
-- [Parallel Matching](../guides/parallel-matching/) - Process large texts efficiently
-- [Redis-Backed Engine](../guides/redis-backed-engine/) - Redis persistence with local speed
-- [Match Details](../reference/api/#findmatches) - Ordered rune spans, matching options, and streaming
-- [API Reference](../reference/api/) - Complete API documentation
+- [Batch Operations](../../guides/batch-operations/) - Optimize bulk operations
+- [Parallel Matching](../../guides/parallel-matching/) - Process large texts efficiently
+- [Redis-Backed Engine](../../guides/redis-backed-engine/) - Redis persistence with local speed
+- [Match Details](../../reference/api/#findmatches) - Ordered rune spans, matching options, and streaming
+- [API Reference](../../reference/api/) - Complete API documentation

--- a/docs/content/guides/batch-operations.md
+++ b/docs/content/guides/batch-operations.md
@@ -113,5 +113,5 @@ for _, ke := range result.Failed {
 
 ## Next Steps
 
-- [Parallel Matching](parallel-matching/) - Process large texts efficiently
-- [API Reference](../reference/api/) - Complete API documentation
+- [Parallel Matching](../parallel-matching/) - Process large texts efficiently
+- [API Reference](../../reference/api/) - Complete API documentation

--- a/docs/content/guides/parallel-matching.md
+++ b/docs/content/guides/parallel-matching.md
@@ -101,5 +101,5 @@ opts := &acor.ParallelOptions{
 
 ## Next Steps
 
-- [Batch Operations](batch-operations/) - Optimize bulk keyword operations
-- [API Reference](../reference/api/) - Complete API documentation
+- [Batch Operations](../batch-operations/) - Optimize bulk keyword operations
+- [API Reference](../../reference/api/) - Complete API documentation

--- a/docs/content/guides/preset-engine.md
+++ b/docs/content/guides/preset-engine.md
@@ -113,5 +113,5 @@ ac.Flush()
 
 ## Next Steps
 
-- [Redis-Backed Engine](redis-backed-engine/) - Redis persistence details
-- [API Reference](../reference/api/) - Complete API documentation
+- [Redis-Backed Engine](../redis-backed-engine/) - Redis persistence details
+- [API Reference](../../reference/api/) - Complete API documentation

--- a/docs/content/guides/redis-backed-engine.md
+++ b/docs/content/guides/redis-backed-engine.md
@@ -116,7 +116,7 @@ disable read/write timeouts or command retries where supported.
 
 ## Preset Selection
 
-The same [architecture presets](preset-engine/#architecture-presets) are available:
+The same [architecture presets](../preset-engine/#architecture-presets) are available:
 
 | Preset | Use Case |
 |--------|----------|
@@ -172,5 +172,5 @@ Use a `Preset`-optimized `AhoCorasick` when you need the fastest possible reads 
 
 ## Next Steps
 
-- [Preset-Optimized Engine](preset-engine/) - Redis-backed engine with local speed
-- [API Reference](../reference/api/) - Complete API documentation
+- [Preset-Optimized Engine](../preset-engine/) - Redis-backed engine with local speed
+- [API Reference](../../reference/api/) - Complete API documentation

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -1,40 +1,73 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ site.Language.LanguageCode }}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ if .Title }}{{ .Title }} | {{ end }}{{ site.Title }}</title>
+  <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ .Title }} | {{ site.Title }}{{ end }}</title>
   <style>
     :root {
       color-scheme: light;
-      --bg: #f3efe6;
-      --surface: #fffdfa;
-      --surface-strong: #f6f1e8;
-      --text: #1e1f1c;
-      --muted: #5d6057;
-      --line: #d9d1c1;
-      --accent: #1b6b57;
-      --accent-soft: #dcefe8;
-      --code: #f4f0e7;
-      --shadow: 0 18px 40px rgba(49, 45, 35, 0.08);
+      --bg: #f4f6f4;
+      --surface: #ffffff;
+      --text: #1d2522;
+      --muted: #596560;
+      --line: #d7dfdc;
+      --accent: #176b57;
+      --accent-hover: #0d5443;
+      --accent-soft: #e3f1ec;
+      --inline-code: #edf2f0;
+      --code-block: #f7f9f8;
+      --shadow: 0 12px 30px rgba(31, 47, 41, 0.07);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        color-scheme: dark;
+        --bg: #101512;
+        --surface: #181e1b;
+        --text: #edf2f0;
+        --muted: #abb8b3;
+        --line: #34403b;
+        --accent: #76d5bc;
+        --accent-hover: #9be4d1;
+        --accent-soft: #1c392f;
+        --inline-code: #25302c;
+        --code-block: #ffffff;
+        --shadow: none;
+      }
     }
 
     * {
       box-sizing: border-box;
     }
 
+    html {
+      scroll-padding-top: 5rem;
+    }
+
     body {
       margin: 0;
-      font-family: Georgia, "Times New Roman", serif;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
       background:
-        radial-gradient(circle at top right, rgba(27, 107, 87, 0.18), transparent 24%),
-        linear-gradient(180deg, #f8f4ec 0%, var(--bg) 100%);
+        radial-gradient(circle at top right, rgba(23, 107, 87, 0.12), transparent 24rem),
+        var(--bg);
       color: var(--text);
-      line-height: 1.65;
+      line-height: 1.7;
     }
 
     a {
       color: var(--accent);
+      text-underline-offset: 0.18em;
+    }
+
+    a:hover {
+      color: var(--accent-hover);
+    }
+
+    a:focus-visible {
+      outline: 3px solid var(--accent);
+      outline-offset: 3px;
+      border-radius: 3px;
     }
 
     code,
@@ -42,8 +75,83 @@
       font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
     }
 
+    :not(pre) > code {
+      padding: 0.15rem 0.35rem;
+      border-radius: 4px;
+      background: var(--inline-code);
+      font-size: 0.9em;
+    }
+
+    .skip-link {
+      position: fixed;
+      top: 0.5rem;
+      left: 0.5rem;
+      z-index: 100;
+      padding: 0.6rem 0.8rem;
+      background: var(--surface);
+      transform: translateY(-150%);
+    }
+
+    .skip-link:focus {
+      transform: translateY(0);
+    }
+
+    .site-header {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      border-bottom: 1px solid var(--line);
+      background: var(--bg);
+    }
+
+    .site-nav {
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      gap: 1.25rem;
+      align-items: center;
+      width: min(1180px, calc(100% - 2rem));
+      min-height: 4rem;
+      margin: 0 auto;
+    }
+
+    .brand {
+      color: var(--text);
+      font-size: 1.15rem;
+      font-weight: 750;
+      letter-spacing: 0.04em;
+      text-decoration: none;
+    }
+
+    .nav-links {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.15rem;
+    }
+
+    .nav-links a,
+    .github-link {
+      display: inline-flex;
+      align-items: center;
+      min-height: 2.75rem;
+      padding: 0 0.65rem;
+      color: var(--muted);
+      font-size: 0.9rem;
+      font-weight: 600;
+      text-decoration: none;
+    }
+
+    .nav-links a:hover,
+    .nav-links a.active,
+    .github-link:hover {
+      color: var(--accent);
+    }
+
+    .nav-links a.active {
+      box-shadow: inset 0 -2px var(--accent);
+    }
+
     .page {
-      width: min(960px, calc(100% - 2rem));
+      width: min(1180px, calc(100% - 2rem));
       margin: 0 auto;
       padding: 2rem 0 4rem;
     }
@@ -52,111 +160,336 @@
     .content {
       background: var(--surface);
       border: 1px solid var(--line);
-      border-radius: 24px;
+      border-radius: 20px;
       box-shadow: var(--shadow);
     }
 
     .hero {
-      padding: 2.5rem;
-      margin-bottom: 1.5rem;
+      max-width: 900px;
+      padding: clamp(1.5rem, 4vw, 3rem);
+      margin: 0 auto 1.5rem;
     }
 
     .eyebrow {
       display: inline-block;
-      padding: 0.35rem 0.7rem;
+      padding: 0.3rem 0.65rem;
       border-radius: 999px;
       background: var(--accent-soft);
       color: var(--accent);
-      font-size: 0.8rem;
-      font-weight: 700;
+      font-size: 0.78rem;
+      font-weight: 750;
       letter-spacing: 0.08em;
       text-transform: uppercase;
     }
 
-    h1,
-    h2,
-    h3 {
-      line-height: 1.15;
-      margin: 0;
-    }
-
-    h1 {
-      font-size: clamp(2.4rem, 6vw, 4.4rem);
-      margin-top: 0.85rem;
-    }
-
-    h2 {
-      font-size: 1.7rem;
-      margin: 2rem 0 0.85rem;
-    }
-
-    p,
-    ul,
-    table,
-    pre {
+    .hero h1 {
+      max-width: 19ch;
       margin: 0.85rem 0 0;
+      font-size: clamp(2.25rem, 6vw, 3.8rem);
+      line-height: 1.08;
     }
 
-    .hero p,
-    .content {
+    .hero p {
+      max-width: 68ch;
+      margin: 1rem 0 0;
+      color: var(--muted);
+      font-size: 1.08rem;
+    }
+
+    .home-layout {
+      max-width: 900px;
+      margin: 0 auto;
+    }
+
+    .docs-layout {
+      display: grid;
+      grid-template-columns: minmax(0, 76ch) minmax(190px, 240px);
+      gap: 2rem;
+      justify-content: center;
+      align-items: start;
+    }
+
+    .breadcrumbs {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.45rem;
+      max-width: 1020px;
+      margin: 0 auto 0.75rem;
+      color: var(--muted);
+      font-size: 0.88rem;
+    }
+
+    .breadcrumbs a {
       color: var(--muted);
     }
 
     .content {
-      padding: 1.75rem;
+      min-width: 0;
+      padding: clamp(1.25rem, 3vw, 2.25rem);
     }
 
     .content > *:first-child {
       margin-top: 0;
     }
 
+    .content h1,
     .content h2,
-    .content h3,
-    .content strong {
+    .content h3 {
       color: var(--text);
+      line-height: 1.25;
+    }
+
+    .content h1 {
+      margin: 0 0 1rem;
+      font-size: clamp(2rem, 5vw, 2.7rem);
+    }
+
+    .content h2 {
+      margin: 2.4rem 0 0.8rem;
+      font-size: 1.55rem;
+    }
+
+    .content h3 {
+      margin: 1.8rem 0 0.65rem;
+      font-size: 1.18rem;
+    }
+
+    p,
+    ul,
+    ol,
+    table,
+    pre,
+    blockquote {
+      margin: 0.9rem 0 0;
+    }
+
+    ul,
+    ol {
+      padding-left: 1.35rem;
+    }
+
+    li + li {
+      margin-top: 0.35rem;
     }
 
     pre {
+      max-width: 100%;
       padding: 1rem;
       overflow-x: auto;
-      border-radius: 16px;
-      background: var(--code);
       border: 1px solid var(--line);
+      border-radius: 10px;
+      background: var(--code-block);
+      color: #1d2522;
+      line-height: 1.55;
+    }
+
+    pre code {
+      padding: 0;
+      background: none;
+      font-size: 0.88rem;
     }
 
     table {
+      display: block;
       width: 100%;
+      max-width: 100%;
+      overflow-x: auto;
       border-collapse: collapse;
+      font-size: 0.94rem;
     }
 
     th,
     td {
-      padding: 0.8rem;
+      min-width: 8rem;
+      padding: 0.7rem 0.8rem;
       text-align: left;
       vertical-align: top;
+      border-bottom: 1px solid var(--line);
+    }
+
+    th {
+      color: var(--text);
+      background: var(--inline-code);
+    }
+
+    blockquote {
+      padding-left: 1rem;
+      border-left: 3px solid var(--accent);
+      color: var(--muted);
+    }
+
+    .toc {
+      position: sticky;
+      top: 5.5rem;
+      max-height: calc(100vh - 7rem);
+      padding-left: 1rem;
+      overflow-y: auto;
+      border-left: 1px solid var(--line);
+      font-size: 0.88rem;
+    }
+
+    .toc strong {
+      font-size: 0.82rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .toc ul {
+      margin: 0.65rem 0 0;
+      padding-left: 0;
+      list-style: none;
+    }
+
+    .toc ul ul {
+      margin-top: 0.25rem;
+      padding-left: 0.85rem;
+    }
+
+    .toc li + li {
+      margin-top: 0.4rem;
+    }
+
+    .toc a {
+      color: var(--muted);
+      text-decoration: none;
+    }
+
+    .toc a:hover {
+      color: var(--accent);
+    }
+
+    .doc-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.8rem;
+      margin-top: 1rem;
+    }
+
+    .doc-card {
+      display: block;
+      padding: 1rem;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      color: var(--text);
+      text-decoration: none;
+    }
+
+    .doc-card:hover {
+      border-color: var(--accent);
+      color: var(--text);
+    }
+
+    .doc-card strong,
+    .doc-card span {
+      display: block;
+    }
+
+    .doc-card span {
+      margin-top: 0.2rem;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .site-footer {
+      padding: 1.5rem 1rem;
       border-top: 1px solid var(--line);
+      color: var(--muted);
+      text-align: center;
+      font-size: 0.85rem;
     }
 
-    ul {
-      padding-left: 1.2rem;
+    @media (max-width: 900px) {
+      .docs-layout {
+        grid-template-columns: minmax(0, 76ch);
+      }
+
+      .toc {
+        position: static;
+        max-height: none;
+        padding: 1rem 1.25rem;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        background: var(--surface);
+      }
     }
 
-    @media (max-width: 860px) {
+    @media (max-width: 700px) {
+      .site-nav {
+        grid-template-columns: auto 1fr;
+        gap: 0 0.75rem;
+        padding-top: 0.35rem;
+      }
+
+      .github-link {
+        justify-self: end;
+      }
+
+      .nav-links {
+        grid-column: 1 / -1;
+        overflow-x: auto;
+        flex-wrap: nowrap;
+      }
+
+      .nav-links a {
+        white-space: nowrap;
+      }
+
+      .page {
+        width: min(100% - 1rem, 1180px);
+        padding-top: 1rem;
+      }
+
       .hero,
       .content {
-        padding: 1.3rem;
+        border-radius: 14px;
+      }
+
+      .doc-grid {
+        grid-template-columns: 1fr;
       }
     }
   </style>
 </head>
 <body>
-  <main class="page">
-    <section class="hero">
-      <span class="eyebrow">ACOR Documentation</span>
-      <h1>{{ .Params.hero_title }}</h1>
-      <p>{{ .Params.hero_text }}</p>
-    </section>
-    {{ block "main" . }}{{ end }}
+  <a class="skip-link" href="#main-content">Skip to content</a>
+  <header class="site-header">
+    <nav class="site-nav" aria-label="Primary navigation">
+      <a class="brand" href="{{ site.Home.RelPermalink }}">ACOR</a>
+      <div class="nav-links">
+        {{ range site.Menus.main }}
+          {{ $href := .URL | relURL }}
+          <a href="{{ $href }}"{{ if hasPrefix $.RelPermalink $href }} class="active" aria-current="location"{{ end }}>{{ .Name }}</a>
+        {{ end }}
+      </div>
+      <a class="github-link" href="https://github.com/skyoo2003/acor">GitHub</a>
+    </nav>
+  </header>
+  <main id="main-content" class="page">
+    {{ if .IsHome }}
+      <section class="hero">
+        <span class="eyebrow">ACOR Documentation</span>
+        <h1>{{ .Params.hero_title }}</h1>
+        <p>{{ .Params.hero_text }}</p>
+      </section>
+    {{ else }}
+      <nav class="breadcrumbs" aria-label="Breadcrumb">
+        {{ range .Ancestors.Reverse }}
+          <a href="{{ .RelPermalink }}">{{ if .IsHome }}Home{{ else }}{{ .LinkTitle }}{{ end }}</a>
+          <span aria-hidden="true">/</span>
+        {{ end }}
+        <span aria-current="page">{{ .LinkTitle }}</span>
+      </nav>
+    {{ end }}
+    <div class="{{ if .IsHome }}home-layout{{ else }}docs-layout{{ end }}">
+      {{ block "main" . }}{{ end }}
+      {{ if not .IsHome }}
+        <aside class="toc" aria-label="On this page">
+          <strong>On this page</strong>
+          {{ .TableOfContents }}
+        </aside>
+      {{ end }}
+    </div>
   </main>
+  <footer class="site-footer">ACOR · Apache License 2.0</footer>
 </body>
 </html>


### PR DESCRIPTION
# Pull Request

## Description

Improve the GitHub Pages documentation UI while keeping the existing Hugo setup.

- Add responsive primary navigation, breadcrumbs, an on-page table of contents, system dark mode, and accessible focus styles.
- Show the hero only on the home page and shorten the landing content into focused documentation links.
- Fix 16 existing internal links that resolved to incorrect nested paths.
- Build Pages changes on pull requests while deploying only push and manual-dispatch builds.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Vet/`make vet`
- [ ] Linting passes (`make lint`)
- [ ] Build succeeds (`make build`)
- [x] Documentation checks pass (`make docs-verify`)
- [x] Hugo 0.147.9 build succeeds
- [x] Documentation updated if needed
- [x] Changelog fragment not required for this documentation and CI-only change
- [x] Commit messages follow guidelines

## Additional Notes

Go tests, vet, lint, and the Go binary build were not run locally because this PR changes only documentation content, Hugo templates, and the Pages workflow.

Generated HTML checks verified 19 pages with exactly one `h1` per page, correct home/subpage chrome, active navigation, and no missing internal links.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).