### PR TITLE
docs: pin installation examples to v0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ACOR talks the standard RESP protocol via [go-redis v9](https://github.com/redis
 ## Installation
 
 ```sh
-go get github.com/skyoo2003/acor/pkg/acor@latest
+go get github.com/skyoo2003/acor/pkg/acor@v0.10.0
 ```
 
 ## Quick Start
@@ -279,7 +279,7 @@ ACOR includes a command-line interface for common operations:
 
 ```sh
 # Install
-go install github.com/skyoo2003/acor/cmd/acor@latest
+go install github.com/skyoo2003/acor/cmd/acor@v0.10.0
 
 # Add keywords
 acor -name mycollection add "keyword1" "keyword2"

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -9,7 +9,7 @@ hero_text: ACOR is a Go library and CLI for storing and querying Aho-Corasick pa
 ACOR requires Go 1.25 or newer and Redis 3.0 or newer, or Valkey 7.2 or newer.
 
 ```sh
-go get github.com/skyoo2003/acor/pkg/acor@latest
+go get github.com/skyoo2003/acor/pkg/acor@v0.10.0
 ```
 
 ```go

--- a/docs/content/getting-started/_index.md
+++ b/docs/content/getting-started/_index.md
@@ -15,7 +15,7 @@ This section covers everything you need to start using ACOR.
 ## Installation
 
 ```bash
-go get github.com/skyoo2003/acor/pkg/acor@latest
+go get github.com/skyoo2003/acor/pkg/acor@v0.10.0
 ```
 
 ## Next Steps

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -15,7 +15,7 @@ ACOR uses the standard RESP protocol via [go-redis v9](https://github.com/redis/
 ## Install the Package
 
 ```bash
-go get github.com/skyoo2003/acor/pkg/acor@latest
+go get github.com/skyoo2003/acor/pkg/acor@v0.10.0
 ```
 
 ## Verify Installation
@@ -51,7 +51,7 @@ func main() {
 Install the command-line tool:
 
 ```bash
-go install github.com/skyoo2003/acor/cmd/acor@latest
+go install github.com/skyoo2003/acor/cmd/acor@v0.10.0
 ```
 
 Verify the CLI:


### PR DESCRIPTION
# Pull Request

## Description

Update all ACOR Go package and CLI installation examples to select v0.10.0 explicitly because the current v1 release is faded out.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [ ] Tests pass (make test) — not run; documentation-only change
- [ ] Vet/make vet — not run; documentation-only change
- [ ] Linting passes (make lint) — not run; documentation-only change
- [ ] Build succeeds (make build) — not run; documentation-only change
- [x] Documentation updated if needed
- [ ] Changelog fragment added (changie new) if this change belongs in the changelog — not added; documentation correction only
- [x] Commit messages follow guidelines

## Additional Notes

No runtime code changes. Verified that no ACOR installation examples still use @latest.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).