### PR TITLE
refactor: collapse the duplicated V2 write path

### DIFF
--- a/pkg/acor/redis_backed.go
+++ b/pkg/acor/redis_backed.go
@@ -371,31 +371,3 @@ func (ac *redisBackedAC) cleanupExpiredSelfSkips() {
 		return true
 	})
 }
-
-// --- V2 Lua script adapter ---
-
-type redisBackedV2 struct {
-	client redis.UniversalClient
-}
-
-func (rb *redisBackedV2) runAddScript(ctx context.Context, args map[string]interface{}) (int64, error) {
-	if err := validateScriptArgs(args); err != nil {
-		return 0, err
-	}
-	cmd := addV2Script.Run(ctx, rb.client,
-		[]string{args[argTrieKey].(string), args[argOutputsKey].(string)},
-		args["oldVersion"], args["newVersion"], args[fieldKeywords],
-		args[fieldPrefixes], args[fieldSuffixes], args["outputs"])
-	return cmd.Int64()
-}
-
-func (rb *redisBackedV2) runRemoveScript(ctx context.Context, args map[string]interface{}) (int64, error) {
-	if err := validateScriptArgs(args); err != nil {
-		return 0, err
-	}
-	cmd := removeV2Script.Run(ctx, rb.client,
-		[]string{args[argTrieKey].(string), args[argOutputsKey].(string)},
-		args["oldVersion"], args["newVersion"], args[fieldKeywords],
-		args[fieldPrefixes], args[fieldSuffixes], args["outputs"])
-	return cmd.Int64()
-}

--- a/pkg/acor/redis_backed_ops.go
+++ b/pkg/acor/redis_backed_ops.go
@@ -4,13 +4,7 @@ package acor
 
 import (
 	"context"
-	"errors"
-	"strings"
-	"time"
 )
-
-const redisBackedMaxRetries = 3
-const redisBackedRetryBackoff = 10 * time.Millisecond
 
 // redisBackedAC implements the operations interface directly, so AhoCorasick
 // dispatches into it with no adapter in between. Suggest/SuggestIndex are the
@@ -42,108 +36,27 @@ func (ac *redisBackedAC) addWith(ctx context.Context, keyword string, rebuild bo
 		return 0, nil
 	}
 
-	v2 := &redisBackedV2{client: ac.redisClient}
-
-	for attempt := 0; attempt < redisBackedMaxRetries; attempt++ {
-		added, err := ac.tryAdd(ctx, keyword, v2, rebuild)
-		if errors.Is(err, ErrConcurrencyConflict) {
-			backoff := time.Duration(attempt+1) * redisBackedRetryBackoff
-			select {
-			case <-ctx.Done():
-				return 0, ctx.Err()
-			case <-time.After(backoff):
-			}
-			continue
-		}
-		if err == nil && added == 1 && rebuild {
-			ac.publishInvalidate(ctx)
-		}
-		return added, err
+	added, err := retryOnConflict(ctx, func() (int, error) { return ac.tryAdd(ctx, keyword, rebuild) })
+	if err == nil && added == 1 && rebuild {
+		ac.publishInvalidate(ctx)
 	}
-	return 0, ErrConcurrencyConflict
+	return added, err
 }
 
-func (ac *redisBackedAC) tryAdd(ctx context.Context, keyword string, v2 *redisBackedV2, rebuild bool) (int, error) { //nolint:gocyclo,funlen
+func (ac *redisBackedAC) tryAdd(ctx context.Context, keyword string, rebuild bool) (int, error) {
 	snap, err := readTrieSnapshot(ctx, ac.storage, ac.name)
 	if err != nil {
 		return 0, err
 	}
 
-	for _, kw := range snap.Keywords {
-		if kw == keyword {
-			return 0, nil
-		}
+	outputs, changed := planAdd(snap, keyword)
+	if !changed {
+		return 0, nil
 	}
 
-	keywordSet := make(map[string]struct{}, len(snap.Keywords)+1)
-	for _, kw := range snap.Keywords {
-		keywordSet[kw] = struct{}{}
-	}
-	prefixSet := make(map[string]struct{}, len(snap.Prefixes))
-	for _, p := range snap.Prefixes {
-		prefixSet[p] = struct{}{}
-	}
-
-	keywordRunes := []rune(keyword)
-	var newPrefixes, newSuffixes []string
-	for i := 0; i < len(keywordRunes); i++ {
-		prefix := string(keywordRunes[:i+1])
-		if _, exists := prefixSet[prefix]; !exists {
-			newPrefixes = append(newPrefixes, prefix)
-			newSuffixes = append(newSuffixes, reverse(prefix))
-			prefixSet[prefix] = struct{}{}
-		}
-	}
-
-	keywordSet[keyword] = struct{}{}
-	newOutputs := make(map[string][]string)
-	for _, prefix := range newPrefixes {
-		outs := computeRBOutputs(prefix, prefixSet, keywordSet)
-		if len(outs) > 0 {
-			newOutputs[prefix] = outs
-		}
-	}
-	for _, prefix := range snap.Prefixes {
-		if prefix == "" {
-			continue
-		}
-		outs := computeRBOutputs(prefix, prefixSet, keywordSet)
-		if len(outs) > 0 {
-			newOutputs[prefix] = outs
-		}
-	}
-
-	snap.Keywords = append(snap.Keywords, keyword)
-	snap.Prefixes = append(snap.Prefixes, newPrefixes...)
-	snap.Suffixes = append(snap.Suffixes, newSuffixes...)
-
-	newVersion, genErr := generateVersion()
-	if genErr != nil {
-		return 0, genErr
-	}
-
-	outputsToSet := make(map[string]string)
-	for state, outs := range newOutputs {
-		jsonOuts, marshalErr := toJSON(outs)
-		if marshalErr != nil {
-			return 0, marshalErr
-		}
-		outputsToSet[state] = jsonOuts
-	}
-
-	args, marshalErr := marshalTrieArgs(snap, outputsToSet, newVersion)
-	if marshalErr != nil {
-		return 0, marshalErr
-	}
-	args[argTrieKey] = trieKey(ac.name)
-	args[argOutputsKey] = outputsKey(ac.name)
-
-	val, err := v2.runAddScript(ctx, args)
+	newVersion, err := commitV2Write(ctx, ac.redisClient, addV2Script, ac.name, snap, outputs)
 	if err != nil {
 		return 0, err
-	}
-	if val == 0 {
-		return 0, ErrConcurrencyConflict
 	}
 
 	ac.applyLocalWrite(keyword, true, newVersion, rebuild)
@@ -205,119 +118,27 @@ func (ac *redisBackedAC) removeWith(ctx context.Context, keyword string, rebuild
 		return 0, nil
 	}
 
-	v2 := &redisBackedV2{client: ac.redisClient}
-
-	for attempt := 0; attempt < redisBackedMaxRetries; attempt++ {
-		removed, err := ac.tryRemove(ctx, keyword, v2, rebuild)
-		if errors.Is(err, ErrConcurrencyConflict) {
-			backoff := time.Duration(attempt+1) * redisBackedRetryBackoff
-			select {
-			case <-ctx.Done():
-				return 0, ctx.Err()
-			case <-time.After(backoff):
-			}
-			continue
-		}
-		if err == nil && removed == 1 && rebuild {
-			ac.publishInvalidate(ctx)
-		}
-		return removed, err
+	removed, err := retryOnConflict(ctx, func() (int, error) { return ac.tryRemove(ctx, keyword, rebuild) })
+	if err == nil && removed == 1 && rebuild {
+		ac.publishInvalidate(ctx)
 	}
-	return 0, ErrConcurrencyConflict
+	return removed, err
 }
 
-func (ac *redisBackedAC) tryRemove(ctx context.Context, keyword string, v2 *redisBackedV2, rebuild bool) (int, error) { //nolint:gocyclo,funlen
+func (ac *redisBackedAC) tryRemove(ctx context.Context, keyword string, rebuild bool) (int, error) {
 	snap, err := readTrieSnapshot(ctx, ac.storage, ac.name)
 	if err != nil {
 		return 0, err
 	}
 
-	keywordExists := false
-	newKeywords := make([]string, 0, len(snap.Keywords))
-	for _, kw := range snap.Keywords {
-		if kw == keyword {
-			keywordExists = true
-		} else {
-			newKeywords = append(newKeywords, kw)
-		}
-	}
-	if !keywordExists {
+	outputs, changed := planRemove(snap, keyword)
+	if !changed {
 		return 0, nil
 	}
 
-	keywordSet := make(map[string]struct{})
-	for _, kw := range newKeywords {
-		keywordSet[kw] = struct{}{}
-	}
-
-	newPrefixes := []string{""}
-	for _, prefix := range snap.Prefixes {
-		if prefix == "" {
-			continue
-		}
-		for kw := range keywordSet {
-			if strings.HasPrefix(kw, prefix) {
-				newPrefixes = append(newPrefixes, prefix)
-				break
-			}
-		}
-	}
-
-	prefixSet := make(map[string]struct{})
-	for _, p := range newPrefixes {
-		prefixSet[p] = struct{}{}
-	}
-
-	newSuffixes := make([]string, len(newPrefixes))
-	for i, p := range newPrefixes {
-		newSuffixes[i] = reverse(p)
-	}
-
-	newOutputs := make(map[string][]string)
-	for _, prefix := range newPrefixes {
-		if prefix == "" {
-			continue
-		}
-		outs := computeRBOutputs(prefix, prefixSet, keywordSet)
-		if len(outs) > 0 {
-			newOutputs[prefix] = outs
-		}
-	}
-
-	newVersion, genErr := generateVersion()
-	if genErr != nil {
-		return 0, genErr
-	}
-
-	outputsToSet := make(map[string]string)
-	for state, outs := range newOutputs {
-		jsonOuts, marshalErr := toJSON(outs)
-		if marshalErr != nil {
-			return 0, marshalErr
-		}
-		outputsToSet[state] = jsonOuts
-	}
-
-	updatedSnap := &trieSnapshot{
-		Keywords: newKeywords,
-		Prefixes: newPrefixes,
-		Suffixes: newSuffixes,
-		Version:  snap.Version,
-	}
-
-	args, marshalErr := marshalTrieArgs(updatedSnap, outputsToSet, newVersion)
-	if marshalErr != nil {
-		return 0, marshalErr
-	}
-	args[argTrieKey] = trieKey(ac.name)
-	args[argOutputsKey] = outputsKey(ac.name)
-
-	val, err := v2.runRemoveScript(ctx, args)
+	newVersion, err := commitV2Write(ctx, ac.redisClient, removeV2Script, ac.name, snap, outputs)
 	if err != nil {
 		return 0, err
-	}
-	if val == 0 {
-		return 0, ErrConcurrencyConflict
 	}
 
 	ac.applyLocalWrite(keyword, false, newVersion, rebuild)
@@ -402,22 +223,4 @@ func (ac *redisBackedAC) suggest(_ context.Context, _ string) ([]string, error) 
 
 func (ac *redisBackedAC) suggestIndex(_ context.Context, _ string) (map[string][]int, error) {
 	return nil, ErrSuggestRequiresRedis
-}
-
-// computeRBOutputs returns all keywords that are suffixes of the given state.
-func computeRBOutputs(state string, prefixSet, keywordSet map[string]struct{}) []string {
-	var outputs []string
-	if _, isKeyword := keywordSet[state]; isKeyword {
-		outputs = append(outputs, state)
-	}
-	stateRunes := []rune(state)
-	for i := 1; i < len(stateRunes); i++ {
-		failState := string(stateRunes[i:])
-		if _, isPrefix := prefixSet[failState]; isPrefix {
-			if _, isKeyword := keywordSet[failState]; isKeyword {
-				outputs = append(outputs, failState)
-			}
-		}
-	}
-	return outputs
 }

--- a/pkg/acor/v2_json_test.go
+++ b/pkg/acor/v2_json_test.go
@@ -31,9 +31,7 @@ func TestToJSONError(t *testing.T) {
 	}
 }
 
-func TestComputeOutputsV2(t *testing.T) {
-	ops := &v2Operations{}
-
+func TestComputeOutputs(t *testing.T) {
 	prefixSet := map[string]struct{}{
 		"":    {},
 		"h":   {},
@@ -62,13 +60,13 @@ func TestComputeOutputsV2(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.state, func(t *testing.T) {
-			got := ops.computeOutputsV2(tt.state, prefixSet, keywordSet)
+			got := computeOutputs(tt.state, prefixSet, keywordSet)
 			if len(got) != len(tt.want) {
-				t.Fatalf("computeOutputsV2(%q) = %v, want %v", tt.state, got, tt.want)
+				t.Fatalf("computeOutputs(%q) = %v, want %v", tt.state, got, tt.want)
 			}
 			for i, v := range got {
 				if v != tt.want[i] {
-					t.Errorf("computeOutputsV2(%q)[%d] = %q, want %q", tt.state, i, v, tt.want[i])
+					t.Errorf("computeOutputs(%q)[%d] = %q, want %q", tt.state, i, v, tt.want[i])
 				}
 			}
 		})

--- a/pkg/acor/v2_lua.go
+++ b/pkg/acor/v2_lua.go
@@ -79,22 +79,14 @@ func validateScriptArgs(args map[string]interface{}) error {
 	return nil
 }
 
-func (o *v2Operations) runAddV2Script(ctx context.Context, client redis.UniversalClient, args map[string]interface{}) (*redis.Cmd, error) {
+// runV2Script evaluates one of the V2 transaction scripts and returns its reply:
+// 1 when the write committed, 0 when the optimistic-lock version check failed.
+func runV2Script(ctx context.Context, client redis.UniversalClient, script *redis.Script, args map[string]interface{}) (int64, error) {
 	if err := validateScriptArgs(args); err != nil {
-		return nil, err
+		return 0, err
 	}
-	return addV2Script.Run(ctx, client,
+	return script.Run(ctx, client,
 		[]string{args[argTrieKey].(string), args[argOutputsKey].(string)},
 		args["oldVersion"], args["newVersion"], args[fieldKeywords],
-		args[fieldPrefixes], args[fieldSuffixes], args["outputs"]), nil
-}
-
-func (o *v2Operations) runRemoveV2Script(ctx context.Context, client redis.UniversalClient, args map[string]interface{}) (*redis.Cmd, error) {
-	if err := validateScriptArgs(args); err != nil {
-		return nil, err
-	}
-	return removeV2Script.Run(ctx, client,
-		[]string{args[argTrieKey].(string), args[argOutputsKey].(string)},
-		args["oldVersion"], args["newVersion"], args[fieldKeywords],
-		args[fieldPrefixes], args[fieldSuffixes], args["outputs"]), nil
+		args[fieldPrefixes], args[fieldSuffixes], args["outputs"]).Int64()
 }

--- a/pkg/acor/v2_lua_test.go
+++ b/pkg/acor/v2_lua_test.go
@@ -110,14 +110,11 @@ func TestLuaScriptInt64SafetyAdd(t *testing.T) {
 	args["trieKey"] = trieKey("test")
 	args["outputsKey"] = outputsKey("test")
 
-	cmd, err := ops.runAddV2Script(ctx, ops.client, args)
+	val, err := runV2Script(ctx, ops.client, addV2Script, args)
 	if err != nil {
 		t.Fatalf("runAddV2Script failed: %v", err)
 	}
-	result, err := cmd.Int64()
-	if err != nil {
-		t.Fatalf("cmd.Int64() failed: %v", err)
-	}
+	result := val
 	if result != 1 {
 		t.Errorf("addV2Script Int64 result = %d, want 1", result)
 	}
@@ -154,14 +151,11 @@ func TestLuaScriptInt64SafetyRemove(t *testing.T) {
 	args["trieKey"] = trieKey("test")
 	args["outputsKey"] = outputsKey("test")
 
-	cmd, err := ops.runRemoveV2Script(ctx, ops.client, args)
+	val, err := runV2Script(ctx, ops.client, removeV2Script, args)
 	if err != nil {
 		t.Fatalf("runRemoveV2Script failed: %v", err)
 	}
-	result, err := cmd.Int64()
-	if err != nil {
-		t.Fatalf("cmd.Int64() failed: %v", err)
-	}
+	result := val
 	if result != 1 {
 		t.Errorf("removeV2Script Int64 result = %d, want 1", result)
 	}

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -99,53 +98,19 @@ func (o *v2Operations) findIndex(ctx context.Context, text string) (map[string][
 }
 
 func (o *v2Operations) add(ctx context.Context, keyword string) (int, error) {
-	keyword = strings.TrimSpace(keyword)
-	if !o.caseSensitive {
-		keyword = strings.ToLower(keyword)
-	}
+	keyword = normalizeKeyword(keyword, o.caseSensitive)
 	if keyword == "" {
 		return 0, nil
 	}
-
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		added, err := o.tryAddV2(ctx, keyword)
-		if errors.Is(err, ErrConcurrencyConflict) {
-			backoff := time.Duration(attempt+1) * retryBackoffBase
-			select {
-			case <-ctx.Done():
-				return 0, ctx.Err()
-			case <-time.After(backoff):
-			}
-			continue
-		}
-		return added, err
-	}
-	return 0, ErrConcurrencyConflict
+	return retryOnConflict(ctx, func() (int, error) { return o.tryAddV2(ctx, keyword) })
 }
 
 func (o *v2Operations) remove(ctx context.Context, keyword string) (int, error) {
-	keyword = strings.TrimSpace(keyword)
-	if !o.caseSensitive {
-		keyword = strings.ToLower(keyword)
-	}
+	keyword = normalizeKeyword(keyword, o.caseSensitive)
 	if keyword == "" {
 		return 0, nil
 	}
-
-	for attempt := 0; attempt < maxRetries; attempt++ {
-		removed, err := o.tryRemoveV2(ctx, keyword)
-		if errors.Is(err, ErrConcurrencyConflict) {
-			backoff := time.Duration(attempt+1) * retryBackoffBase
-			select {
-			case <-ctx.Done():
-				return 0, ctx.Err()
-			case <-time.After(backoff):
-			}
-			continue
-		}
-		return removed, err
-	}
-	return 0, ErrConcurrencyConflict
+	return retryOnConflict(ctx, func() (int, error) { return o.tryRemoveV2(ctx, keyword) })
 }
 
 func (o *v2Operations) flush(ctx context.Context) error {

--- a/pkg/acor/v2_plan.go
+++ b/pkg/acor/v2_plan.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import "strings"
+
+// This file holds the pure, side-effect-free half of a V2 write: given a trie
+// snapshot and a keyword, work out the new snapshot and the output lists that
+// changed. Both V2 callers — v2Operations (Redis-resident reads) and
+// redisBackedAC (preset mode, local engine) — plan identically and differ only
+// in what they do after the Lua script commits, so the planning lives here once.
+
+// planAdd computes the trie mutation for inserting keyword. On success snap is
+// updated in place and outputs maps each state whose output list changed to its
+// new value. changed is false when the keyword is already present, in which case
+// snap is untouched and no write is needed.
+func planAdd(snap *trieSnapshot, keyword string) (outputs map[string][]string, changed bool) {
+	keywordSet := make(map[string]struct{}, len(snap.Keywords)+1)
+	for _, kw := range snap.Keywords {
+		keywordSet[kw] = struct{}{}
+	}
+	if _, exists := keywordSet[keyword]; exists {
+		return nil, false
+	}
+
+	prefixSet := make(map[string]struct{}, len(snap.Prefixes))
+	for _, p := range snap.Prefixes {
+		prefixSet[p] = struct{}{}
+	}
+
+	keywordRunes := []rune(keyword)
+	var newPrefixes, newSuffixes []string
+	for i := range keywordRunes {
+		prefix := string(keywordRunes[:i+1])
+		if _, exists := prefixSet[prefix]; !exists {
+			newPrefixes = append(newPrefixes, prefix)
+			newSuffixes = append(newSuffixes, reverse(prefix))
+			prefixSet[prefix] = struct{}{}
+		}
+	}
+
+	keywordSet[keyword] = struct{}{}
+	outputs = make(map[string][]string)
+	for _, prefix := range newPrefixes {
+		if outs := computeOutputs(prefix, prefixSet, keywordSet); len(outs) > 0 {
+			outputs[prefix] = outs
+		}
+	}
+	// Pre-existing states can gain an output too: the new keyword may be a
+	// suffix of one of them, so every old prefix is recomputed.
+	for _, prefix := range snap.Prefixes {
+		if prefix == "" {
+			continue
+		}
+		if outs := computeOutputs(prefix, prefixSet, keywordSet); len(outs) > 0 {
+			outputs[prefix] = outs
+		}
+	}
+
+	snap.Keywords = append(snap.Keywords, keyword)
+	snap.Prefixes = append(snap.Prefixes, newPrefixes...)
+	snap.Suffixes = append(snap.Suffixes, newSuffixes...)
+	return outputs, true
+}
+
+// planRemove computes the trie mutation for deleting keyword. On success snap is
+// updated in place and outputs holds the full replacement output set (the remove
+// script clears the outputs hash first, so this is not a delta). changed is false
+// when the keyword is absent.
+func planRemove(snap *trieSnapshot, keyword string) (outputs map[string][]string, changed bool) {
+	newKeywords := make([]string, 0, len(snap.Keywords))
+	found := false
+	for _, kw := range snap.Keywords {
+		if kw == keyword {
+			found = true
+			continue
+		}
+		newKeywords = append(newKeywords, kw)
+	}
+	if !found {
+		return nil, false
+	}
+
+	keywordSet := make(map[string]struct{}, len(newKeywords))
+	for _, kw := range newKeywords {
+		keywordSet[kw] = struct{}{}
+	}
+
+	// Keep only the prefixes still reachable from a surviving keyword.
+	newPrefixes := []string{""}
+	for _, prefix := range snap.Prefixes {
+		if prefix == "" {
+			continue
+		}
+		for kw := range keywordSet {
+			if strings.HasPrefix(kw, prefix) {
+				newPrefixes = append(newPrefixes, prefix)
+				break
+			}
+		}
+	}
+
+	prefixSet := make(map[string]struct{}, len(newPrefixes))
+	for _, p := range newPrefixes {
+		prefixSet[p] = struct{}{}
+	}
+
+	newSuffixes := make([]string, len(newPrefixes))
+	for i, p := range newPrefixes {
+		newSuffixes[i] = reverse(p)
+	}
+
+	outputs = make(map[string][]string)
+	for _, prefix := range newPrefixes {
+		if prefix == "" {
+			continue
+		}
+		if outs := computeOutputs(prefix, prefixSet, keywordSet); len(outs) > 0 {
+			outputs[prefix] = outs
+		}
+	}
+
+	snap.Keywords = newKeywords
+	snap.Prefixes = newPrefixes
+	snap.Suffixes = newSuffixes
+	return outputs, true
+}
+
+// computeOutputs returns every keyword that ends at state: state itself when it
+// is a keyword, plus each proper suffix of state that is both a live prefix and
+// a keyword (the outputs reachable by following failure links).
+func computeOutputs(state string, prefixSet, keywordSet map[string]struct{}) []string {
+	var outputs []string
+
+	if _, isKeyword := keywordSet[state]; isKeyword {
+		outputs = append(outputs, state)
+	}
+
+	stateRunes := []rune(state)
+	for i := 1; i < len(stateRunes); i++ {
+		failState := string(stateRunes[i:])
+		if _, isPrefix := prefixSet[failState]; !isPrefix {
+			continue
+		}
+		if _, isKeyword := keywordSet[failState]; isKeyword {
+			outputs = append(outputs, failState)
+		}
+	}
+
+	return outputs
+}

--- a/pkg/acor/v2_retry_test.go
+++ b/pkg/acor/v2_retry_test.go
@@ -116,3 +116,28 @@ func TestV2RemoveMaxRetriesExhausted(t *testing.T) {
 		t.Fatalf("remove() should succeed on retry, got: %v", err)
 	}
 }
+
+// TestConflictBackoffBounds pins the backoff window per attempt: a linear ramp
+// with jitter that never reaches into the next attempt's slot, so the schedule
+// stays ordered while still spreading concurrent writers.
+func TestConflictBackoffBounds(t *testing.T) {
+	for attempt := range maxRetries {
+		lo := time.Duration(attempt+1) * retryBackoffBase
+		hi := lo + retryBackoffBase
+
+		// Sample enough times to catch a jitter range that is off by a factor.
+		var sawJitter bool
+		for range 200 {
+			got := conflictBackoff(attempt)
+			if got < lo || got >= hi {
+				t.Fatalf("conflictBackoff(%d) = %v, want [%v, %v)", attempt, got, lo, hi)
+			}
+			if got != lo {
+				sawJitter = true
+			}
+		}
+		if !sawJitter {
+			t.Errorf("conflictBackoff(%d) never varied from %v; jitter is not being applied", attempt, lo)
+		}
+	}
+}

--- a/pkg/acor/v2_transaction.go
+++ b/pkg/acor/v2_transaction.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"strings"
 	"time"
+
+	"github.com/redis/go-redis/v9"
 )
 
 // versionRandBytes is the number of random bytes used to extend version timestamps
@@ -110,225 +112,94 @@ func toJSON(v any) (string, error) {
 	return string(b), nil
 }
 
-func (o *v2Operations) tryAddV2(ctx context.Context, keyword string) (int, error) { //nolint:gocyclo,funlen
+// commitV2Write stamps a fresh version onto a planned mutation and commits it
+// through script under optimistic locking. It returns the version it wrote, or
+// ErrConcurrencyConflict when another writer won the race and the caller should
+// re-read the snapshot and retry.
+func commitV2Write(ctx context.Context, client redis.UniversalClient, script *redis.Script,
+	name string, snap *trieSnapshot, outputs map[string][]string) (int64, error) {
+	newVersion, err := generateVersion()
+	if err != nil {
+		return 0, err
+	}
+
+	encoded := make(map[string]string, len(outputs))
+	for state, outs := range outputs {
+		jsonOuts, marshalErr := toJSON(outs)
+		if marshalErr != nil {
+			return 0, newOperationError("marshal", SchemaV2, marshalErr)
+		}
+		encoded[state] = jsonOuts
+	}
+
+	args, err := marshalTrieArgs(snap, encoded, newVersion)
+	if err != nil {
+		return 0, err
+	}
+	args[argTrieKey] = trieKey(name)
+	args[argOutputsKey] = outputsKey(name)
+
+	result, err := runV2Script(ctx, client, script, args)
+	if err != nil {
+		return 0, newRedisError("EVAL", trieKey(name), err)
+	}
+	if result == 0 {
+		return 0, ErrConcurrencyConflict
+	}
+	return newVersion, nil
+}
+
+// retryOnConflict runs attempt until it stops reporting a lost optimistic-lock
+// race, backing off linearly in between. Shared by both V2 write paths.
+func retryOnConflict(ctx context.Context, attempt func() (int, error)) (int, error) {
+	for i := 0; i < maxRetries; i++ {
+		n, err := attempt()
+		if !errors.Is(err, ErrConcurrencyConflict) {
+			return n, err
+		}
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(time.Duration(i+1) * retryBackoffBase):
+		}
+	}
+	return 0, ErrConcurrencyConflict
+}
+
+func (o *v2Operations) tryAddV2(ctx context.Context, keyword string) (int, error) {
 	snap, err := readTrieSnapshot(ctx, o.storage, o.name)
 	if err != nil {
 		return 0, err
 	}
 
-	keywordSet := make(map[string]struct{}, len(snap.Keywords))
-	for _, kw := range snap.Keywords {
-		keywordSet[kw] = struct{}{}
-	}
-	if _, exists := keywordSet[keyword]; exists {
+	outputs, changed := planAdd(snap, keyword)
+	if !changed {
 		return 0, nil
 	}
 
-	prefixSet := make(map[string]struct{}, len(snap.Prefixes))
-	for _, p := range snap.Prefixes {
-		prefixSet[p] = struct{}{}
-	}
-
-	keywordRunes := []rune(keyword)
-	var newPrefixes, newSuffixes []string
-
-	for i := 0; i < len(keywordRunes); i++ {
-		prefix := string(keywordRunes[:i+1])
-		if _, exists := prefixSet[prefix]; !exists {
-			newPrefixes = append(newPrefixes, prefix)
-			newSuffixes = append(newSuffixes, reverse(prefix))
-			prefixSet[prefix] = struct{}{}
-		}
-	}
-
-	newOutputs := make(map[string][]string)
-	keywordSet[keyword] = struct{}{}
-	for _, prefix := range newPrefixes {
-		prefixOutputs := o.computeOutputsV2(prefix, prefixSet, keywordSet)
-		if len(prefixOutputs) > 0 {
-			newOutputs[prefix] = prefixOutputs
-		}
-	}
-
-	for _, prefix := range snap.Prefixes {
-		if prefix == "" {
-			continue
-		}
-		updatedOutputs := o.computeOutputsV2(prefix, prefixSet, keywordSet)
-		if len(updatedOutputs) > 0 {
-			newOutputs[prefix] = updatedOutputs
-		}
-	}
-
-	// Build updated snapshot
-	snap.Keywords = append(snap.Keywords, keyword)
-	snap.Prefixes = append(snap.Prefixes, newPrefixes...)
-	snap.Suffixes = append(snap.Suffixes, newSuffixes...)
-
-	newVersion, genErr := generateVersion()
-	if genErr != nil {
-		return 0, genErr
-	}
-
-	outputsToUpdate := make(map[string]string)
-	for state, outs := range newOutputs {
-		jsonOuts, marshalErr := toJSON(outs)
-		if marshalErr != nil {
-			return 0, newOperationError("marshal", SchemaV2, marshalErr)
-		}
-		outputsToUpdate[state] = jsonOuts
-	}
-
-	args, err := marshalTrieArgs(snap, outputsToUpdate, newVersion)
-	if err != nil {
+	if _, err := commitV2Write(ctx, o.client, addV2Script, o.name, snap, outputs); err != nil {
 		return 0, err
-	}
-	args[argTrieKey] = trieKey(o.name)
-	args[argOutputsKey] = outputsKey(o.name)
-
-	cmd, err := o.runAddV2Script(ctx, o.client, args)
-	if err != nil {
-		return 0, newRedisError("EVAL", trieKey(o.name), err)
-	}
-	result, err := cmd.Int64()
-	if err != nil {
-		return 0, newRedisError("EVAL", trieKey(o.name), err)
-	}
-
-	if result == 0 {
-		return 0, ErrConcurrencyConflict
 	}
 
 	o.publishInvalidate(ctx)
-
 	return 1, nil
 }
 
-func (o *v2Operations) tryRemoveV2(ctx context.Context, keyword string) (int, error) { //nolint:gocyclo,funlen
+func (o *v2Operations) tryRemoveV2(ctx context.Context, keyword string) (int, error) {
 	snap, err := readTrieSnapshot(ctx, o.storage, o.name)
 	if err != nil {
 		return 0, err
 	}
 
-	keywordExists := false
-	newKeywords := make([]string, 0, len(snap.Keywords))
-	for _, kw := range snap.Keywords {
-		if kw == keyword {
-			keywordExists = true
-		} else {
-			newKeywords = append(newKeywords, kw)
-		}
-	}
-
-	if !keywordExists {
+	outputs, changed := planRemove(snap, keyword)
+	if !changed {
 		return 0, nil
 	}
 
-	keywordSet := make(map[string]struct{})
-	for _, kw := range newKeywords {
-		keywordSet[kw] = struct{}{}
-	}
-
-	newPrefixes := []string{""}
-	for _, prefix := range snap.Prefixes {
-		if prefix == "" {
-			continue
-		}
-		keep := false
-		for kw := range keywordSet {
-			if strings.HasPrefix(kw, prefix) {
-				keep = true
-				break
-			}
-		}
-		if keep {
-			newPrefixes = append(newPrefixes, prefix)
-		}
-	}
-
-	prefixSet := make(map[string]struct{})
-	for _, p := range newPrefixes {
-		prefixSet[p] = struct{}{}
-	}
-
-	newSuffixes := make([]string, len(newPrefixes))
-	for i, p := range newPrefixes {
-		newSuffixes[i] = reverse(p)
-	}
-
-	newOutputs := make(map[string][]string)
-	for _, prefix := range newPrefixes {
-		if prefix == "" {
-			continue
-		}
-		outs := o.computeOutputsV2(prefix, prefixSet, keywordSet)
-		if len(outs) > 0 {
-			newOutputs[prefix] = outs
-		}
-	}
-
-	newVersion, genErr := generateVersion()
-	if genErr != nil {
-		return 0, genErr
-	}
-
-	outputsToSet := make(map[string]string)
-	for state, outs := range newOutputs {
-		jsonOuts, marshalErr := toJSON(outs)
-		if marshalErr != nil {
-			return 0, newOperationError("marshal", SchemaV2, marshalErr)
-		}
-		outputsToSet[state] = jsonOuts
-	}
-
-	updatedSnap := &trieSnapshot{
-		Keywords: newKeywords,
-		Prefixes: newPrefixes,
-		Suffixes: newSuffixes,
-		Version:  snap.Version,
-	}
-
-	args, err := marshalTrieArgs(updatedSnap, outputsToSet, newVersion)
-	if err != nil {
+	if _, err := commitV2Write(ctx, o.client, removeV2Script, o.name, snap, outputs); err != nil {
 		return 0, err
-	}
-	args[argTrieKey] = trieKey(o.name)
-	args[argOutputsKey] = outputsKey(o.name)
-
-	cmd, err := o.runRemoveV2Script(ctx, o.client, args)
-	if err != nil {
-		return 0, newRedisError("EVAL", trieKey(o.name), err)
-	}
-	result, err := cmd.Int64()
-	if err != nil {
-		return 0, newRedisError("EVAL", trieKey(o.name), err)
-	}
-
-	if result == 0 {
-		return 0, ErrConcurrencyConflict
 	}
 
 	o.publishInvalidate(ctx)
-
 	return 1, nil
-}
-
-func (o *v2Operations) computeOutputsV2(state string, prefixSet, keywordSet map[string]struct{}) []string {
-	var outputs []string
-
-	if _, isKeyword := keywordSet[state]; isKeyword {
-		outputs = append(outputs, state)
-	}
-
-	stateRunes := []rune(state)
-	for i := 1; i < len(stateRunes); i++ {
-		failState := string(stateRunes[i:])
-		if _, isPrefix := prefixSet[failState]; isPrefix {
-			if _, isKeyword := keywordSet[failState]; isKeyword {
-				outputs = append(outputs, failState)
-			}
-		}
-	}
-
-	return outputs
 }

--- a/pkg/acor/v2_transaction.go
+++ b/pkg/acor/v2_transaction.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	mrand "math/rand/v2"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -150,20 +151,40 @@ func commitV2Write(ctx context.Context, client redis.UniversalClient, script *re
 }
 
 // retryOnConflict runs attempt until it stops reporting a lost optimistic-lock
-// race, backing off linearly in between. Shared by both V2 write paths.
+// race, backing off in between. Shared by both V2 write paths.
 func retryOnConflict(ctx context.Context, attempt func() (int, error)) (int, error) {
 	for i := 0; i < maxRetries; i++ {
 		n, err := attempt()
 		if !errors.Is(err, ErrConcurrencyConflict) {
 			return n, err
 		}
+		// Nothing left to wait for after the last attempt.
+		if i == maxRetries-1 {
+			break
+		}
 		select {
 		case <-ctx.Done():
 			return 0, ctx.Err()
-		case <-time.After(time.Duration(i+1) * retryBackoffBase):
+		case <-time.After(conflictBackoff(i)):
 		}
 	}
 	return 0, ErrConcurrencyConflict
+}
+
+// conflictBackoff returns how long to wait before retry attempt+1: a linear
+// ramp plus jitter in [0, retryBackoffBase).
+//
+// The jitter is what keeps contention from persisting. Two writers that lose
+// the same CAS race lose it at the same instant, so a purely deterministic
+// schedule wakes them together and they collide again on every retry. Spreading
+// the wakeups over one base interval breaks that lockstep.
+//
+// math/rand is the right tool here: this only spreads load, and no security
+// property depends on the value. Version stamps and invalidation IDs, which do
+// need unpredictability, keep using crypto/rand.
+func conflictBackoff(attempt int) time.Duration {
+	jitter := mrand.N(retryBackoffBase) //nolint:gosec // G404: load spreading, not a security decision.
+	return time.Duration(attempt+1)*retryBackoffBase + jitter
 }
 
 func (o *v2Operations) tryAddV2(ctx context.Context, keyword string) (int, error) {

--- a/pkg/acor/version_precision_test.go
+++ b/pkg/acor/version_precision_test.go
@@ -77,14 +77,11 @@ func TestLuaVersionComparisonAbove2to53(t *testing.T) {
 	args["trieKey"] = trieKey("test")
 	args["outputsKey"] = outputsKey("test")
 
-	cmd, err := ops.runAddV2Script(ctx, ops.client, args)
+	val, err := runV2Script(ctx, ops.client, addV2Script, args)
 	if err != nil {
 		t.Fatalf("addV2Script with matching large version failed: %v", err)
 	}
-	result, err := cmd.Int()
-	if err != nil {
-		t.Fatalf("addV2Script with matching large version failed: %v", err)
-	}
+	result := int(val)
 	if result != 1 {
 		t.Errorf("addV2Script = %d, want 1 (version should match for %d)", result, largeOldVersion)
 	}
@@ -98,14 +95,11 @@ func TestLuaVersionComparisonAbove2to53(t *testing.T) {
 	args2["trieKey"] = trieKey("test")
 	args2["outputsKey"] = outputsKey("test")
 
-	cmd2, err := ops.runAddV2Script(ctx, ops.client, args2)
+	val2, err := runV2Script(ctx, ops.client, addV2Script, args2)
 	if err != nil {
 		t.Fatalf("addV2Script conflict check failed: %v", err)
 	}
-	result2, err := cmd2.Int()
-	if err != nil {
-		t.Fatalf("addV2Script conflict check failed: %v", err)
-	}
+	result2 := int(val2)
 	if result2 != 0 {
 		t.Errorf("addV2Script = %d, want 0 (conflict between %d and %d should be detected)",
 			result2, largeOldVersion, largeNewVersion)
@@ -194,14 +188,11 @@ func TestLuaVersionStringComparison(t *testing.T) {
 			args["trieKey"] = trieKey("test")
 			args["outputsKey"] = outputsKey("test")
 
-			cmd, err := ops.runAddV2Script(ctx, ops.client, args)
+			val, err := runV2Script(ctx, ops.client, addV2Script, args)
 			if err != nil {
 				t.Fatalf("addV2Script error: %v", err)
 			}
-			result, err := cmd.Int()
-			if err != nil {
-				t.Fatalf("addV2Script error: %v", err)
-			}
+			result := int(val)
 
 			if tt.wantConflict {
 				if result != 0 {
@@ -251,14 +242,11 @@ func TestLuaVersionRemoveScriptPrecision(t *testing.T) {
 	args["trieKey"] = trieKey("test")
 	args["outputsKey"] = outputsKey("test")
 
-	cmd, err := ops.runRemoveV2Script(ctx, ops.client, args)
+	val, err := runV2Script(ctx, ops.client, removeV2Script, args)
 	if err != nil {
 		t.Fatalf("removeV2Script error: %v", err)
 	}
-	result, err := cmd.Int()
-	if err != nil {
-		t.Fatalf("removeV2Script error: %v", err)
-	}
+	result := int(val)
 	if result != 1 {
 		t.Errorf("removeV2Script = %d, want 1 (version %d should match)", result, largeVersion)
 	}
@@ -271,14 +259,11 @@ func TestLuaVersionRemoveScriptPrecision(t *testing.T) {
 	args2["trieKey"] = trieKey("test")
 	args2["outputsKey"] = outputsKey("test")
 
-	cmd2, err := ops.runRemoveV2Script(ctx, ops.client, args2)
+	val2, err := runV2Script(ctx, ops.client, removeV2Script, args2)
 	if err != nil {
 		t.Fatalf("removeV2Script stale version error: %v", err)
 	}
-	result2, err := cmd2.Int()
-	if err != nil {
-		t.Fatalf("removeV2Script stale version error: %v", err)
-	}
+	result2 := int(val2)
 	if result2 != 0 {
 		t.Errorf("removeV2Script = %d, want 0 (stale version should conflict)", result2)
 	}


### PR DESCRIPTION
# Pull Request

## Description

`redis_backed_ops.go` was a near line-for-line copy of the `v2Operations` write path — same trie planning, same output computation, same script invocation, same retry loop, roughly 400 lines duplicated. The two paths genuinely differ only in what happens *after* the Lua script commits: `v2Operations` publishes an invalidation, `redisBackedAC` also applies the write to its local engine. Everything before that is now shared.

- **`v2_plan.go`** (new): `planAdd` / `planRemove` compute the new snapshot and the changed output lists as pure functions — no context, no I/O, so they are trivially testable. `computeOutputs` replaces the byte-identical `computeOutputsV2` and `computeRBOutputs`.
- **`commitV2Write`**: marshals a plan, stamps a version, runs the script under optimistic locking, and returns `ErrConcurrencyConflict` on a lost race.
- **`retryOnConflict`**: replaces two copies of the backoff loop. The preset-mode constants `redisBackedMaxRetries` and `redisBackedRetryBackoff` were duplicates of `maxRetries` / `retryBackoffBase` and are gone.
- **`runV2Script`**: replaces four script runners — two methods on `v2Operations` and two on the now-deleted `redisBackedV2` adapter.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — skip for internal-only changes (CI, tests, refactors); see [RELEASE.md](../RELEASE.md)
- [x] Commit messages follow guidelines

No changelog fragment: internal refactor with no user-visible effect.