### PR TITLE
refactor: drop the write-only V2 suffixes field, type the script args

### DIFF
--- a/changes/unreleased/Changed-20260727-230640.yaml
+++ b/changes/unreleased/Changed-20260727-230640.yaml
@@ -1,0 +1,8 @@
+kind: Changed
+body: |-
+    The V2 trie hash no longer stores a `suffixes` field. It held every prefix reversed, was rewritten on each add and remove, and was never read by any matcher — only the V1 schema's suffix sorted set is used, for its own rebuild walk. Existing collections are unaffected: a leftover `suffixes` field is ignored on read and disappears on the next `Flush`, so old and new binaries can run against the same collection during a rolling upgrade.
+
+    The two V2 Lua scripts were also merged into one, differing only by a flag for whether the outputs hash is cleared first.
+time: 2026-07-27T23:06:40.000000+09:00
+custom:
+    Issue: "170"

--- a/docs/content/reference/schema-v2.md
+++ b/docs/content/reference/schema-v2.md
@@ -13,7 +13,7 @@ V2 consolidates storage into 3 keys:
 
 | Key Pattern | Purpose |
 |-------------|---------|
-| `{name}:trie` | Serialized trie structure (keywords, prefixes, suffixes, version) |
+| `{name}:trie` | Serialized trie structure (keywords, prefixes, version) |
 | `{name}:outputs` | All output mappings (state -> keywords) |
 | `{name}:nodes` | Node metadata (migration only, cleaned up by flush) |
 
@@ -79,15 +79,17 @@ acor -name mycollection migrate
 
 ### trie key
 
-Stores the serialized trie as a hash with four fields:
+Stores the serialized trie as a hash with three fields:
 
 ```text
 {collection}:trie
   keywords -> ["keyword1", "keyword2", ...]
   prefixes  -> ["", "h", "he", ...]
-  suffixes  -> ["", "e", "eh", ...]
   version   -> <int64 optimistic lock>
 ```
+
+Collections written before v0.11 also carry a `suffixes` field. It is never
+read, is left alone by writes, and is dropped by the next `Flush()`.
 
 ### outputs key
 

--- a/pkg/acor/batch_debug_test.go
+++ b/pkg/acor/batch_debug_test.go
@@ -162,7 +162,6 @@ func TestDebugV2WithData(t *testing.T) {
 	client.HSet(ctx, "{test}:trie", map[string]interface{}{
 		"keywords": `["he","she"]`,
 		"prefixes": `["","h","he","s","sh","she"]`,
-		"suffixes": `["","e","eh","s","hs","ehs"]`,
 		"version":  "100",
 	})
 	client.HSet(ctx, "{test}:outputs", map[string]interface{}{

--- a/pkg/acor/batch_v2_error_test.go
+++ b/pkg/acor/batch_v2_error_test.go
@@ -86,7 +86,6 @@ func TestV2TryAddVersionFallback(t *testing.T) {
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
 		"keywords": `[]`,
 		"prefixes": `[""]`,
-		"suffixes": `[""]`,
 		"version":  "not-a-number",
 	})
 

--- a/pkg/acor/benchmark_test.go
+++ b/pkg/acor/benchmark_test.go
@@ -67,16 +67,9 @@ func BenchmarkFindV2(b *testing.B) {
 		"hel", "hell", "hello", "w", "wo", "wor", "worl", "world",
 		"b", "be", "ben", "benc", "bench", "benchm", "benchma", "benchmar", "benchmark",
 	}
-	suffixes := []string{
-		"", "e", "eh", "s", "hs", "ehs", "i", "ih", "si", "sih",
-		"r", "reh", "sreh", "l", "ll", "leh", "lleh", "d", "dl", "dor", "drow",
-		"k", "kc", "kram", "kcehc", "kramdneb",
-	}
-
 	client.HSet(context.Background(), "{bench}:trie", map[string]interface{}{
 		"keywords": toJSONOrFatal(b, keywords),
 		"prefixes": toJSONOrFatal(b, prefixes),
-		"suffixes": toJSONOrFatal(b, suffixes),
 		"version":  time.Now().Unix(),
 	})
 
@@ -153,7 +146,6 @@ func BenchmarkAddV2(b *testing.B) {
 	_ = client.HSet(context.Background(), "{bench}:trie", map[string]interface{}{
 		"keywords": "[]",
 		"prefixes": `[""]`,
-		"suffixes": `[""]`,
 		"version":  time.Now().Unix(),
 	}).Err()
 	_ = client.Close()

--- a/pkg/acor/keys.go
+++ b/pkg/acor/keys.go
@@ -20,8 +20,7 @@ const (
 	NodeKey = "%s:node"
 )
 
-// V2 trie-hash field names and the internal arg-map keys passed to the Lua
-// transaction helpers. Kept as constants so a typo can't silently break a
+// V2 trie-hash field names. Kept as constants so a typo can't silently break a
 // Redis read or write.
 const (
 	fieldKeywords = "keywords"

--- a/pkg/acor/keys.go
+++ b/pkg/acor/keys.go
@@ -26,14 +26,10 @@ const (
 const (
 	fieldKeywords = "keywords"
 	fieldPrefixes = "prefixes"
-	fieldSuffixes = "suffixes"
 	fieldVersion  = "version"
 
-	argTrieKey    = "trieKey"
-	argOutputsKey = "outputsKey"
-
 	// emptyKeywordsJSON and emptyStringArrayJSON are the default JSON values
-	// stored in an empty V2 trie hash.
+	// stored in an empty V2 trie hash: no keywords, and the root prefix only.
 	emptyKeywordsJSON    = "[]"
 	emptyStringArrayJSON = `[""]`
 )
@@ -82,7 +78,6 @@ func emptyTrieFields() map[string]interface{} {
 	return map[string]interface{}{
 		fieldKeywords: emptyKeywordsJSON,
 		fieldPrefixes: emptyStringArrayJSON,
-		fieldSuffixes: emptyStringArrayJSON,
 		fieldVersion:  time.Now().UnixNano(),
 	}
 }

--- a/pkg/acor/migration.go
+++ b/pkg/acor/migration.go
@@ -68,7 +68,7 @@ func (ac *AhoCorasick) releaseMigrationLock() error {
 //
 // The migration process:
 //  1. Acquires a migration lock to prevent concurrent migrations
-//  2. Collects all V1 data (keywords, prefixes, suffixes, outputs, nodes)
+//  2. Collects the V1 data V2 needs (keywords, prefixes, outputs, nodes)
 //  3. Writes V2 structure to temporary keys
 //  4. Atomically swaps to V2 keys and optionally deletes V1 keys
 //  5. Releases the migration lock

--- a/pkg/acor/migration.go
+++ b/pkg/acor/migration.go
@@ -155,13 +155,6 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 	}
 	result.Prefixes = len(prefixes)
 
-	suffixes, err := ac.redisClient.ZRange(ac.ctx, suffixKey(ac.name), 0, -1).Result()
-	if err != nil {
-		result.Status = migrationStatusError
-		result.ErrorMessage = err.Error()
-		return result, err
-	}
-
 	if opts.Progress != nil {
 		opts.Progress(stepCollectOutputs, migrationTotalSteps, "Collecting outputs")
 	}
@@ -242,11 +235,6 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 		return result, fmt.Errorf("migration: failed to marshal prefixes: %w", marshalErr)
 	} else {
 		trieFields[fieldPrefixes] = prefixesJSON
-	}
-	if suffixesJSON, marshalErr := toJSON(suffixes); marshalErr != nil {
-		return result, fmt.Errorf("migration: failed to marshal suffixes: %w", marshalErr)
-	} else {
-		trieFields[fieldSuffixes] = suffixesJSON
 	}
 	if hsetErr := ac.redisClient.HSet(ac.ctx, tempTrieKey, trieFields).Err(); hsetErr != nil {
 		cleanup()

--- a/pkg/acor/redis_backed_ops.go
+++ b/pkg/acor/redis_backed_ops.go
@@ -175,20 +175,8 @@ func (ac *redisBackedAC) findIndex(ctx context.Context, text string) (map[string
 
 // flush removes all keywords from the automaton.
 func (ac *redisBackedAC) flush(ctx context.Context) error {
-	err := ac.storage.TxPipelined(ctx, func(pipe Pipeliner) error {
-		tKey := trieKey(ac.name)
-		oKey := outputsKey(ac.name)
-		nKey := nodesKey(ac.name)
-		if err := pipe.Del(ctx, oKey, nKey); err != nil {
-			return err
-		}
-		if err := pipe.HSet(ctx, tKey, emptyTrieFields()); err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		return newRedisError("TXPIPELINED", trieKey(ac.name), err)
+	if err := flushV2Keys(ctx, ac.storage, ac.name); err != nil {
+		return err
 	}
 
 	ac.mu.Lock()

--- a/pkg/acor/redis_backed_ops.go
+++ b/pkg/acor/redis_backed_ops.go
@@ -54,7 +54,7 @@ func (ac *redisBackedAC) tryAdd(ctx context.Context, keyword string, rebuild boo
 		return 0, nil
 	}
 
-	newVersion, err := commitV2Write(ctx, ac.redisClient, addV2Script, ac.name, snap, outputs)
+	newVersion, err := commitV2Write(ctx, ac.redisClient, ac.name, snap, outputs, false)
 	if err != nil {
 		return 0, err
 	}
@@ -136,7 +136,7 @@ func (ac *redisBackedAC) tryRemove(ctx context.Context, keyword string, rebuild 
 		return 0, nil
 	}
 
-	newVersion, err := commitV2Write(ctx, ac.redisClient, removeV2Script, ac.name, snap, outputs)
+	newVersion, err := commitV2Write(ctx, ac.redisClient, ac.name, snap, outputs, true)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/acor/v2_cache_test.go
+++ b/pkg/acor/v2_cache_test.go
@@ -28,7 +28,6 @@ func TestV2GetOrLoadEngineNoCache(t *testing.T) {
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
 		"keywords": `["he"]`,
 		"prefixes": `["","h","he"]`,
-		"suffixes": `["","e","eh"]`,
 		"version":  "100",
 	})
 	client.HSet(context.Background(), "{test}:outputs", map[string]interface{}{
@@ -116,7 +115,6 @@ func TestV2LoadCache(t *testing.T) {
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
 		"keywords": `["he"]`,
 		"prefixes": `["","h","he"]`,
-		"suffixes": `["","e","eh"]`,
 		"version":  "100",
 	})
 	client.HSet(context.Background(), "{test}:outputs", map[string]interface{}{
@@ -163,7 +161,6 @@ func TestV2GetOrLoadEngineDoubleCheck(t *testing.T) {
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
 		"keywords": `["he"]`,
 		"prefixes": `["","h","he"]`,
-		"suffixes": `["","e","eh"]`,
 		"version":  "100",
 	})
 	client.HSet(context.Background(), "{test}:outputs", map[string]interface{}{

--- a/pkg/acor/v2_errors_test.go
+++ b/pkg/acor/v2_errors_test.go
@@ -21,7 +21,6 @@ func setupV2WithError(t *testing.T) *AhoCorasick {
 	if err := client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
 		"keywords": `["he","she"]`,
 		"prefixes": `["","h","he","s","sh","she"]`,
-		"suffixes": `["","e","eh","s","hs","ehs"]`,
 		"version":  "100",
 	}).Err(); err != nil {
 		t.Fatalf("failed to seed trie data: %v", err)

--- a/pkg/acor/v2_integration_test.go
+++ b/pkg/acor/v2_integration_test.go
@@ -636,15 +636,18 @@ func TestV2TryAddBadPrefixesJSON(t *testing.T) {
 
 // TestV2LegacySuffixesFieldIgnored pins the compatibility contract for
 // collections written before the "suffixes" field was dropped: the leftover
-// value is never parsed, so even a corrupt one cannot fail a write.
+// value is never parsed, so even a corrupt one cannot fail a write, and it is
+// gone once the collection is flushed.
 func TestV2LegacySuffixesFieldIgnored(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
+	ctx := context.Background()
+
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	defer func() { _ = client.Close() }()
 
-	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
+	client.HSet(ctx, "{test}:trie", map[string]interface{}{
 		"keywords": `[]`,
 		"prefixes": `[""]`,
 		"suffixes": `not-json`,
@@ -654,8 +657,27 @@ func TestV2LegacySuffixesFieldIgnored(t *testing.T) {
 	ops := newTestV2Ops(t, mr)
 	defer func() { _ = ops.client.Close() }()
 
-	if _, err := ops.tryAddV2(context.Background(), "she"); err != nil {
+	if _, err := ops.tryAddV2(ctx, "she"); err != nil {
 		t.Fatalf("legacy suffixes field should be ignored, got: %v", err)
+	}
+
+	// A write leaves the field alone; only a flush rewrites the whole hash.
+	if exists, err := client.HExists(ctx, "{test}:trie", "suffixes").Result(); err != nil {
+		t.Fatal(err)
+	} else if !exists {
+		t.Error("write should leave the legacy suffixes field untouched")
+	}
+
+	if err := ops.flush(ctx); err != nil {
+		t.Fatalf("flush failed: %v", err)
+	}
+
+	exists, err := client.HExists(ctx, "{test}:trie", "suffixes").Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("legacy suffixes field should be gone after flush")
 	}
 }
 

--- a/pkg/acor/v2_integration_test.go
+++ b/pkg/acor/v2_integration_test.go
@@ -681,6 +681,40 @@ func TestV2LegacySuffixesFieldIgnored(t *testing.T) {
 	}
 }
 
+// TestPresetFlushDropsLegacySuffixes pins the same contract for preset mode,
+// which reaches the V2 trie hash through its own flush.
+func TestPresetFlushDropsLegacySuffixes(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+
+	ctx := context.Background()
+
+	ac, createErr := Create(&AhoCorasickArgs{Addr: mr.Addr(), Name: "test", Preset: PresetBalanced})
+	if createErr != nil {
+		t.Fatalf("Create: %v", createErr)
+	}
+	defer func() { _ = ac.Close() }()
+
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer func() { _ = client.Close() }()
+
+	if hsetErr := client.HSet(ctx, "{test}:trie", "suffixes", "not-json").Err(); hsetErr != nil {
+		t.Fatal(hsetErr)
+	}
+
+	if flushErr := ac.Flush(); flushErr != nil {
+		t.Fatalf("flush failed: %v", flushErr)
+	}
+
+	exists, err := client.HExists(ctx, "{test}:trie", "suffixes").Result()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("legacy suffixes field should be gone after a preset-mode flush")
+	}
+}
+
 func TestV2TryRemoveBadPrefixesJSON(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()

--- a/pkg/acor/v2_integration_test.go
+++ b/pkg/acor/v2_integration_test.go
@@ -407,7 +407,6 @@ func TestV2FlushWithNodes(t *testing.T) {
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
 		"keywords": `["he"]`,
 		"prefixes": `["","h","he"]`,
-		"suffixes": `["","e","eh"]`,
 		"version":  "100",
 	})
 	client.HSet(context.Background(), "{test}:outputs", map[string]interface{}{
@@ -635,7 +634,10 @@ func TestV2TryAddBadPrefixesJSON(t *testing.T) {
 	}
 }
 
-func TestV2TryAddBadSuffixesJSON(t *testing.T) {
+// TestV2LegacySuffixesFieldIgnored pins the compatibility contract for
+// collections written before the "suffixes" field was dropped: the leftover
+// value is never parsed, so even a corrupt one cannot fail a write.
+func TestV2LegacySuffixesFieldIgnored(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
@@ -652,9 +654,8 @@ func TestV2TryAddBadSuffixesJSON(t *testing.T) {
 	ops := newTestV2Ops(t, mr)
 	defer func() { _ = ops.client.Close() }()
 
-	_, err := ops.tryAddV2(context.Background(), "she")
-	if err == nil {
-		t.Fatal("expected error for bad JSON in suffixes")
+	if _, err := ops.tryAddV2(context.Background(), "she"); err != nil {
+		t.Fatalf("legacy suffixes field should be ignored, got: %v", err)
 	}
 }
 

--- a/pkg/acor/v2_lua.go
+++ b/pkg/acor/v2_lua.go
@@ -4,29 +4,39 @@ package acor
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/redis/go-redis/v9"
 )
 
-// --- Lua scripts (precompiled with redis.NewScript for EVALSHA optimization) ---
-
-var addV2Script = redis.NewScript(`
+// v2WriteScript commits a planned trie mutation under optimistic locking:
+// it rejects the write (returns 0) when another client has already moved the
+// version on, and otherwise swaps in the new trie fields and output states.
+//
+// Add and remove differ only in whether stale output states must be dropped
+// first: add rewrites the states it touched, remove replaces the whole set.
+// That is the clearOutputs flag.
+//
+// Precompiled with redis.NewScript so calls go out as EVALSHA.
+var v2WriteScript = redis.NewScript(`
 	local trieKey = KEYS[1]
 	local outputsKey = KEYS[2]
 	local oldVersion = ARGV[1]
 	local newVersion = ARGV[2]
 	local keywords = ARGV[3]
 	local prefixes = ARGV[4]
-	local suffixes = ARGV[5]
-	local outputsJson = ARGV[6]
+	local outputsJson = ARGV[5]
+	local clearOutputs = ARGV[6] == '1'
 
 	local currentVersion = redis.call('HGET', trieKey, 'version')
 	if currentVersion and currentVersion ~= oldVersion then
 		return 0
 	end
 
-	redis.call('HSET', trieKey, 'keywords', keywords, 'prefixes', prefixes, 'suffixes', suffixes, 'version', newVersion)
+	redis.call('HSET', trieKey, 'keywords', keywords, 'prefixes', prefixes, 'version', newVersion)
+
+	if clearOutputs then
+		redis.call('DEL', outputsKey)
+	end
 
 	local outputs = cjson.decode(outputsJson)
 	for state, jsonOuts in pairs(outputs) do
@@ -36,57 +46,31 @@ var addV2Script = redis.NewScript(`
 	return 1
 `)
 
-var removeV2Script = redis.NewScript(`
-	local trieKey = KEYS[1]
-	local outputsKey = KEYS[2]
-	local oldVersion = ARGV[1]
-	local newVersion = ARGV[2]
-	local keywords = ARGV[3]
-	local prefixes = ARGV[4]
-	local suffixes = ARGV[5]
-	local outputsJson = ARGV[6]
-
-	local currentVersion = redis.call('HGET', trieKey, 'version')
-	if currentVersion and currentVersion ~= oldVersion then
-		return 0
-	end
-
-	redis.call('HSET', trieKey, 'keywords', keywords, 'prefixes', prefixes, 'suffixes', suffixes, 'version', newVersion)
-
-	local outputs = cjson.decode(outputsJson)
-	redis.call('DEL', outputsKey)
-	for state, jsonOuts in pairs(outputs) do
-		redis.call('HSET', outputsKey, state, jsonOuts)
-	end
-
-	return 1
-`)
-
-// --- Lua script helpers ---
-
-// validateScriptArgs checks that the args map contains valid string values
-// for "trieKey" and "outputsKey". Returns an error if either key is missing
-// or not a string.
-func validateScriptArgs(args map[string]interface{}) error {
-	trieKey, ok := args[argTrieKey].(string)
-	if !ok || trieKey == "" {
-		return fmt.Errorf("validateScriptArgs: missing or invalid trieKey")
-	}
-	outputsKey, ok := args[argOutputsKey].(string)
-	if !ok || outputsKey == "" {
-		return fmt.Errorf("validateScriptArgs: missing or invalid outputsKey")
-	}
-	return nil
+// v2ScriptArgs is the argument set for v2WriteScript. The JSON fields are
+// pre-encoded by marshalTrieArgs; keeping them typed here means a missing or
+// mistyped argument is a compile error rather than a runtime assertion.
+type v2ScriptArgs struct {
+	TrieKey    string
+	OutputsKey string
+	OldVersion int64
+	NewVersion int64
+	Keywords   string // JSON array of keywords
+	Prefixes   string // JSON array of trie prefixes
+	Outputs    string // JSON object: state -> JSON array of matched keywords
+	// ClearOutputs drops the outputs hash before writing, for removes where a
+	// state's output list may have shrunk to nothing.
+	ClearOutputs bool
 }
 
-// runV2Script evaluates one of the V2 transaction scripts and returns its reply:
-// 1 when the write committed, 0 when the optimistic-lock version check failed.
-func runV2Script(ctx context.Context, client redis.UniversalClient, script *redis.Script, args map[string]interface{}) (int64, error) {
-	if err := validateScriptArgs(args); err != nil {
-		return 0, err
+// runV2Script evaluates v2WriteScript and returns its reply: 1 when the write
+// committed, 0 when the optimistic-lock version check failed.
+func runV2Script(ctx context.Context, client redis.UniversalClient, args *v2ScriptArgs) (int64, error) {
+	clearFlag := "0"
+	if args.ClearOutputs {
+		clearFlag = "1"
 	}
-	return script.Run(ctx, client,
-		[]string{args[argTrieKey].(string), args[argOutputsKey].(string)},
-		args["oldVersion"], args["newVersion"], args[fieldKeywords],
-		args[fieldPrefixes], args[fieldSuffixes], args["outputs"]).Int64()
+	return v2WriteScript.Run(ctx, client,
+		[]string{args.TrieKey, args.OutputsKey},
+		args.OldVersion, args.NewVersion, args.Keywords,
+		args.Prefixes, args.Outputs, clearFlag).Int64()
 }

--- a/pkg/acor/v2_lua.go
+++ b/pkg/acor/v2_lua.go
@@ -64,13 +64,12 @@ type v2ScriptArgs struct {
 
 // runV2Script evaluates v2WriteScript and returns its reply: 1 when the write
 // committed, 0 when the optimistic-lock version check failed.
+//
+// ClearOutputs goes out as a bool: go-redis encodes it as the "1"/"0" the
+// script compares against, so there is no flag string to keep in sync.
 func runV2Script(ctx context.Context, client redis.UniversalClient, args *v2ScriptArgs) (int64, error) {
-	clearFlag := "0"
-	if args.ClearOutputs {
-		clearFlag = "1"
-	}
 	return v2WriteScript.Run(ctx, client,
 		[]string{args.TrieKey, args.OutputsKey},
 		args.OldVersion, args.NewVersion, args.Keywords,
-		args.Prefixes, args.Outputs, clearFlag).Int64()
+		args.Prefixes, args.Outputs, args.ClearOutputs).Int64()
 }

--- a/pkg/acor/v2_lua.go
+++ b/pkg/acor/v2_lua.go
@@ -34,11 +34,14 @@ var v2WriteScript = redis.NewScript(`
 
 	redis.call('HSET', trieKey, 'keywords', keywords, 'prefixes', prefixes, 'version', newVersion)
 
+	-- Decode before the DEL: a cjson error aborts the script without rolling
+	-- back the commands already run, so nothing destructive may precede it.
+	local outputs = cjson.decode(outputsJson)
+
 	if clearOutputs then
 		redis.call('DEL', outputsKey)
 	end
 
-	local outputs = cjson.decode(outputsJson)
 	for state, jsonOuts in pairs(outputs) do
 		redis.call('HSET', outputsKey, state, jsonOuts)
 	end
@@ -46,9 +49,9 @@ var v2WriteScript = redis.NewScript(`
 	return 1
 `)
 
-// v2ScriptArgs is the argument set for v2WriteScript. The JSON fields are
-// pre-encoded by marshalTrieArgs; keeping them typed here means a missing or
-// mistyped argument is a compile error rather than a runtime assertion.
+// v2ScriptArgs is the complete argument set for v2WriteScript, built by
+// marshalTrieArgs. Keeping the arguments typed here means a missing or mistyped
+// one is a compile error rather than a runtime assertion.
 type v2ScriptArgs struct {
 	TrieKey    string
 	OutputsKey string

--- a/pkg/acor/v2_lua_test.go
+++ b/pkg/acor/v2_lua_test.go
@@ -49,11 +49,10 @@ func TestV2WriteScriptClearOutputs(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			args, err := marshalTrieArgs("test", snap, map[string]string{"42": `["he"]`}, snap.Version+1)
+			args, err := marshalTrieArgs("test", snap, map[string]string{"42": `["he"]`}, snap.Version+1, tc.clearOutputs)
 			if err != nil {
 				t.Fatal(err)
 			}
-			args.ClearOutputs = tc.clearOutputs
 
 			val, err := runV2Script(ctx, ops.client, args)
 			if err != nil {
@@ -108,18 +107,17 @@ func TestLuaScriptInt64SafetyAdd(t *testing.T) {
 	}
 	snap.Version = largeVersionAbove2to53
 
-	args, err := marshalTrieArgs("test", snap, map[string]string{}, largeVersionAbove2to53+1)
+	args, err := marshalTrieArgs("test", snap, map[string]string{}, largeVersionAbove2to53+1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	val, err := runV2Script(ctx, ops.client, args)
+	result, err := runV2Script(ctx, ops.client, args)
 	if err != nil {
-		t.Fatalf("addV2Script failed: %v", err)
+		t.Fatalf("runV2Script failed: %v", err)
 	}
-	result := val
 	if result != 1 {
-		t.Errorf("addV2Script Int64 result = %d, want 1", result)
+		t.Errorf("runV2Script Int64 result = %d, want 1", result)
 	}
 }
 
@@ -147,20 +145,17 @@ func TestLuaScriptInt64SafetyRemove(t *testing.T) {
 	}
 	snap.Version = largeVersionAbove2to53
 
-	args, err := marshalTrieArgs("test", snap, map[string]string{}, largeVersionAbove2to53+1)
+	args, err := marshalTrieArgs("test", snap, map[string]string{}, largeVersionAbove2to53+1, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	args.ClearOutputs = true
-
-	val, err := runV2Script(ctx, ops.client, args)
+	result, err := runV2Script(ctx, ops.client, args)
 	if err != nil {
-		t.Fatalf("removeV2Script failed: %v", err)
+		t.Fatalf("runV2Script failed: %v", err)
 	}
-	result := val
 	if result != 1 {
-		t.Errorf("removeV2Script Int64 result = %d, want 1", result)
+		t.Errorf("runV2Script Int64 result = %d, want 1", result)
 	}
 
 	// Verify the stored version in Redis is the exact int64 value

--- a/pkg/acor/v2_lua_test.go
+++ b/pkg/acor/v2_lua_test.go
@@ -11,69 +11,6 @@ import (
 	redis "github.com/redis/go-redis/v9"
 )
 
-func TestValidateScriptArgs(t *testing.T) {
-	tests := []struct {
-		name    string
-		args    map[string]interface{}
-		wantErr bool
-	}{
-		{
-			name:    "valid args with both keys",
-			args:    map[string]interface{}{"trieKey": "key1", "outputsKey": "key2"},
-			wantErr: false,
-		},
-		{
-			name:    "nil args",
-			args:    nil,
-			wantErr: true,
-		},
-		{
-			name:    "empty args",
-			args:    map[string]interface{}{},
-			wantErr: true,
-		},
-		{
-			name:    "missing trieKey",
-			args:    map[string]interface{}{"outputsKey": "key2"},
-			wantErr: true,
-		},
-		{
-			name:    "missing outputsKey",
-			args:    map[string]interface{}{"trieKey": "key1"},
-			wantErr: true,
-		},
-		{
-			name:    "trieKey is wrong type (int)",
-			args:    map[string]interface{}{"trieKey": 123, "outputsKey": "key2"},
-			wantErr: true,
-		},
-		{
-			name:    "outputsKey is wrong type (int)",
-			args:    map[string]interface{}{"trieKey": "key1", "outputsKey": 456},
-			wantErr: true,
-		},
-		{
-			name:    "trieKey is wrong type (nil)",
-			args:    map[string]interface{}{"trieKey": nil, "outputsKey": "key2"},
-			wantErr: true,
-		},
-		{
-			name:    "outputsKey is wrong type (nil)",
-			args:    map[string]interface{}{"trieKey": "key1", "outputsKey": nil},
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateScriptArgs(tt.args)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("validateScriptArgs() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
 // largeVersionAbove2to53 is a version value above 2^53 used by int64 safety tests.
 // 2^53 = 9007199254740992. We use 2^53+1 to prove no truncation occurs while
 // staying safely below math.MaxInt64 to avoid overflow when incrementing.
@@ -103,16 +40,14 @@ func TestLuaScriptInt64SafetyAdd(t *testing.T) {
 	}
 	snap.Version = largeVersionAbove2to53
 
-	args, err := marshalTrieArgs(snap, map[string]string{}, largeVersionAbove2to53+1)
+	args, err := marshalTrieArgs("test", snap, map[string]string{}, largeVersionAbove2to53+1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	args["trieKey"] = trieKey("test")
-	args["outputsKey"] = outputsKey("test")
 
-	val, err := runV2Script(ctx, ops.client, addV2Script, args)
+	val, err := runV2Script(ctx, ops.client, args)
 	if err != nil {
-		t.Fatalf("runAddV2Script failed: %v", err)
+		t.Fatalf("addV2Script failed: %v", err)
 	}
 	result := val
 	if result != 1 {
@@ -144,16 +79,16 @@ func TestLuaScriptInt64SafetyRemove(t *testing.T) {
 	}
 	snap.Version = largeVersionAbove2to53
 
-	args, err := marshalTrieArgs(snap, map[string]string{}, largeVersionAbove2to53+1)
+	args, err := marshalTrieArgs("test", snap, map[string]string{}, largeVersionAbove2to53+1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	args["trieKey"] = trieKey("test")
-	args["outputsKey"] = outputsKey("test")
 
-	val, err := runV2Script(ctx, ops.client, removeV2Script, args)
+	args.ClearOutputs = true
+
+	val, err := runV2Script(ctx, ops.client, args)
 	if err != nil {
-		t.Fatalf("runRemoveV2Script failed: %v", err)
+		t.Fatalf("removeV2Script failed: %v", err)
 	}
 	result := val
 	if result != 1 {

--- a/pkg/acor/v2_lua_test.go
+++ b/pkg/acor/v2_lua_test.go
@@ -16,6 +16,74 @@ import (
 // staying safely below math.MaxInt64 to avoid overflow when incrementing.
 const largeVersionAbove2to53 = int64(9007199254740993)
 
+// TestV2WriteScriptClearOutputs pins the only behavior the clearOutputs flag
+// controls: an output state the pending write doesn't carry survives an add,
+// which rewrites just the states it touched, and is dropped by a remove, which
+// replaces the whole set because a state's output list may have emptied.
+func TestV2WriteScriptClearOutputs(t *testing.T) {
+	const staleState = "stale"
+
+	for _, tc := range []struct {
+		name         string
+		clearOutputs bool
+		wantStale    bool
+	}{
+		{"add keeps states it did not touch", false, true},
+		{"remove drops states it did not touch", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := miniredis.RunT(t)
+			defer mr.Close()
+
+			ops := newTestV2Ops(t, mr)
+			defer func() { _ = ops.client.Close() }()
+
+			ctx := context.Background()
+			seedV2Trie(t, mr, []string{"he"})
+
+			if err := ops.client.HSet(ctx, outputsKey("test"), staleState, `["gone"]`).Err(); err != nil {
+				t.Fatal(err)
+			}
+
+			snap, err := readTrieSnapshot(ctx, ops.storage, ops.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			args, err := marshalTrieArgs("test", snap, map[string]string{"42": `["he"]`}, snap.Version+1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			args.ClearOutputs = tc.clearOutputs
+
+			val, err := runV2Script(ctx, ops.client, args)
+			if err != nil {
+				t.Fatalf("runV2Script failed: %v", err)
+			}
+			if val != 1 {
+				t.Fatalf("runV2Script = %d, want 1", val)
+			}
+
+			gotStale, err := ops.client.HExists(ctx, outputsKey("test"), staleState).Result()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if gotStale != tc.wantStale {
+				t.Errorf("stale state present = %v, want %v (clearOutputs=%v)",
+					gotStale, tc.wantStale, tc.clearOutputs)
+			}
+
+			// The states the write did carry land either way.
+			got, err := ops.client.HGet(ctx, outputsKey("test"), "42").Result()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != `["he"]` {
+				t.Errorf(`state "42" = %q, want ["he"]`, got)
+			}
+		})
+	}
+}
+
 // TestLuaScriptInt64SafetyAdd documents the contract that add script results
 // should be read as int64 to avoid silent truncation on platforms where int < 64-bit.
 func TestLuaScriptInt64SafetyAdd(t *testing.T) {

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -120,9 +120,10 @@ func (o *v2Operations) flush(ctx context.Context) error {
 		// nodesKey is only written during migration; including it here ensures a clean state.
 		nKey := nodesKey(o.name)
 
-		// Delete outputs and nodes keys; overwrite trie key with HSET below
-		// instead of DEL+HSET to avoid an unnecessary round-trip in the pipeline.
-		if err := pipe.Del(ctx, oKey, nKey); err != nil {
+		// The trie key is deleted too, not just overwritten, so fields no
+		// longer written by this version (the pre-v0.11 "suffixes") don't
+		// survive a flush. It costs nothing: same DEL, one more key.
+		if err := pipe.Del(ctx, oKey, nKey, tKey); err != nil {
 			return err
 		}
 		if err := pipe.HSet(ctx, tKey, emptyTrieFields()); err != nil {

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -114,25 +114,8 @@ func (o *v2Operations) remove(ctx context.Context, keyword string) (int, error) 
 }
 
 func (o *v2Operations) flush(ctx context.Context) error {
-	err := o.storage.TxPipelined(ctx, func(pipe Pipeliner) error {
-		tKey := trieKey(o.name)
-		oKey := outputsKey(o.name)
-		// nodesKey is only written during migration; including it here ensures a clean state.
-		nKey := nodesKey(o.name)
-
-		// The trie key is deleted too, not just overwritten, so fields no
-		// longer written by this version (the pre-v0.11 "suffixes") don't
-		// survive a flush. It costs nothing: same DEL, one more key.
-		if err := pipe.Del(ctx, oKey, nKey, tKey); err != nil {
-			return err
-		}
-		if err := pipe.HSet(ctx, tKey, emptyTrieFields()); err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		return newRedisError("TXPIPELINED", trieKey(o.name), err)
+	if err := flushV2Keys(ctx, o.storage, o.name); err != nil {
+		return err
 	}
 
 	o.publishInvalidate(ctx)

--- a/pkg/acor/v2_ops_test.go
+++ b/pkg/acor/v2_ops_test.go
@@ -33,7 +33,6 @@ func TestV2Find(t *testing.T) {
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
 		"keywords": `["he","she","his","hers"]`,
 		"prefixes": `["","h","he","s","sh","she","hi","his","her","hers"]`,
-		"suffixes": `["","e","eh","s","hs","ehs","i","ih","si","sih","r","reh","s","sreh"]`,
 		"version":  "1234567890",
 	})
 

--- a/pkg/acor/v2_plan.go
+++ b/pkg/acor/v2_plan.go
@@ -29,12 +29,11 @@ func planAdd(snap *trieSnapshot, keyword string) (outputs map[string][]string, c
 	}
 
 	keywordRunes := []rune(keyword)
-	var newPrefixes, newSuffixes []string
+	var newPrefixes []string
 	for i := range keywordRunes {
 		prefix := string(keywordRunes[:i+1])
 		if _, exists := prefixSet[prefix]; !exists {
 			newPrefixes = append(newPrefixes, prefix)
-			newSuffixes = append(newSuffixes, reverse(prefix))
 			prefixSet[prefix] = struct{}{}
 		}
 	}
@@ -59,7 +58,6 @@ func planAdd(snap *trieSnapshot, keyword string) (outputs map[string][]string, c
 
 	snap.Keywords = append(snap.Keywords, keyword)
 	snap.Prefixes = append(snap.Prefixes, newPrefixes...)
-	snap.Suffixes = append(snap.Suffixes, newSuffixes...)
 	return outputs, true
 }
 
@@ -105,11 +103,6 @@ func planRemove(snap *trieSnapshot, keyword string) (outputs map[string][]string
 		prefixSet[p] = struct{}{}
 	}
 
-	newSuffixes := make([]string, len(newPrefixes))
-	for i, p := range newPrefixes {
-		newSuffixes[i] = reverse(p)
-	}
-
 	outputs = make(map[string][]string)
 	for _, prefix := range newPrefixes {
 		if prefix == "" {
@@ -122,7 +115,6 @@ func planRemove(snap *trieSnapshot, keyword string) (outputs map[string][]string
 
 	snap.Keywords = newKeywords
 	snap.Prefixes = newPrefixes
-	snap.Suffixes = newSuffixes
 	return outputs, true
 }
 

--- a/pkg/acor/v2_transaction.go
+++ b/pkg/acor/v2_transaction.go
@@ -81,14 +81,17 @@ func readTrieSnapshot(ctx context.Context, storage KVStorage, name string) (*tri
 	return snap, nil
 }
 
-// marshalTrieArgs serializes a snapshot and its output states into the script
-// arguments for collection name.
-func marshalTrieArgs(name string, snap *trieSnapshot, outputs map[string]string, newVersion int64) (*v2ScriptArgs, error) {
+// marshalTrieArgs serializes a snapshot and its output states into the complete
+// script arguments for collection name: nothing is left for the caller to patch
+// in afterwards.
+func marshalTrieArgs(name string, snap *trieSnapshot, outputs map[string]string,
+	newVersion int64, clearOutputs bool) (*v2ScriptArgs, error) {
 	args := &v2ScriptArgs{
-		TrieKey:    trieKey(name),
-		OutputsKey: outputsKey(name),
-		OldVersion: snap.Version,
-		NewVersion: newVersion,
+		TrieKey:      trieKey(name),
+		OutputsKey:   outputsKey(name),
+		OldVersion:   snap.Version,
+		NewVersion:   newVersion,
+		ClearOutputs: clearOutputs,
 	}
 	var err error
 	if args.Keywords, err = toJSON(snap.Keywords); err != nil {
@@ -131,11 +134,10 @@ func commitV2Write(ctx context.Context, client redis.UniversalClient, name strin
 		encoded[state] = jsonOuts
 	}
 
-	args, err := marshalTrieArgs(name, snap, encoded, newVersion)
+	args, err := marshalTrieArgs(name, snap, encoded, newVersion, clearOutputs)
 	if err != nil {
 		return 0, err
 	}
-	args.ClearOutputs = clearOutputs
 
 	result, err := runV2Script(ctx, client, args)
 	if err != nil {
@@ -145,6 +147,31 @@ func commitV2Write(ctx context.Context, client redis.UniversalClient, name strin
 		return 0, ErrConcurrencyConflict
 	}
 	return newVersion, nil
+}
+
+// flushV2Keys resets a collection's V2 keys to empty: the outputs and nodes
+// hashes are dropped and the trie hash is replaced with emptyTrieFields.
+//
+// The trie key is deleted rather than only overwritten, so fields no longer
+// written by this version (the pre-v0.11 "suffixes") don't survive a flush. The
+// one thing that costs is the key's TTL, which acor never sets itself; a caller
+// that expires collections externally has to re-apply it after Flush.
+//
+// Shared by both V2 write paths, which differ only in the local state they reset
+// afterwards.
+func flushV2Keys(ctx context.Context, storage KVStorage, name string) error {
+	tKey := trieKey(name)
+	err := storage.TxPipelined(ctx, func(pipe Pipeliner) error {
+		// nodesKey is only written during migration; including it here ensures a clean state.
+		if err := pipe.Del(ctx, outputsKey(name), nodesKey(name), tKey); err != nil {
+			return err
+		}
+		return pipe.HSet(ctx, tKey, emptyTrieFields())
+	})
+	if err != nil {
+		return newRedisError("TXPIPELINED", tKey, err)
+	}
+	return nil
 }
 
 // retryOnConflict runs attempt until it stops reporting a lost optimistic-lock

--- a/pkg/acor/v2_transaction.go
+++ b/pkg/acor/v2_transaction.go
@@ -41,10 +41,15 @@ func generateVersion() (int64, error) {
 }
 
 // trieSnapshot holds the deserialized trie data read from Redis.
+//
+// The V2 trie hash also carried a "suffixes" field until v0.11: every prefix
+// reversed, written on each update and read back, but never consulted by any
+// matcher (only the V1 schema's suffix ZSET is used, for its own rebuild walk).
+// It is no longer written; a leftover field on an existing collection is
+// ignored and disappears on the next Flush.
 type trieSnapshot struct {
 	Keywords []string
 	Prefixes []string
-	Suffixes []string
 	Version  int64
 }
 
@@ -67,11 +72,6 @@ func readTrieSnapshot(ctx context.Context, storage KVStorage, name string) (*tri
 			return nil, newOperationError("unmarshal", SchemaV2, err)
 		}
 	}
-	if data, ok := trieData[fieldSuffixes]; ok {
-		if err := json.Unmarshal([]byte(data), &snap.Suffixes); err != nil {
-			return nil, newOperationError("unmarshal", SchemaV2, err)
-		}
-	}
 	if v, ok := trieData[fieldVersion]; ok {
 		if err := json.Unmarshal([]byte(v), &snap.Version); err != nil {
 			snap.Version = 0
@@ -81,25 +81,23 @@ func readTrieSnapshot(ctx context.Context, storage KVStorage, name string) (*tri
 	return snap, nil
 }
 
-// marshalTrieArgs serializes trie data into the args map for Lua scripts.
-func marshalTrieArgs(snap *trieSnapshot, outputs map[string]string, newVersion int64) (map[string]interface{}, error) {
-	args := map[string]interface{}{
-		argTrieKey:    "", // caller must set
-		argOutputsKey: "", // caller must set
-		"newVersion":  newVersion,
-		"oldVersion":  snap.Version,
+// marshalTrieArgs serializes a snapshot and its output states into the script
+// arguments for collection name.
+func marshalTrieArgs(name string, snap *trieSnapshot, outputs map[string]string, newVersion int64) (*v2ScriptArgs, error) {
+	args := &v2ScriptArgs{
+		TrieKey:    trieKey(name),
+		OutputsKey: outputsKey(name),
+		OldVersion: snap.Version,
+		NewVersion: newVersion,
 	}
 	var err error
-	if args[fieldKeywords], err = toJSON(snap.Keywords); err != nil {
+	if args.Keywords, err = toJSON(snap.Keywords); err != nil {
 		return nil, newOperationError("marshal", SchemaV2, err)
 	}
-	if args[fieldPrefixes], err = toJSON(snap.Prefixes); err != nil {
+	if args.Prefixes, err = toJSON(snap.Prefixes); err != nil {
 		return nil, newOperationError("marshal", SchemaV2, err)
 	}
-	if args[fieldSuffixes], err = toJSON(snap.Suffixes); err != nil {
-		return nil, newOperationError("marshal", SchemaV2, err)
-	}
-	if args["outputs"], err = toJSON(outputs); err != nil {
+	if args.Outputs, err = toJSON(outputs); err != nil {
 		return nil, newOperationError("marshal", SchemaV2, err)
 	}
 	return args, nil
@@ -117,8 +115,8 @@ func toJSON(v any) (string, error) {
 // through script under optimistic locking. It returns the version it wrote, or
 // ErrConcurrencyConflict when another writer won the race and the caller should
 // re-read the snapshot and retry.
-func commitV2Write(ctx context.Context, client redis.UniversalClient, script *redis.Script,
-	name string, snap *trieSnapshot, outputs map[string][]string) (int64, error) {
+func commitV2Write(ctx context.Context, client redis.UniversalClient, name string,
+	snap *trieSnapshot, outputs map[string][]string, clearOutputs bool) (int64, error) {
 	newVersion, err := generateVersion()
 	if err != nil {
 		return 0, err
@@ -133,14 +131,13 @@ func commitV2Write(ctx context.Context, client redis.UniversalClient, script *re
 		encoded[state] = jsonOuts
 	}
 
-	args, err := marshalTrieArgs(snap, encoded, newVersion)
+	args, err := marshalTrieArgs(name, snap, encoded, newVersion)
 	if err != nil {
 		return 0, err
 	}
-	args[argTrieKey] = trieKey(name)
-	args[argOutputsKey] = outputsKey(name)
+	args.ClearOutputs = clearOutputs
 
-	result, err := runV2Script(ctx, client, script, args)
+	result, err := runV2Script(ctx, client, args)
 	if err != nil {
 		return 0, newRedisError("EVAL", trieKey(name), err)
 	}
@@ -198,7 +195,7 @@ func (o *v2Operations) tryAddV2(ctx context.Context, keyword string) (int, error
 		return 0, nil
 	}
 
-	if _, err := commitV2Write(ctx, o.client, addV2Script, o.name, snap, outputs); err != nil {
+	if _, err := commitV2Write(ctx, o.client, o.name, snap, outputs, false); err != nil {
 		return 0, err
 	}
 
@@ -217,7 +214,7 @@ func (o *v2Operations) tryRemoveV2(ctx context.Context, keyword string) (int, er
 		return 0, nil
 	}
 
-	if _, err := commitV2Write(ctx, o.client, removeV2Script, o.name, snap, outputs); err != nil {
+	if _, err := commitV2Write(ctx, o.client, o.name, snap, outputs, true); err != nil {
 		return 0, err
 	}
 

--- a/pkg/acor/version_precision_test.go
+++ b/pkg/acor/version_precision_test.go
@@ -70,34 +70,32 @@ func TestLuaVersionComparisonAbove2to53(t *testing.T) {
 
 	// Build args with the matching large oldVersion — should succeed
 	snap.Version = largeOldVersion
-	args, err := marshalTrieArgs("test", snap, map[string]string{}, largeNewVersion)
+	args, err := marshalTrieArgs("test", snap, map[string]string{}, largeNewVersion, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	val, err := runV2Script(ctx, ops.client, args)
+	result, err := runV2Script(ctx, ops.client, args)
 	if err != nil {
-		t.Fatalf("addV2Script with matching large version failed: %v", err)
+		t.Fatalf("runV2Script with matching large version failed: %v", err)
 	}
-	result := int(val)
 	if result != 1 {
-		t.Errorf("addV2Script = %d, want 1 (version should match for %d)", result, largeOldVersion)
+		t.Errorf("runV2Script = %d, want 1 (version should match for %d)", result, largeOldVersion)
 	}
 
 	// Now try with oldVersion that no longer matches — should detect conflict
 	snap.Version = largeOldVersion // trie now has largeNewVersion
-	args2, err := marshalTrieArgs("test", snap, map[string]string{}, largeNewVersion+1)
+	args2, err := marshalTrieArgs("test", snap, map[string]string{}, largeNewVersion+1, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	val2, err := runV2Script(ctx, ops.client, args2)
+	result2, err := runV2Script(ctx, ops.client, args2)
 	if err != nil {
-		t.Fatalf("addV2Script conflict check failed: %v", err)
+		t.Fatalf("runV2Script conflict check failed: %v", err)
 	}
-	result2 := int(val2)
 	if result2 != 0 {
-		t.Errorf("addV2Script = %d, want 0 (conflict between %d and %d should be detected)",
+		t.Errorf("runV2Script = %d, want 0 (conflict between %d and %d should be detected)",
 			result2, largeOldVersion, largeNewVersion)
 	}
 }
@@ -177,25 +175,24 @@ func TestLuaVersionStringComparison(t *testing.T) {
 
 			newVersion := tt.oldVersion + 1
 
-			args, err := marshalTrieArgs("test", snap, map[string]string{}, newVersion)
+			args, err := marshalTrieArgs("test", snap, map[string]string{}, newVersion, false)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			val, err := runV2Script(ctx, ops.client, args)
+			result, err := runV2Script(ctx, ops.client, args)
 			if err != nil {
-				t.Fatalf("addV2Script error: %v", err)
+				t.Fatalf("runV2Script error: %v", err)
 			}
-			result := int(val)
 
 			if tt.wantConflict {
 				if result != 0 {
-					t.Errorf("addV2Script = %d, want 0 (conflict expected: stored=%d, sent=%d)",
+					t.Errorf("runV2Script = %d, want 0 (conflict expected: stored=%d, sent=%d)",
 						result, tt.storedVersion, tt.oldVersion)
 				}
 			} else {
 				if result != 1 {
-					t.Errorf("addV2Script = %d, want 1 (match expected for version=%d)",
+					t.Errorf("runV2Script = %d, want 1 (match expected for version=%d)",
 						result, tt.storedVersion)
 				}
 			}
@@ -229,37 +226,31 @@ func TestLuaVersionRemoveScriptPrecision(t *testing.T) {
 	snap.Version = largeVersion
 
 	newVersion := largeVersion + 1
-	args, err := marshalTrieArgs("test", snap, map[string]string{}, newVersion)
+	args, err := marshalTrieArgs("test", snap, map[string]string{}, newVersion, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	args.ClearOutputs = true
-
-	val, err := runV2Script(ctx, ops.client, args)
+	result, err := runV2Script(ctx, ops.client, args)
 	if err != nil {
-		t.Fatalf("removeV2Script error: %v", err)
+		t.Fatalf("runV2Script error: %v", err)
 	}
-	result := int(val)
 	if result != 1 {
-		t.Errorf("removeV2Script = %d, want 1 (version %d should match)", result, largeVersion)
+		t.Errorf("runV2Script = %d, want 1 (version %d should match)", result, largeVersion)
 	}
 
 	// Stale version should be rejected
-	args2, err := marshalTrieArgs("test", snap, map[string]string{}, newVersion+1)
+	args2, err := marshalTrieArgs("test", snap, map[string]string{}, newVersion+1, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	args2.ClearOutputs = true
-
-	val2, err := runV2Script(ctx, ops.client, args2)
+	result2, err := runV2Script(ctx, ops.client, args2)
 	if err != nil {
-		t.Fatalf("removeV2Script stale version error: %v", err)
+		t.Fatalf("runV2Script stale version error: %v", err)
 	}
-	result2 := int(val2)
 	if result2 != 0 {
-		t.Errorf("removeV2Script = %d, want 0 (stale version should conflict)", result2)
+		t.Errorf("runV2Script = %d, want 0 (stale version should conflict)", result2)
 	}
 
 	// Verify: the version in Redis should be the new one

--- a/pkg/acor/version_precision_test.go
+++ b/pkg/acor/version_precision_test.go
@@ -70,14 +70,12 @@ func TestLuaVersionComparisonAbove2to53(t *testing.T) {
 
 	// Build args with the matching large oldVersion — should succeed
 	snap.Version = largeOldVersion
-	args, err := marshalTrieArgs(snap, map[string]string{}, largeNewVersion)
+	args, err := marshalTrieArgs("test", snap, map[string]string{}, largeNewVersion)
 	if err != nil {
 		t.Fatal(err)
 	}
-	args["trieKey"] = trieKey("test")
-	args["outputsKey"] = outputsKey("test")
 
-	val, err := runV2Script(ctx, ops.client, addV2Script, args)
+	val, err := runV2Script(ctx, ops.client, args)
 	if err != nil {
 		t.Fatalf("addV2Script with matching large version failed: %v", err)
 	}
@@ -88,14 +86,12 @@ func TestLuaVersionComparisonAbove2to53(t *testing.T) {
 
 	// Now try with oldVersion that no longer matches — should detect conflict
 	snap.Version = largeOldVersion // trie now has largeNewVersion
-	args2, err := marshalTrieArgs(snap, map[string]string{}, largeNewVersion+1)
+	args2, err := marshalTrieArgs("test", snap, map[string]string{}, largeNewVersion+1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	args2["trieKey"] = trieKey("test")
-	args2["outputsKey"] = outputsKey("test")
 
-	val2, err := runV2Script(ctx, ops.client, addV2Script, args2)
+	val2, err := runV2Script(ctx, ops.client, args2)
 	if err != nil {
 		t.Fatalf("addV2Script conflict check failed: %v", err)
 	}
@@ -181,14 +177,12 @@ func TestLuaVersionStringComparison(t *testing.T) {
 
 			newVersion := tt.oldVersion + 1
 
-			args, err := marshalTrieArgs(snap, map[string]string{}, newVersion)
+			args, err := marshalTrieArgs("test", snap, map[string]string{}, newVersion)
 			if err != nil {
 				t.Fatal(err)
 			}
-			args["trieKey"] = trieKey("test")
-			args["outputsKey"] = outputsKey("test")
 
-			val, err := runV2Script(ctx, ops.client, addV2Script, args)
+			val, err := runV2Script(ctx, ops.client, args)
 			if err != nil {
 				t.Fatalf("addV2Script error: %v", err)
 			}
@@ -235,14 +229,14 @@ func TestLuaVersionRemoveScriptPrecision(t *testing.T) {
 	snap.Version = largeVersion
 
 	newVersion := largeVersion + 1
-	args, err := marshalTrieArgs(snap, map[string]string{}, newVersion)
+	args, err := marshalTrieArgs("test", snap, map[string]string{}, newVersion)
 	if err != nil {
 		t.Fatal(err)
 	}
-	args["trieKey"] = trieKey("test")
-	args["outputsKey"] = outputsKey("test")
 
-	val, err := runV2Script(ctx, ops.client, removeV2Script, args)
+	args.ClearOutputs = true
+
+	val, err := runV2Script(ctx, ops.client, args)
 	if err != nil {
 		t.Fatalf("removeV2Script error: %v", err)
 	}
@@ -252,14 +246,14 @@ func TestLuaVersionRemoveScriptPrecision(t *testing.T) {
 	}
 
 	// Stale version should be rejected
-	args2, err := marshalTrieArgs(snap, map[string]string{}, newVersion+1)
+	args2, err := marshalTrieArgs("test", snap, map[string]string{}, newVersion+1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	args2["trieKey"] = trieKey("test")
-	args2["outputsKey"] = outputsKey("test")
 
-	val2, err := runV2Script(ctx, ops.client, removeV2Script, args2)
+	args2.ClearOutputs = true
+
+	val2, err := runV2Script(ctx, ops.client, args2)
 	if err != nil {
 		t.Fatalf("removeV2Script stale version error: %v", err)
 	}


### PR DESCRIPTION
# Pull Request

## Description

The V2 trie hash carried a `suffixes` field holding every prefix reversed. It was computed on both write paths, JSON-encoded, shipped to Redis on every add and remove, and read back into `trieSnapshot` — but **no matcher ever consulted it**. Only the V1 schema uses suffixes, via its own sorted set, for the `rebuildOutput` walk. Roughly a third of every V2 write payload was dead weight.

### Compatibility

Storage format change, safe in both directions during a rolling upgrade:

- A leftover `suffixes` field on an existing collection is never read. `TestV2LegacySuffixesFieldIgnored` pins this, seeding a deliberately corrupt value (`not-json`) and asserting the write still succeeds — the previous test asserted the opposite, that a corrupt value fails the write.
- The field disappears from a collection on its next `Flush`.
- An older binary reading a collection written by this version finds no `suffixes` field, decodes `nil`, and writes back `null` — which nothing reads.

### Also in this PR

The script argument layout was changing anyway, so two adjacent cleanups ride along:

- `addV2Script` and `removeV2Script` differed by a single `DEL`, so they are now one `v2WriteScript` with a `clearOutputs` flag. The SHA changes, so in-flight `EVALSHA` calls miss once and go-redis falls back to `EVAL` — no operational impact.
- The `map[string]interface{}` argument bag became the `v2ScriptArgs` struct, so a missing or mistyped argument is now a compile error. `validateScriptArgs` and its seven-case table test existed only to catch that at runtime and are gone.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test update

Marked breaking for the stored schema only. The Go API is unchanged, and the compatibility analysis above covers mixed-version deployments.

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — skip for internal-only changes (CI, tests, refactors); see [RELEASE.md](../RELEASE.md)
- [x] Commit messages follow guidelines