### PR TITLE
refactor: share one self-invalidation implementation between both modes

### DIFF
--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -312,9 +312,8 @@ type AhoCorasick struct {
 	buildTrieHook func(string) error
 	schemaVersion int // kept for SchemaVersion() and migration.go
 
-	selfInvalidationCleanupInterval uint64
-	rollbackTimeout                 time.Duration
-	caseSensitive                   bool
+	rollbackTimeout time.Duration
+	caseSensitive   bool
 
 	cache     *trieCache
 	pubsub    Subscription
@@ -450,6 +449,9 @@ func createOriginal(args *AhoCorasickArgs) (*AhoCorasick, error) {
 	var cache *trieCache
 	if args.EnableCache {
 		cache = &trieCache{}
+		// Set before the cache is shared with the listener goroutine; selfSkipSet
+		// reads it without synchronization. Zero means the default interval.
+		cache.selfSkip.cleanupEvery = args.SelfInvalidationCleanupInterval
 	}
 
 	ac := &AhoCorasick{
@@ -460,11 +462,6 @@ func createOriginal(args *AhoCorasickArgs) (*AhoCorasick, error) {
 		schemaVersion: schemaVersion,
 		cache:         cache,
 		mode:          modeOriginal,
-	}
-	if args.SelfInvalidationCleanupInterval > 0 {
-		ac.selfInvalidationCleanupInterval = args.SelfInvalidationCleanupInterval
-	} else {
-		ac.selfInvalidationCleanupInterval = defaultSelfInvalidationCleanupInterval
 	}
 	ac.rollbackTimeout = resolveRollbackTimeout(args.RollbackTimeout)
 	ac.caseSensitive = args.CaseSensitive
@@ -553,13 +550,12 @@ func (ac *AhoCorasick) Close() error {
 
 func (ac *AhoCorasick) newV2Ops(cache *trieCache) operations {
 	return &v2Operations{
-		storage:                         ac.storage,
-		client:                          ac.redisClient,
-		name:                            ac.name,
-		cache:                           cache,
-		logger:                          ac.logger,
-		selfInvalidationCleanupInterval: ac.selfInvalidationCleanupInterval,
-		caseSensitive:                   ac.caseSensitive,
+		storage:       ac.storage,
+		client:        ac.redisClient,
+		name:          ac.name,
+		cache:         cache,
+		logger:        ac.logger,
+		caseSensitive: ac.caseSensitive,
 	}
 }
 

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -264,7 +264,7 @@ type AhoCorasickArgs struct {
 	// sweep runs relative to publishInvalidate calls. Every N publishes triggers one O(n)
 	// sweep of the pending self-invalidations map. Lower values reduce memory usage at the
 	// cost of more frequent cleanup; higher values trade memory for less CPU overhead.
-	// Defaults to 128 if unset or zero.
+	// Applies to both EnableCache and Preset mode. Defaults to 128 if unset or zero.
 	SelfInvalidationCleanupInterval uint64
 	// CaseSensitive controls whether keyword matching is case-sensitive.
 	// When false (default), keywords are lowercased on Add/Remove and search text

--- a/pkg/acor/cache.go
+++ b/pkg/acor/cache.go
@@ -4,71 +4,18 @@ package acor
 
 import (
 	"sync"
-	"time"
 
 	matchengine "github.com/skyoo2003/acor/internal/engine"
 )
-
-// pendingSelfInvalidationTTL limits how long a self-skip entry lives.
-// Lost pub/sub messages leave inert entries; this TTL prevents unbounded
-// growth in long-running processes. 30s is orders of magnitude beyond
-// typical Redis pub/sub delivery latency.
-const pendingSelfInvalidationTTL = 30 * time.Second
 
 type trieCache struct {
 	mu     sync.RWMutex
 	loadMu sync.Mutex
 	engine *matchengine.Engine
 	valid  bool
-	// pendingSelfInvalidations holds self-published message IDs so the listener
-	// can skip cache invalidation already performed by the local publisher.
-	// sync.Map is used for lock-free access by concurrent publisher/listener goroutines.
-	// Entries store time.Time values; expired entries are cleaned up lazily or via
-	// cleanupExpiredSelfInvalidations to prevent unbounded growth from lost messages.
-	pendingSelfInvalidations sync.Map
-}
-
-func skipSelfSet(c *trieCache, id string) {
-	c.pendingSelfInvalidations.Store(id, time.Now())
-}
-
-func skipSelfClear(c *trieCache, id string) {
-	c.pendingSelfInvalidations.Delete(id)
-}
-
-// skipSelfCheck atomically checks and removes a self-published message ID.
-// Returns true if the ID was found and not expired (self-message → skip invalidation).
-func skipSelfCheck(c *trieCache, id string) bool {
-	val, loaded := c.pendingSelfInvalidations.LoadAndDelete(id)
-	if !loaded {
-		return false
-	}
-	t, ok := val.(time.Time)
-	if !ok {
-		return false
-	}
-	age := time.Since(t)
-	if age < 0 {
-		return false
-	}
-	return age < pendingSelfInvalidationTTL
-}
-
-// cleanupExpiredSelfInvalidations removes stale entries to prevent unbounded map growth
-// when Redis pub/sub messages are lost. Safe for concurrent use.
-func cleanupExpiredSelfInvalidations(c *trieCache) {
-	cutoff := time.Now().Add(-pendingSelfInvalidationTTL)
-	c.pendingSelfInvalidations.Range(func(key, value interface{}) bool {
-		t, ok := value.(time.Time)
-		if !ok {
-			c.pendingSelfInvalidations.Delete(key)
-			return true
-		}
-		if t.Before(cutoff) {
-			c.pendingSelfInvalidations.Delete(key)
-		}
-		return true
-	})
+	// selfSkip holds the IDs this instance published, so the listener can skip
+	// the invalidation the publisher already applied. See selfSkipSet.
+	selfSkip selfSkipSet
 }
 
 // buildEngineFromOutputs builds a local Aho-Corasick match engine from the V2

--- a/pkg/acor/cache_test.go
+++ b/pkg/acor/cache_test.go
@@ -96,89 +96,89 @@ func TestTrieCache_ConcurrentAccess(t *testing.T) {
 	wg.Wait()
 }
 
-func TestSkipSelfCheck_AcceptsKnownID(t *testing.T) {
+func TestSelfSkipClaim_AcceptsKnownID(t *testing.T) {
 	c := &trieCache{}
-	skipSelfSet(c, "msg-1")
+	c.selfSkip.add("msg-1")
 
-	if !skipSelfCheck(c, "msg-1") {
-		t.Error("expected skipSelfCheck to return true for known ID")
+	if !c.selfSkip.claim("msg-1") {
+		t.Error("expected claim to return true for known ID")
 	}
 }
 
-func TestSkipSelfCheck_RejectsUnknownID(t *testing.T) {
+func TestSelfSkipClaim_RejectsUnknownID(t *testing.T) {
 	c := &trieCache{}
 
-	if skipSelfCheck(c, "unknown") {
-		t.Error("expected skipSelfCheck to return false for unknown ID")
+	if c.selfSkip.claim("unknown") {
+		t.Error("expected claim to return false for unknown ID")
 	}
 }
 
-func TestSkipSelfCheck_RemovesOnMatch(t *testing.T) {
+func TestSelfSkipClaim_RemovesOnMatch(t *testing.T) {
 	c := &trieCache{}
-	skipSelfSet(c, "msg-1")
+	c.selfSkip.add("msg-1")
 
-	skipSelfCheck(c, "msg-1")
+	c.selfSkip.claim("msg-1")
 
-	if skipSelfCheck(c, "msg-1") {
-		t.Error("expected second skipSelfCheck to return false (ID was consumed)")
+	if c.selfSkip.claim("msg-1") {
+		t.Error("expected second claim to return false (ID was consumed)")
 	}
 }
 
-func TestSkipSelfCheck_DoesNotLeakAcrossIDs(t *testing.T) {
+func TestSelfSkipClaim_DoesNotLeakAcrossIDs(t *testing.T) {
 	c := &trieCache{}
-	skipSelfSet(c, "msg-1")
+	c.selfSkip.add("msg-1")
 
-	if skipSelfCheck(c, "msg-2") {
+	if c.selfSkip.claim("msg-2") {
 		t.Error("msg-2 should not match msg-1's pending entry")
 	}
-	if !skipSelfCheck(c, "msg-1") {
+	if !c.selfSkip.claim("msg-1") {
 		t.Error("msg-1 should still be available after msg-2 check failed")
 	}
 }
 
-func TestSkipSelfClear(t *testing.T) {
+func TestSelfSkipForget(t *testing.T) {
 	c := &trieCache{}
-	skipSelfSet(c, "msg-1")
-	skipSelfClear(c, "msg-1")
+	c.selfSkip.add("msg-1")
+	c.selfSkip.forget("msg-1")
 
-	if skipSelfCheck(c, "msg-1") {
-		t.Error("expected skipSelfCheck to return false after skipSelfClear")
+	if c.selfSkip.claim("msg-1") {
+		t.Error("expected claim to return false after forget")
 	}
 }
 
-func TestSkipSelfCheck_RejectsExpiredID(t *testing.T) {
+func TestSelfSkipClaim_RejectsExpiredID(t *testing.T) {
 	c := &trieCache{}
 	expiredID := "expired-msg" //nolint:goconst // test value
-	c.pendingSelfInvalidations.Store(expiredID, time.Now().Add(-2*pendingSelfInvalidationTTL))
+	c.selfSkip.ids.Store(expiredID, time.Now().Add(-2*selfSkipTTL))
 
-	if skipSelfCheck(c, expiredID) {
-		t.Error("expected skipSelfCheck to return false for expired ID")
+	if c.selfSkip.claim(expiredID) {
+		t.Error("expected claim to return false for expired ID")
 	}
 }
 
-func TestCleanupExpiredSelfInvalidations(t *testing.T) {
+func TestSelfSkipSweep(t *testing.T) {
 	c := &trieCache{}
 	now := time.Now()
 	freshID := "fresh-msg"
 	expiredID := "expired-msg" //nolint:goconst // test value
 
-	c.pendingSelfInvalidations.Store(freshID, now)
-	c.pendingSelfInvalidations.Store(expiredID, now.Add(-pendingSelfInvalidationTTL).Add(-time.Second))
+	c.selfSkip.ids.Store(freshID, now)
+	c.selfSkip.ids.Store(expiredID, now.Add(-selfSkipTTL).Add(-time.Second))
 
-	cleanupExpiredSelfInvalidations(c)
+	c.selfSkip.sweep()
 
-	if skipSelfCheck(c, expiredID) {
-		t.Errorf("expected expired self-invalidation %q to be pruned by cleanupExpiredSelfInvalidations", expiredID)
+	if c.selfSkip.claim(expiredID) {
+		t.Errorf("expected expired self-invalidation %q to be pruned by sweep", expiredID)
 	}
-	if !skipSelfCheck(c, freshID) {
-		t.Errorf("expected fresh self-invalidation %q to remain consumable after cleanupExpiredSelfInvalidations", freshID)
+	if !c.selfSkip.claim(freshID) {
+		t.Errorf("expected fresh self-invalidation %q to remain consumable after sweep", freshID)
 	}
-	if skipSelfCheck(c, freshID) {
+	if c.selfSkip.claim(freshID) {
 		t.Errorf("expected fresh self-invalidation %q to be single-consumption", freshID)
 	}
 }
 
-func TestSkipSelfCheck_ConcurrentAccess(t *testing.T) {
+func TestSelfSkipClaim_ConcurrentAccess(t *testing.T) {
 	c := &trieCache{}
 	var wg sync.WaitGroup
 
@@ -195,14 +195,14 @@ func TestSkipSelfCheck_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(msgID string) {
 			defer wg.Done()
-			skipSelfSet(c, msgID)
+			c.selfSkip.add(msgID)
 		}(id)
 
 		for j := 0; j < checksPerID; j++ {
 			wg.Add(1)
 			go func(msgID string) {
 				defer wg.Done()
-				if skipSelfCheck(c, msgID) {
+				if c.selfSkip.claim(msgID) {
 					mu.Lock()
 					truePerID[msgID]++
 					totalTrue++

--- a/pkg/acor/invalidation.go
+++ b/pkg/acor/invalidation.go
@@ -23,6 +23,13 @@ import (
 // Redis pub/sub delivery latency.
 const selfSkipTTL = 30 * time.Second
 
+// invalidateIDBytes is the length of the random suffix in an invalidation ID.
+const invalidateIDBytes = 8
+
+// defaultSelfInvalidationCleanupInterval controls how often selfSkipSet.sweep
+// runs relative to publishInvalidate calls. Every N publishes triggers one O(n) sweep.
+const defaultSelfInvalidationCleanupInterval = 128
+
 // selfSkipSet remembers the invalidation IDs this process published so the
 // listener can skip the invalidation it already applied locally.
 //
@@ -30,8 +37,11 @@ const selfSkipTTL = 30 * time.Second
 // entries are swept periodically rather than on a timer: every cleanupEvery
 // publishes triggers one O(n) pass.
 type selfSkipSet struct {
-	ids          sync.Map // id -> time.Time of the publish
-	publishCount uint64
+	ids sync.Map // id -> time.Time of the publish
+	// publishCount is atomic.Uint64 rather than a bare uint64 so it stays
+	// 8-byte aligned: this struct is embedded by value, and on 386/arm (both
+	// released by goreleaser) a misaligned atomic.AddUint64 panics.
+	publishCount atomic.Uint64
 	// cleanupEvery is the number of publishes between sweeps. Zero means
 	// defaultSelfInvalidationCleanupInterval. Immutable: set it before the set
 	// is shared with the listener goroutine, since add reads it unsynchronized.
@@ -46,7 +56,7 @@ func (s *selfSkipSet) add(id string) {
 	if every == 0 {
 		every = defaultSelfInvalidationCleanupInterval
 	}
-	if atomic.AddUint64(&s.publishCount, 1)%every == 0 {
+	if s.publishCount.Add(1)%every == 0 {
 		s.sweep()
 	}
 }
@@ -91,14 +101,24 @@ func (s *selfSkipSet) sweep() {
 
 // newInvalidationID returns an id unique to this publish. The timestamp keeps
 // ids ordered for debugging; the random suffix keeps two instances publishing in
-// the same nanosecond from colliding. A failed read degrades to the timestamp
-// alone, which at worst causes an unnecessary invalidation.
+// the same nanosecond from generating the same id — a collision is the dangerous
+// direction, since the loser would mistake the winner's message for its own echo
+// and skip a real invalidation.
+//
+// The id itself contains a ':', so it must always be recovered with the
+// invalidatePayloadSplitMax-limited split isSelfEcho uses, never a full split.
 func newInvalidationID() string {
 	b := make([]byte, invalidateIDBytes)
-	if _, err := rand.Read(b); err != nil {
-		b = b[:0]
-	}
+	// Since Go 1.24 crypto/rand.Read never reports an error; it crashes the
+	// process instead, so there is no degraded path to handle here.
+	_, _ = rand.Read(b)
 	return fmt.Sprintf("%d:%x", time.Now().UnixNano(), b)
+}
+
+// invalidationPayload formats the message published on a collection's channel.
+// isSelfEcho is the matching parser; the two must stay in sync.
+func invalidationPayload(name, id string) string {
+	return name + ":" + id
 }
 
 // isSelfEcho reports whether payload is this instance's own invalidation, which

--- a/pkg/acor/invalidation.go
+++ b/pkg/acor/invalidation.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Cross-instance cache invalidation, shared by the two modes that keep local
+// state: the V2 trie cache and the preset engine. Both publish a message on the
+// collection's channel after a write and both must ignore the echo of their own
+// publish, so the bookkeeping lives here once.
+
+// selfSkipTTL bounds how long a self-published ID is remembered. A publish whose
+// message never comes back — dropped delivery, a listener restart — would
+// otherwise leak an entry forever. 30s is orders of magnitude beyond normal
+// Redis pub/sub delivery latency.
+const selfSkipTTL = 30 * time.Second
+
+// selfSkipSet remembers the invalidation IDs this process published so the
+// listener can skip the invalidation it already applied locally.
+//
+// sync.Map keeps the publisher and listener goroutines off a shared lock. Stale
+// entries are swept periodically rather than on a timer: every cleanupEvery
+// publishes triggers one O(n) pass.
+type selfSkipSet struct {
+	ids          sync.Map // id -> time.Time of the publish
+	publishCount uint64
+	// cleanupEvery is the number of publishes between sweeps. Zero means
+	// defaultSelfInvalidationCleanupInterval.
+	cleanupEvery uint64
+}
+
+// add records id as self-published and periodically sweeps expired entries.
+func (s *selfSkipSet) add(id string) {
+	s.ids.Store(id, time.Now())
+
+	every := s.cleanupEvery
+	if every == 0 {
+		every = defaultSelfInvalidationCleanupInterval
+	}
+	if atomic.AddUint64(&s.publishCount, 1)%every == 0 {
+		s.sweep()
+	}
+}
+
+// forget drops an id, for a publish that never made it to Redis.
+func (s *selfSkipSet) forget(id string) {
+	s.ids.Delete(id)
+}
+
+// claim atomically consumes id, reporting whether it was a live self-publish.
+// An expired or unknown id returns false, so the caller invalidates.
+func (s *selfSkipSet) claim(id string) bool {
+	val, loaded := s.ids.LoadAndDelete(id)
+	if !loaded {
+		return false
+	}
+	t, ok := val.(time.Time)
+	if !ok {
+		return false
+	}
+	age := time.Since(t)
+	// A negative age means the clock moved backwards; treat it as untrustworthy
+	// and invalidate rather than skip.
+	if age < 0 {
+		return false
+	}
+	return age < selfSkipTTL
+}
+
+// sweep removes expired entries so lost messages cannot grow the map without
+// bound. Safe for concurrent use.
+func (s *selfSkipSet) sweep() {
+	cutoff := time.Now().Add(-selfSkipTTL)
+	s.ids.Range(func(key, value interface{}) bool {
+		t, ok := value.(time.Time)
+		if !ok || t.Before(cutoff) {
+			s.ids.Delete(key)
+		}
+		return true
+	})
+}
+
+// newInvalidationID returns an id unique to this publish. The timestamp keeps
+// ids ordered for debugging; the random suffix keeps two instances publishing in
+// the same nanosecond from colliding. A failed read degrades to the timestamp
+// alone, which at worst causes an unnecessary invalidation.
+func newInvalidationID() string {
+	b := make([]byte, invalidateIDBytes)
+	if _, err := rand.Read(b); err != nil {
+		b = b[:0]
+	}
+	return fmt.Sprintf("%d:%x", time.Now().UnixNano(), b)
+}
+
+// isSelfEcho reports whether payload is this instance's own invalidation, which
+// has already been applied locally. A payload that does not parse, or names a
+// different collection, counts as foreign: a corrupt message then still
+// invalidates instead of silently leaving stale data behind.
+func isSelfEcho(payload, name string, skip *selfSkipSet) bool {
+	parts := strings.SplitN(payload, ":", invalidatePayloadSplitMax)
+	if len(parts) != invalidatePayloadSplitMax || parts[0] != name {
+		return false
+	}
+	return skip.claim(parts[1])
+}
+
+// subscribeInvalidations subscribes to the collection's invalidation channel and
+// calls onMessage for every payload received, until stopCh is closed, ctx is
+// canceled, or the subscription channel closes. The caller closes the returned
+// Subscription to release the connection.
+func subscribeInvalidations(ctx context.Context, storage KVStorage, name string,
+	stopCh <-chan struct{}, onMessage func(payload string)) (Subscription, error) {
+	pubsub := storage.Subscribe(ctx, invalidateChannelPrefix+name)
+	if err := pubsub.Receive(ctx); err != nil {
+		_ = pubsub.Close()
+		return nil, err
+	}
+
+	go func() {
+		msgCh := pubsub.Channel()
+		for {
+			select {
+			case msg, ok := <-msgCh:
+				if !ok {
+					return
+				}
+				onMessage(msg.Payload)
+			case <-stopCh:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return pubsub, nil
+}

--- a/pkg/acor/invalidation.go
+++ b/pkg/acor/invalidation.go
@@ -33,7 +33,8 @@ type selfSkipSet struct {
 	ids          sync.Map // id -> time.Time of the publish
 	publishCount uint64
 	// cleanupEvery is the number of publishes between sweeps. Zero means
-	// defaultSelfInvalidationCleanupInterval.
+	// defaultSelfInvalidationCleanupInterval. Immutable: set it before the set
+	// is shared with the listener goroutine, since add reads it unsynchronized.
 	cleanupEvery uint64
 }
 

--- a/pkg/acor/invalidation_test.go
+++ b/pkg/acor/invalidation_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestIsSelfEcho(t *testing.T) {
+	const name = "coll"
+
+	tests := []struct {
+		name    string
+		payload string
+		want    bool
+	}{
+		{"own publish", name + ":msg-1", true},
+		{"unknown id", name + ":msg-other", false},
+		{"other collection", "other:msg-1", false},
+		{"no separator", name, false},
+		{"empty id", name + ":", false},
+		{"id keeps trailing segments", name + ":msg-1:extra", false},
+		{"empty payload", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var skip selfSkipSet
+			skip.add("msg-1")
+
+			if got := isSelfEcho(tt.payload, name, &skip); got != tt.want {
+				t.Errorf("isSelfEcho(%q, %q) = %v, want %v", tt.payload, name, got, tt.want)
+			}
+		})
+	}
+}
+
+// stubSubscription is a Subscription whose message channel the test drives.
+type stubSubscription struct {
+	msgCh      chan PubSubMessage
+	receiveErr error
+	closed     chan struct{}
+}
+
+func newStubSubscription() *stubSubscription {
+	return &stubSubscription{msgCh: make(chan PubSubMessage), closed: make(chan struct{}, 1)}
+}
+
+func (s *stubSubscription) Receive(context.Context) error { return s.receiveErr }
+func (s *stubSubscription) Channel() <-chan PubSubMessage { return s.msgCh }
+func (s *stubSubscription) Close() error                  { s.closed <- struct{}{}; return nil }
+
+// stubSubStorage only supports Subscribe; the embedded nil interface panics if
+// subscribeInvalidations ever reaches for another method.
+type stubSubStorage struct {
+	KVStorage
+	sub Subscription
+}
+
+func (s stubSubStorage) Subscribe(context.Context, ...string) Subscription { return s.sub }
+
+func TestSubscribeInvalidations_DeliversPayloads(t *testing.T) {
+	sub := newStubSubscription()
+	got := make(chan string, 1)
+
+	pubsub, err := subscribeInvalidations(context.Background(), stubSubStorage{sub: sub},
+		"coll", make(chan struct{}), func(payload string) { got <- payload })
+	if err != nil {
+		t.Fatalf("subscribeInvalidations failed: %v", err)
+	}
+	defer func() { _ = pubsub.Close() }()
+
+	sub.msgCh <- PubSubMessage{Payload: "coll:msg-1"}
+
+	select {
+	case payload := <-got:
+		if payload != "coll:msg-1" {
+			t.Errorf("got payload %q, want %q", payload, "coll:msg-1")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("onMessage was never called")
+	}
+}
+
+func TestSubscribeInvalidations_ReceiveErrorClosesSubscription(t *testing.T) {
+	wantErr := errors.New("subscribe confirm failed")
+	sub := newStubSubscription()
+	sub.receiveErr = wantErr
+
+	pubsub, err := subscribeInvalidations(context.Background(), stubSubStorage{sub: sub},
+		"coll", make(chan struct{}), func(string) { t.Error("onMessage called after Receive error") })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got error %v, want %v", err, wantErr)
+	}
+	if pubsub != nil {
+		t.Error("expected nil Subscription on Receive error")
+	}
+	select {
+	case <-sub.closed:
+	default:
+		t.Error("expected the subscription to be closed on Receive error")
+	}
+}
+
+func TestSubscribeInvalidations_StopsOnStopCh(t *testing.T) {
+	sub := newStubSubscription()
+	stopCh := make(chan struct{})
+
+	if _, err := subscribeInvalidations(context.Background(), stubSubStorage{sub: sub},
+		"coll", stopCh, func(string) {}); err != nil {
+		t.Fatalf("subscribeInvalidations failed: %v", err)
+	}
+
+	close(stopCh)
+	assertListenerStopped(t, sub.msgCh)
+}
+
+func TestSubscribeInvalidations_StopsOnContextCancel(t *testing.T) {
+	sub := newStubSubscription()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if _, err := subscribeInvalidations(ctx, stubSubStorage{sub: sub},
+		"coll", make(chan struct{}), func(string) {}); err != nil {
+		t.Fatalf("subscribeInvalidations failed: %v", err)
+	}
+
+	cancel()
+	assertListenerStopped(t, sub.msgCh)
+}
+
+// assertListenerStopped verifies the listener goroutine has returned: a send on
+// its unbuffered message channel only completes while it is still selecting.
+// A live goroutine may deliver one more message before it notices the stop
+// signal (select picks a ready case at random), so retry until a send blocks.
+func assertListenerStopped(t *testing.T, msgCh chan PubSubMessage) {
+	t.Helper()
+
+	const attempts = 20
+	for i := 0; i < attempts; i++ {
+		select {
+		case msgCh <- PubSubMessage{Payload: "coll:msg-1"}:
+		case <-time.After(100 * time.Millisecond):
+			return
+		}
+	}
+	t.Fatalf("listener still consuming messages after %d sends past the stop signal", attempts)
+}

--- a/pkg/acor/invalidation_test.go
+++ b/pkg/acor/invalidation_test.go
@@ -38,6 +38,23 @@ func TestIsSelfEcho(t *testing.T) {
 	}
 }
 
+// TestIsSelfEcho_RoundTripsGeneratedID guards the load-bearing detail that a real
+// invalidation ID itself contains a ':': only the limited SplitN in isSelfEcho
+// recovers it intact. A plain strings.Split here would silently turn every
+// self-echo into a redundant invalidation, and the literal IDs above would not
+// catch it.
+func TestIsSelfEcho_RoundTripsGeneratedID(t *testing.T) {
+	const name = "coll"
+
+	var skip selfSkipSet
+	id := newInvalidationID()
+	skip.add(id)
+
+	if !isSelfEcho(invalidationPayload(name, id), name, &skip) {
+		t.Errorf("isSelfEcho did not recognize its own payload for generated ID %q", id)
+	}
+}
+
 // stubSubscription is a Subscription whose message channel the test drives.
 type stubSubscription struct {
 	msgCh      chan PubSubMessage
@@ -65,12 +82,16 @@ func (s stubSubStorage) Subscribe(context.Context, ...string) Subscription { ret
 func TestSubscribeInvalidations_DeliversPayloads(t *testing.T) {
 	sub := newStubSubscription()
 	got := make(chan string, 1)
+	stopCh := make(chan struct{})
 
 	pubsub, err := subscribeInvalidations(context.Background(), stubSubStorage{sub: sub},
-		"coll", make(chan struct{}), func(payload string) { got <- payload })
+		"coll", stopCh, func(payload string) { got <- payload })
 	if err != nil {
 		t.Fatalf("subscribeInvalidations failed: %v", err)
 	}
+	// Closing the stub Subscription does not close its channel, so the listener
+	// goroutine only exits via stopCh.
+	t.Cleanup(func() { close(stopCh) })
 	defer func() { _ = pubsub.Close() }()
 
 	sub.msgCh <- PubSubMessage{Payload: "coll:msg-1"}

--- a/pkg/acor/pubsub.go
+++ b/pkg/acor/pubsub.go
@@ -12,14 +12,17 @@ const (
 func (ac *AhoCorasick) startCacheListener() error {
 	ac.stopCh = make(chan struct{})
 
+	// Bind the cache once per message: RollbackToV1 clears ac.cache, so re-reading
+	// the field mid-callback can hand us a nil pointer between the guard and the use.
+	cache := ac.cache
 	pubsub, err := subscribeInvalidations(ac.ctx, ac.storage, ac.name, ac.stopCh, func(payload string) {
-		if ac.cache == nil {
+		if cache == nil {
 			return
 		}
-		if isSelfEcho(payload, ac.name, &ac.cache.selfSkip) {
+		if isSelfEcho(payload, ac.name, &cache.selfSkip) {
 			return
 		}
-		ac.cache.invalidate()
+		cache.invalidate()
 	})
 	if err != nil {
 		return fmt.Errorf("pub/sub connection failed: %w", err)
@@ -29,11 +32,15 @@ func (ac *AhoCorasick) startCacheListener() error {
 	return nil
 }
 
+// stopCacheListener is idempotent: RollbackToV1 stops the listener mid-life and
+// Close stops it again, and closing an already-closed stopCh would panic.
 func (ac *AhoCorasick) stopCacheListener() {
 	if ac.stopCh != nil {
 		close(ac.stopCh)
+		ac.stopCh = nil
 	}
 	if ac.pubsub != nil {
 		_ = ac.pubsub.Close()
+		ac.pubsub = nil
 	}
 }

--- a/pkg/acor/pubsub.go
+++ b/pkg/acor/pubsub.go
@@ -2,10 +2,7 @@
 
 package acor
 
-import (
-	"fmt"
-	"strings"
-)
+import "fmt"
 
 const (
 	invalidateChannelPrefix   = "acor:invalidate:"
@@ -13,41 +10,22 @@ const (
 )
 
 func (ac *AhoCorasick) startCacheListener() error {
-	channel := invalidateChannelPrefix + ac.name
-	pubsub := ac.storage.Subscribe(ac.ctx, channel)
+	ac.stopCh = make(chan struct{})
 
-	if err := pubsub.Receive(ac.ctx); err != nil {
-		_ = pubsub.Close()
+	pubsub, err := subscribeInvalidations(ac.ctx, ac.storage, ac.name, ac.stopCh, func(payload string) {
+		if ac.cache == nil {
+			return
+		}
+		if isSelfEcho(payload, ac.name, &ac.cache.selfSkip) {
+			return
+		}
+		ac.cache.invalidate()
+	})
+	if err != nil {
 		return fmt.Errorf("pub/sub connection failed: %w", err)
 	}
 
 	ac.pubsub = pubsub
-	ac.stopCh = make(chan struct{})
-
-	go func() {
-		msgCh := pubsub.Channel()
-		for {
-			select {
-			case msg, ok := <-msgCh:
-				if !ok {
-					return
-				}
-				if ac.cache != nil {
-					if parts := strings.SplitN(msg.Payload, ":", invalidatePayloadSplitMax); len(parts) == invalidatePayloadSplitMax && parts[0] == ac.name {
-						if skipSelfCheck(ac.cache, parts[1]) {
-							continue
-						}
-						ac.cache.invalidate()
-					}
-				}
-			case <-ac.stopCh:
-				return
-			case <-ac.ctx.Done():
-				return
-			}
-		}
-	}()
-
 	return nil
 }
 

--- a/pkg/acor/redis_backed.go
+++ b/pkg/acor/redis_backed.go
@@ -4,7 +4,6 @@ package acor
 
 import (
 	"context"
-	"crypto/rand"
 	"fmt"
 	"strings"
 	"sync"
@@ -39,15 +38,14 @@ type redisBackedAC struct {
 	stale        bool
 	pollInterval time.Duration
 
-	selfSkip      sync.Map
-	selfSkipCount uint64
-	reloadGroup   singleflight.Group
-	pubsub        Subscription
-	stopCh        chan struct{}
-	ctx           context.Context
-	cancel        context.CancelFunc
-	closeOnce     sync.Once
-	closed        int32
+	selfSkip    selfSkipSet
+	reloadGroup singleflight.Group
+	pubsub      Subscription
+	stopCh      chan struct{}
+	ctx         context.Context
+	cancel      context.CancelFunc
+	closeOnce   sync.Once
+	closed      int32
 }
 
 // newRedisBacked creates a Redis-backed Aho-Corasick engine. It loads the
@@ -223,8 +221,6 @@ func (ac *redisBackedAC) ensureValid(ctx context.Context) error {
 
 // --- Pub/Sub ---
 
-const selfInvalTTL = 30 * time.Second
-
 // publishRetryAttempts / publishRetryBackoff give the fire-and-forget invalidation
 // PUBLISH a few tries before giving up, so a single transient blip does not drop a
 // whole batch's cross-node notification. The version poller (InvalidationPollInterval)
@@ -235,41 +231,20 @@ const (
 )
 
 func (ac *redisBackedAC) startListener() error {
-	channel := invalidateChannelPrefix + ac.name
-	pubsub := ac.storage.Subscribe(ac.ctx, channel)
-	if err := pubsub.Receive(ac.ctx); err != nil {
-		_ = pubsub.Close()
+	ac.stopCh = make(chan struct{})
+
+	pubsub, err := subscribeInvalidations(ac.ctx, ac.storage, ac.name, ac.stopCh, ac.handleInvalidation)
+	if err != nil {
 		return err
 	}
 
 	ac.pubsub = pubsub
-	ac.stopCh = make(chan struct{})
-
-	go func() {
-		msgCh := pubsub.Channel()
-		for {
-			select {
-			case msg, ok := <-msgCh:
-				if !ok {
-					return
-				}
-				ac.handleInvalidation(msg.Payload)
-			case <-ac.stopCh:
-				return
-			case <-ac.ctx.Done():
-				return
-			}
-		}
-	}()
-
 	return nil
 }
 
 func (ac *redisBackedAC) handleInvalidation(payload string) {
-	if parts := strings.SplitN(payload, ":", invalidatePayloadSplitMax); len(parts) == invalidatePayloadSplitMax && parts[0] == ac.name {
-		if ac.skipSelfCheck(parts[1]) {
-			return
-		}
+	if isSelfEcho(payload, ac.name, &ac.selfSkip) {
+		return
 	}
 	ac.markStale()
 }
@@ -310,35 +285,12 @@ func (ac *redisBackedAC) pollVersion() {
 	}
 }
 
-func (ac *redisBackedAC) skipSelfSet(id string) {
-	ac.selfSkip.Store(id, time.Now())
-}
-
-func (ac *redisBackedAC) skipSelfCheck(id string) bool {
-	val, loaded := ac.selfSkip.LoadAndDelete(id)
-	if !loaded {
-		return false
-	}
-	t, ok := val.(time.Time)
-	if !ok {
-		return false
-	}
-	return time.Since(t) < selfInvalTTL
-}
-
 func (ac *redisBackedAC) publishInvalidate(ctx context.Context) {
 	channel := invalidateChannelPrefix + ac.name
-	b := make([]byte, invalidateIDBytes)
-	if _, err := rand.Read(b); err != nil {
-		b = b[:0]
-	}
-	msgID := fmt.Sprintf("%d:%x", time.Now().UnixNano(), b)
+	msgID := newInvalidationID()
 	payload := ac.name + ":" + msgID
 
-	ac.skipSelfSet(msgID)
-	if atomic.AddUint64(&ac.selfSkipCount, 1)%defaultSelfInvalidationCleanupInterval == 0 {
-		ac.cleanupExpiredSelfSkips()
-	}
+	ac.selfSkip.add(msgID)
 
 	var err error
 	for attempt := 0; attempt < publishRetryAttempts; attempt++ {
@@ -351,23 +303,12 @@ func (ac *redisBackedAC) publishInvalidate(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			// Undelivered: drop the self-skip entry so it does not linger, then stop.
-			ac.selfSkip.Delete(msgID)
+			ac.selfSkip.forget(msgID)
 			return
 		case <-time.After(publishRetryBackoff):
 		}
 	}
 	if err != nil {
-		ac.selfSkip.Delete(msgID)
+		ac.selfSkip.forget(msgID)
 	}
-}
-
-func (ac *redisBackedAC) cleanupExpiredSelfSkips() {
-	cutoff := time.Now().Add(-selfInvalTTL)
-	ac.selfSkip.Range(func(key, value interface{}) bool {
-		t, ok := value.(time.Time)
-		if !ok || t.Before(cutoff) {
-			ac.selfSkip.Delete(key)
-		}
-		return true
-	})
 }

--- a/pkg/acor/redis_backed.go
+++ b/pkg/acor/redis_backed.go
@@ -81,6 +81,9 @@ func newRedisBacked(ctx context.Context, args *AhoCorasickArgs) (*redisBackedAC,
 		ctx:           acCtx,
 		cancel:        acCancel,
 	}
+	// Set before startListener shares the set with the listener goroutine;
+	// selfSkipSet reads it without synchronization. Zero means the default.
+	ac.selfSkip.cleanupEvery = args.SelfInvalidationCleanupInterval
 
 	if err := ac.initTrie(ctx); err != nil {
 		acCancel()
@@ -288,7 +291,7 @@ func (ac *redisBackedAC) pollVersion() {
 func (ac *redisBackedAC) publishInvalidate(ctx context.Context) {
 	channel := invalidateChannelPrefix + ac.name
 	msgID := newInvalidationID()
-	payload := ac.name + ":" + msgID
+	payload := invalidationPayload(ac.name, msgID)
 
 	ac.selfSkip.add(msgID)
 

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -13,15 +13,9 @@ import (
 	matchengine "github.com/skyoo2003/acor/internal/engine"
 )
 
-// defaultSelfInvalidationCleanupInterval controls how often selfSkipSet.sweep
-// runs relative to publishInvalidate calls. Every N publishes triggers one O(n) sweep.
-const defaultSelfInvalidationCleanupInterval = 128
-
 const maxRetries = 3
 
 const retryBackoffBase = 10 * time.Millisecond
-
-const invalidateIDBytes = 8
 
 // Compile-time check that v2Operations satisfies the operations interface.
 var _ operations = (*v2Operations)(nil)
@@ -279,7 +273,7 @@ func (o *v2Operations) publishInvalidate(ctx context.Context) {
 		o.cache.selfSkip.add(msgID)
 	}
 
-	err := o.storage.Publish(ctx, channel, o.name+":"+msgID)
+	err := o.storage.Publish(ctx, channel, invalidationPayload(o.name, msgID))
 	if err != nil {
 		if o.cache != nil {
 			o.cache.selfSkip.forget(msgID)

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -13,7 +13,7 @@ import (
 	matchengine "github.com/skyoo2003/acor/internal/engine"
 )
 
-// defaultSelfInvalidationCleanupInterval controls how often cleanupExpiredSelfInvalidations
+// defaultSelfInvalidationCleanupInterval controls how often selfSkipSet.sweep
 // runs relative to publishInvalidate calls. Every N publishes triggers one O(n) sweep.
 const defaultSelfInvalidationCleanupInterval = 128
 
@@ -30,13 +30,12 @@ var _ operations = (*v2Operations)(nil)
 // It holds all dependencies needed for V2 Aho-Corasick operations without
 // depending directly on the AhoCorasick struct.
 type v2Operations struct {
-	storage                         KVStorage
-	client                          redis.UniversalClient
-	name                            string
-	cache                           *trieCache
-	logger                          Logger
-	selfInvalidationCleanupInterval uint64
-	caseSensitive                   bool
+	storage       KVStorage
+	client        redis.UniversalClient
+	name          string
+	cache         *trieCache
+	logger        Logger
+	caseSensitive bool
 }
 
 // --- operations interface methods ---
@@ -277,7 +276,6 @@ func (o *v2Operations) publishInvalidate(ctx context.Context) {
 	msgID := newInvalidationID()
 
 	if o.cache != nil {
-		o.cache.selfSkip.cleanupEvery = o.selfInvalidationCleanupInterval
 		o.cache.selfSkip.add(msgID)
 	}
 

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -4,11 +4,8 @@ package acor
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
-	"fmt"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -38,7 +35,6 @@ type v2Operations struct {
 	name                            string
 	cache                           *trieCache
 	logger                          Logger
-	selfInvalidationPublishCount    uint64
 	selfInvalidationCleanupInterval uint64
 	caseSensitive                   bool
 }
@@ -278,29 +274,21 @@ func (o *v2Operations) loadEngine(ctx context.Context) (*matchengine.Engine, err
 // unique ID to avoid a leakable counter when skipping self-messages.
 func (o *v2Operations) publishInvalidate(ctx context.Context) {
 	channel := invalidateChannelPrefix + o.name
-	b := make([]byte, invalidateIDBytes)
-	if _, err := rand.Read(b); err != nil && o.logger != nil {
-		o.logger.Printf("failed to generate random invalidation ID, using zero bytes: %v", err)
-	}
-	msgID := fmt.Sprintf("%d:%x", time.Now().UnixNano(), b)
-	payload := o.name + ":" + msgID
+	msgID := newInvalidationID()
 
 	if o.cache != nil {
-		skipSelfSet(o.cache, msgID)
-		interval := o.selfInvalidationCleanupInterval
-		if interval == 0 {
-			interval = defaultSelfInvalidationCleanupInterval
-		}
-		if atomic.AddUint64(&o.selfInvalidationPublishCount, 1)%interval == 0 {
-			cleanupExpiredSelfInvalidations(o.cache)
-		}
+		o.cache.selfSkip.cleanupEvery = o.selfInvalidationCleanupInterval
+		o.cache.selfSkip.add(msgID)
 	}
-	err := o.storage.Publish(ctx, channel, payload)
-	if err != nil && o.cache != nil {
-		skipSelfClear(o.cache, msgID)
-	}
-	if err != nil && o.logger != nil {
-		o.logger.Printf("failed to publish cache invalidation: channel=%s error=%v", channel, err)
+
+	err := o.storage.Publish(ctx, channel, o.name+":"+msgID)
+	if err != nil {
+		if o.cache != nil {
+			o.cache.selfSkip.forget(msgID)
+		}
+		if o.logger != nil {
+			o.logger.Printf("failed to publish cache invalidation: channel=%s error=%v", channel, err)
+		}
 	}
 	if o.cache != nil {
 		o.cache.invalidate()


### PR DESCRIPTION
# Pull Request

## Description

The V2 trie cache and the preset engine each carried their own copy of the same mechanism:

- a `sync.Map` of self-published message IDs keyed to a publish time
- a 30s TTL constant (`pendingSelfInvalidationTTL` and `selfInvalTTL`, same value)
- a periodic sweep of expired entries
- a pub/sub listener goroutine parsing `"<name>:<id>"` payloads to decide whether a message was its own echo

`invalidation.go` now holds that once:

- **`selfSkipSet`** — `add` / `forget` / `claim` / `sweep`, with the sweep interval configurable so `AhoCorasickArgs.SelfInvalidationCleanupInterval` keeps working as documented
- **`newInvalidationID`** — timestamp plus random suffix
- **`isSelfEcho`** — payload parsing and the skip decision
- **`subscribeInvalidations`** — the listener goroutine, parameterised by an `onMessage` callback

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — skip for internal-only changes (CI, tests, refactors); see [RELEASE.md](../RELEASE.md)
- [x] Commit messages follow guidelines

No changelog fragment: the one behaviour difference below is unreachable without a corrupt pub/sub payload.