### PR TITLE
refactor: replace the hand-rolled worker pools with errgroup

### DIFF
--- a/changes/unreleased/Fixed-20260727-231913.yaml
+++ b/changes/unreleased/Fixed-20260727-231913.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: |-
+    `FindParallelContext` now deduplicates its results for short texts, matching `FindParallel` and the documented contract that each keyword appears at most once. Previously a text that fit in a single chunk took a shortcut that returned every occurrence, so the result shape depended on the input length.
+time: 2026-07-27T23:19:13.000000+09:00
+custom:
+    Issue: "172"

--- a/changes/unreleased/Fixed-20260728-101500.yaml
+++ b/changes/unreleased/Fixed-20260728-101500.yaml
@@ -1,0 +1,6 @@
+kind: Fixed
+body: |-
+    The `Preset` modes now honor a canceled or expired context in `FindContext`, `FindIndexContext` and their parallel variants. They match against a local in-memory engine, so once the engine was warm no Redis call was made and the context was never consulted: a call with an already-canceled context ran the full scan and returned complete results with a nil error. They now return the context error, matching the V2 schema mode.
+time: 2026-07-28T10:15:00.000000+09:00
+custom:
+    Issue: "172"

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -169,7 +169,9 @@ const rollbackBatchWorkers = 10
 // batchWriter modes, where each write already rebuilt and published).
 //
 // Errors are logged, not returned: this is the failure path already, and the
-// caller is about to return the original error.
+// caller is about to return the original error. ctx is not checked for
+// cancellation either: callers pass context.WithoutCancel so the undo still runs
+// when the batch failed because the caller's context went away.
 func (ac *AhoCorasick) rollbackBatch(ctx context.Context, keywords []string, op string,
 	undo func(context.Context, string) (int, error), commit func(context.Context)) {
 	if len(keywords) == 0 {
@@ -177,11 +179,8 @@ func (ac *AhoCorasick) rollbackBatch(ctx context.Context, keywords []string, op 
 	}
 
 	var g errgroup.Group
-	g.SetLimit(min(rollbackBatchWorkers, len(keywords)))
+	g.SetLimit(rollbackBatchWorkers)
 	for _, keyword := range keywords {
-		if ctx.Err() != nil {
-			break
-		}
 		g.Go(func() error {
 			if _, err := undo(ctx, keyword); err != nil && ac.logger != nil {
 				ac.logger.Printf("rollback: failed to %s %q: %v", op, keyword, err)

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -6,7 +6,8 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"sync"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // batchWriter is implemented by modes (preset) that can coalesce the local
@@ -146,43 +147,49 @@ func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []stri
 	return result, nil
 }
 
+// rollbackAdded undoes the adds a failed transactional batch already committed.
 func (ac *AhoCorasick) rollbackAdded(ctx context.Context, keywords []string) {
+	remove, commit := ac.batchRemoveFns()
+	ac.rollbackBatch(ctx, keywords, "remove", remove, commit)
+}
+
+// rollbackRemoved re-adds the removes a failed transactional batch already committed.
+func (ac *AhoCorasick) rollbackRemoved(ctx context.Context, keywords []string) {
+	add, commit := ac.batchAddFns()
+	ac.rollbackBatch(ctx, keywords, "re-add", add, commit)
+}
+
+// rollbackBatchWorkers caps how many undo operations run at once. Rollback is
+// off the hot path and hits Redis per keyword, so a small fixed pool is enough.
+const rollbackBatchWorkers = 10
+
+// rollbackBatch applies undo to every keyword concurrently and then commits once.
+// It uses the deferred write plus a single commit so a failed batch triggers one
+// rebuild and publish rather than one per keyword (commit is a no-op outside
+// batchWriter modes, where each write already rebuilt and published).
+//
+// Errors are logged, not returned: this is the failure path already, and the
+// caller is about to return the original error.
+func (ac *AhoCorasick) rollbackBatch(ctx context.Context, keywords []string, op string,
+	undo func(context.Context, string) (int, error), commit func(context.Context)) {
 	if len(keywords) == 0 {
 		return
 	}
 
-	// Use the deferred write + single commit so a failed batch triggers one
-	// rebuild/publish, not one per rolled-back keyword (commit is a no-op outside
-	// batchWriter modes, where each remove already rebuilt/published).
-	remove, commit := ac.batchRemoveFns()
-
-	maxWorkers := 10
-	if len(keywords) < maxWorkers {
-		maxWorkers = len(keywords)
-	}
-
-	sem := make(chan struct{}, maxWorkers)
-	var wg sync.WaitGroup
-
+	var g errgroup.Group
+	g.SetLimit(min(rollbackBatchWorkers, len(keywords)))
 	for _, keyword := range keywords {
-		select {
-		case sem <- struct{}{}:
-		case <-ctx.Done():
-			wg.Wait()
-			return
+		if ctx.Err() != nil {
+			break
 		}
-		wg.Add(1)
-		go func(k string) {
-			defer func() {
-				<-sem
-				wg.Done()
-			}()
-			if _, err := remove(ctx, k); err != nil && ac.logger != nil {
-				ac.logger.Printf("rollback: failed to remove %q: %v", k, err)
+		g.Go(func() error {
+			if _, err := undo(ctx, keyword); err != nil && ac.logger != nil {
+				ac.logger.Printf("rollback: failed to %s %q: %v", op, keyword, err)
 			}
-		}(keyword)
+			return nil
+		})
 	}
-	wg.Wait()
+	_ = g.Wait()
 	commit(ctx)
 }
 
@@ -294,44 +301,6 @@ func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []s
 
 	result.Removed = removed
 	return result, nil
-}
-
-func (ac *AhoCorasick) rollbackRemoved(ctx context.Context, keywords []string) {
-	if len(keywords) == 0 {
-		return
-	}
-
-	// Deferred write + single commit, mirroring rollbackAdded.
-	add, commit := ac.batchAddFns()
-
-	maxWorkers := 10
-	if len(keywords) < maxWorkers {
-		maxWorkers = len(keywords)
-	}
-
-	sem := make(chan struct{}, maxWorkers)
-	var wg sync.WaitGroup
-
-	for _, keyword := range keywords {
-		select {
-		case sem <- struct{}{}:
-		case <-ctx.Done():
-			wg.Wait()
-			return
-		}
-		wg.Add(1)
-		go func(k string) {
-			defer func() {
-				<-sem
-				wg.Done()
-			}()
-			if _, err := add(ctx, k); err != nil && ac.logger != nil {
-				ac.logger.Printf("rollback: failed to re-add %q: %v", k, err)
-			}
-		}(keyword)
-	}
-	wg.Wait()
-	commit(ctx)
 }
 
 // FindMany searches for keywords in multiple texts and returns a map of text to matches.

--- a/pkg/acor/batch_parallel_test.go
+++ b/pkg/acor/batch_parallel_test.go
@@ -8,42 +8,66 @@ import (
 	"testing"
 )
 
-func TestParallelContextCancellation(t *testing.T) {
-	ac, mr := createAhoCorasick(t)
-	defer mr.Close()
-	defer func() { _ = ac.Close() }()
+// parallelCancellationTargets covers both ops implementations: V2 reaches Redis
+// per find, the preset mode matches against a warm in-memory engine and so only
+// sees cancellation if it checks ctx itself.
+func parallelCancellationTargets(t *testing.T) map[string]*AhoCorasick {
+	t.Helper()
 
-	if _, err := ac.Add("he"); err != nil {
+	v2, mr := createAhoCorasick(t)
+	t.Cleanup(func() { _ = v2.Close(); mr.Close() })
+
+	presetMR := createTestRedisServer(t)
+	preset, err := Create(&AhoCorasickArgs{Addr: presetMR.Addr(), Name: "cancel-preset", Preset: PresetBalanced})
+	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { _ = preset.Close() })
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	for _, ac := range []*AhoCorasick{v2, preset} {
+		if _, err := ac.Add("he"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return map[string]*AhoCorasick{"v2": v2, "preset": preset}
+}
 
+func TestParallelContextCancellation(t *testing.T) {
 	longText := strings.Repeat("he is here ", 100)
-	_, _ = ac.FindParallelContext(ctx, longText, &ParallelOptions{
-		ChunkSize: 20,
-		Workers:   2,
-	})
+
+	for name, ac := range parallelCancellationTargets(t) {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			got, err := ac.FindParallelContext(ctx, longText, &ParallelOptions{
+				ChunkSize: 20,
+				Workers:   2,
+			})
+			if err == nil {
+				t.Fatalf("FindParallelContext() on a canceled context returned %v, want an error", got)
+			}
+		})
+	}
 }
 
 func TestParallelIndexContextCancellation(t *testing.T) {
-	ac, mr := createAhoCorasick(t)
-	defer mr.Close()
-	defer func() { _ = ac.Close() }()
-
-	if _, err := ac.Add("he"); err != nil {
-		t.Fatal(err)
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
 	longText := strings.Repeat("he is here ", 100)
-	_, _ = ac.FindIndexParallelContext(ctx, longText, &ParallelOptions{
-		ChunkSize: 20,
-		Workers:   2,
-	})
+
+	for name, ac := range parallelCancellationTargets(t) {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			got, err := ac.FindIndexParallelContext(ctx, longText, &ParallelOptions{
+				ChunkSize: 20,
+				Workers:   2,
+			})
+			if err == nil {
+				t.Fatalf("FindIndexParallelContext() on a canceled context returned %v, want an error", got)
+			}
+		})
+	}
 }
 
 func TestFindParallelInvalidChunkSize(t *testing.T) {

--- a/pkg/acor/context_ops.go
+++ b/pkg/acor/context_ops.go
@@ -2,10 +2,7 @@
 
 package acor
 
-import (
-	"context"
-	"sort"
-)
+import "context"
 
 // AddContext inserts a keyword with context for cancellation and timeout propagation.
 func (ac *AhoCorasick) AddContext(ctx context.Context, keyword string) (int, error) {
@@ -101,6 +98,7 @@ func (ac *AhoCorasick) FindManyContext(ctx context.Context, texts []string) (map
 }
 
 // FindParallelContext searches for keywords using parallel processing with context.
+// Like FindParallel, the result is a set: each keyword appears at most once.
 func (ac *AhoCorasick) FindParallelContext(ctx context.Context, text string, opts *ParallelOptions) ([]string, error) {
 	opts = normalizeParallelOptions(opts)
 	if opts.ChunkSize <= 0 {
@@ -111,17 +109,19 @@ func (ac *AhoCorasick) FindParallelContext(ctx context.Context, text string, opt
 	if len(chunks) == 0 {
 		return []string{}, nil
 	}
-	if len(chunks) == 1 {
-		return ac.FindContext(ctx, text)
-	}
 
-	results, errors := runStringWorkersCtx(ctx, ac, chunks, opts.Workers)
-	allMatches, err := collectOrderedStringResults(results, errors)
-
+	perChunk, err := scanChunks(ctx, chunks, opts.Workers, func(ctx context.Context, c chunk) ([]string, error) {
+		return ac.ops.find(ctx, c.text)
+	})
 	if err != nil {
 		return nil, err
 	}
-	return allMatches, nil
+
+	var all []string
+	for _, matches := range perChunk {
+		all = append(all, matches...)
+	}
+	return dedupPreservingOrder(all), nil
 }
 
 // FindIndexParallelContext searches for keywords with indices using parallel processing with context.
@@ -135,24 +135,12 @@ func (ac *AhoCorasick) FindIndexParallelContext(ctx context.Context, text string
 	if len(chunks) == 0 {
 		return map[string][]int{}, nil
 	}
-	if len(chunks) == 1 {
-		return ac.FindIndexContext(ctx, text)
-	}
 
-	results, errors := runIndexWorkersCtx(ctx, ac, chunks, opts.Workers)
-	allMatches, err := collectIndexResults(results, errors)
+	perChunk, err := scanChunks(ctx, chunks, opts.Workers, func(ctx context.Context, c chunk) (map[string][]int, error) {
+		return ac.ops.findIndex(ctx, c.text)
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	result := make(map[string][]int)
-	for keyword, indices := range allMatches {
-		sortedIndices := make([]int, 0, len(indices))
-		for idx := range indices {
-			sortedIndices = append(sortedIndices, idx)
-		}
-		sort.Ints(sortedIndices)
-		result[keyword] = sortedIndices
-	}
-	return result, nil
+	return mergeIndexResults(chunks, perChunk), nil
 }

--- a/pkg/acor/find_test.go
+++ b/pkg/acor/find_test.go
@@ -312,6 +312,9 @@ func TestFindParallelEdgeCases(t *testing.T) {
 		{"sentence boundaries", "test hello world.", &ParallelOptions{Workers: 2, ChunkSize: 10, Boundary: ChunkBoundarySentence}},
 		{"nil options uses defaults", "test hello world", nil},
 		{"single worker", "test hello world", &ParallelOptions{Workers: 1, ChunkSize: 100}},
+		// Repeats inside one chunk: Find reports every occurrence, FindParallel a set.
+		{"repeated keyword single chunk", "test test hello test", &ParallelOptions{Workers: 2, ChunkSize: 100}},
+		{"repeated keyword multi chunk", "test hello world test hello world", &ParallelOptions{Workers: 2, ChunkSize: 10, Overlap: 5}},
 	}
 
 	for _, tt := range tests {
@@ -321,13 +324,16 @@ func TestFindParallelEdgeCases(t *testing.T) {
 				t.Errorf("FindParallel() error: %v", err)
 			}
 
-			// Compare against sequential Find to ensure parallel results match.
+			// FindParallel returns a set (first-seen order); Find returns every
+			// occurrence. Dedup the sequential result before comparing, otherwise this
+			// only passes for texts that happen not to repeat a keyword.
 			sequential, seqErr := ac.Find(tt.text)
 			if seqErr != nil {
 				t.Fatalf("sequential Find() error: %v", seqErr)
 			}
-			if !reflect.DeepEqual(results, sequential) {
-				t.Errorf("FindParallel() = %v, want sequential Find() = %v", results, sequential)
+			want := dedupPreservingOrder(sequential)
+			if !reflect.DeepEqual(results, want) {
+				t.Errorf("FindParallel() = %v, want dedup(sequential Find()) = %v", results, want)
 			}
 		})
 	}

--- a/pkg/acor/parallel.go
+++ b/pkg/acor/parallel.go
@@ -144,8 +144,9 @@ func scanChunks[T any](ctx context.Context, chunks []chunk, workers int, scan fu
 // The text is split into chunks processed by multiple goroutines, which can
 // significantly improve performance for very large texts.
 //
-// If opts is nil, DefaultParallelOptions() is used. For small texts that fit
-// within a single chunk, this method delegates to Find without parallelization.
+// If opts is nil, DefaultParallelOptions() is used. A text that fits within a
+// single chunk is scanned by a single worker, so it pays no parallelization cost
+// while still returning the same shape as a multi-chunk scan.
 //
 // Note: Due to chunk overlap for boundary handling, duplicate matches are
 // automatically deduplicated in the returned slice, so each keyword appears at

--- a/pkg/acor/parallel.go
+++ b/pkg/acor/parallel.go
@@ -196,6 +196,9 @@ func (ac *AhoCorasick) FindIndexParallel(text string, opts *ParallelOptions) (ma
 // mergeIndexResults folds per-chunk index maps into one, shifting each chunk's
 // offsets back into the original text and dropping the duplicates that chunk
 // overlap produces. Indices come back sorted.
+//
+// perChunk must be index-aligned with chunks; scanChunks guarantees this by
+// building its result slice from the same chunks it was handed.
 func mergeIndexResults(chunks []chunk, perChunk []map[string][]int) map[string][]int {
 	merged := make(map[string]map[int]struct{})
 	for i, matches := range perChunk {

--- a/pkg/acor/parallel.go
+++ b/pkg/acor/parallel.go
@@ -6,8 +6,9 @@ import (
 	"context"
 	"runtime"
 	"sort"
-	"sync"
 	"unicode"
+
+	"golang.org/x/sync/errgroup"
 )
 
 type chunk struct {
@@ -115,89 +116,28 @@ func dedupPreservingOrder(in []string) []string {
 	return out
 }
 
-//nolint:gocritic // Returns channels for concurrent result collection
-func runStringWorkers(ac *AhoCorasick, chunks []chunk, workers int) (<-chan indexedStringResult, <-chan error) {
-	return runStringWorkersCtx(ac.ctx, ac, chunks, workers)
-}
+// scanChunks runs scan over every chunk with at most workers running at once,
+// writing each result into its own slot so the output keeps chunk order without
+// a sort. It returns the first error any chunk reported.
+func scanChunks[T any](ctx context.Context, chunks []chunk, workers int, scan func(context.Context, chunk) (T, error)) ([]T, error) {
+	results := make([]T, len(chunks))
 
-//nolint:gocritic // Returns channels for concurrent result collection
-func runStringWorkersCtx(ctx context.Context, ac *AhoCorasick, chunks []chunk, workers int) (<-chan indexedStringResult, <-chan error) {
-	results := make(chan indexedStringResult, len(chunks))
-	errors := make(chan error, len(chunks))
-
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, workers)
-
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(workers)
 	for i, c := range chunks {
-		select {
-		case <-ctx.Done():
-			wg.Wait()
-			close(results)
-			close(errors)
-			return results, errors
-		default:
-		}
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(i int, c chunk) {
-			defer func() { <-sem }()
-			defer wg.Done()
-			matches, err := ac.ops.find(ctx, c.text)
+		g.Go(func() error {
+			res, err := scan(gctx, c)
 			if err != nil {
-				errors <- err
-				return
+				return err
 			}
-			results <- indexedStringResult{matches: matches, chunkIndex: i}
-		}(i, c)
+			results[i] = res
+			return nil
+		})
 	}
-
-	go func() {
-		wg.Wait()
-		close(results)
-		close(errors)
-	}()
-
-	return results, errors
-}
-
-// collectOrderedStringResults collects matches preserving chunk order and
-// deduplicating across chunks (a keyword appears at most once), matching the
-// FindParallel contract.
-func collectOrderedStringResults(results <-chan indexedStringResult, errors <-chan error) ([]string, error) {
-	var allChunkResults []indexedStringResult
-	var firstErr error
-
-	resultsOpen, errorsOpen := true, true
-
-	for resultsOpen || errorsOpen {
-		select {
-		case err, ok := <-errors:
-			if !ok {
-				errorsOpen = false
-				continue
-			}
-			if firstErr == nil {
-				firstErr = err
-			}
-		case res, ok := <-results:
-			if !ok {
-				resultsOpen = false
-				continue
-			}
-			allChunkResults = append(allChunkResults, res)
-		}
+	if err := g.Wait(); err != nil {
+		return nil, err
 	}
-
-	sort.Slice(allChunkResults, func(i, j int) bool {
-		return allChunkResults[i].chunkIndex < allChunkResults[j].chunkIndex
-	})
-
-	var allMatches []string
-	for _, r := range allChunkResults {
-		allMatches = append(allMatches, r.matches...)
-	}
-
-	return dedupPreservingOrder(allMatches), firstErr
+	return results, nil
 }
 
 // FindParallel searches for keywords in text using parallel processing.
@@ -226,122 +166,7 @@ func collectOrderedStringResults(results <-chan indexedStringResult, errors <-ch
 //	}
 //	matches, err := ac.FindParallel(largeLogFile, opts)
 func (ac *AhoCorasick) FindParallel(text string, opts *ParallelOptions) ([]string, error) {
-	opts = normalizeParallelOptions(opts)
-	if opts.ChunkSize <= 0 {
-		return nil, ErrInvalidChunkSize
-	}
-
-	chunks := splitChunks(text, opts)
-	if len(chunks) == 0 {
-		return []string{}, nil
-	}
-	if len(chunks) == 1 {
-		// Match the multi-chunk contract: dedup so the result set doesn't depend
-		// on whether the text fit in one chunk.
-		matches, err := ac.Find(text)
-		if err != nil {
-			return nil, err
-		}
-		return dedupPreservingOrder(matches), nil
-	}
-
-	results, errors := runStringWorkers(ac, chunks, opts.Workers)
-	allMatches, err := collectOrderedStringResults(results, errors)
-	if err != nil {
-		return nil, err
-	}
-	return allMatches, nil
-}
-
-type indexedResult struct {
-	matches map[string][]int
-	offset  int
-}
-
-type indexedStringResult struct {
-	matches    []string
-	chunkIndex int
-}
-
-//nolint:gocritic // Returns channels for concurrent result collection
-func runIndexWorkers(ac *AhoCorasick, chunks []chunk, workers int) (<-chan indexedResult, <-chan error) {
-	return runIndexWorkersCtx(ac.ctx, ac, chunks, workers)
-}
-
-//nolint:gocritic // Returns channels for concurrent result collection
-func runIndexWorkersCtx(ctx context.Context, ac *AhoCorasick, chunks []chunk, workers int) (<-chan indexedResult, <-chan error) {
-	results := make(chan indexedResult, len(chunks))
-	errors := make(chan error, len(chunks))
-
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, workers)
-
-	for _, c := range chunks {
-		select {
-		case <-ctx.Done():
-			wg.Wait()
-			close(results)
-			close(errors)
-			return results, errors
-		default:
-		}
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(c chunk) {
-			defer func() { <-sem }()
-			defer wg.Done()
-			matches, err := ac.ops.findIndex(ctx, c.text)
-			if err != nil {
-				errors <- err
-				return
-			}
-			results <- indexedResult{matches: matches, offset: c.textOffset}
-		}(c)
-	}
-
-	go func() {
-		wg.Wait()
-		close(results)
-		close(errors)
-	}()
-
-	return results, errors
-}
-
-func collectIndexResults(results <-chan indexedResult, errors <-chan error) (map[string]map[int]struct{}, error) {
-	allMatches := make(map[string]map[int]struct{})
-	var firstErr error
-
-	resultsOpen, errorsOpen := true, true
-
-	for resultsOpen || errorsOpen {
-		select {
-		case err, ok := <-errors:
-			if !ok {
-				errorsOpen = false
-				continue
-			}
-			if firstErr == nil {
-				firstErr = err
-			}
-		case res, ok := <-results:
-			if !ok {
-				resultsOpen = false
-				continue
-			}
-			for keyword, indices := range res.matches {
-				if allMatches[keyword] == nil {
-					allMatches[keyword] = make(map[int]struct{})
-				}
-				for _, idx := range indices {
-					adjustedIdx := idx + res.offset
-					allMatches[keyword][adjustedIdx] = struct{}{}
-				}
-			}
-		}
-	}
-
-	return allMatches, firstErr
+	return ac.FindParallelContext(ac.ctx, text, opts)
 }
 
 // FindIndexParallel searches for keywords with indices using parallel processing.
@@ -365,33 +190,33 @@ func collectIndexResults(results <-chan indexedResult, errors <-chan error) (map
 //	    fmt.Printf("%s found at: %v\n", keyword, indices)
 //	}
 func (ac *AhoCorasick) FindIndexParallel(text string, opts *ParallelOptions) (map[string][]int, error) {
-	opts = normalizeParallelOptions(opts)
-	if opts.ChunkSize <= 0 {
-		return nil, ErrInvalidChunkSize
-	}
+	return ac.FindIndexParallelContext(ac.ctx, text, opts)
+}
 
-	chunks := splitChunks(text, opts)
-	if len(chunks) == 0 {
-		return map[string][]int{}, nil
-	}
-	if len(chunks) == 1 {
-		return ac.FindIndex(text)
-	}
-
-	results, errors := runIndexWorkers(ac, chunks, opts.Workers)
-	allMatches, err := collectIndexResults(results, errors)
-	if err != nil {
-		return nil, err
-	}
-
-	result := make(map[string][]int)
-	for keyword, indices := range allMatches {
-		sortedIndices := make([]int, 0, len(indices))
-		for idx := range indices {
-			sortedIndices = append(sortedIndices, idx)
+// mergeIndexResults folds per-chunk index maps into one, shifting each chunk's
+// offsets back into the original text and dropping the duplicates that chunk
+// overlap produces. Indices come back sorted.
+func mergeIndexResults(chunks []chunk, perChunk []map[string][]int) map[string][]int {
+	merged := make(map[string]map[int]struct{})
+	for i, matches := range perChunk {
+		for keyword, indices := range matches {
+			if merged[keyword] == nil {
+				merged[keyword] = make(map[int]struct{})
+			}
+			for _, idx := range indices {
+				merged[keyword][idx+chunks[i].textOffset] = struct{}{}
+			}
 		}
-		sort.Ints(sortedIndices)
-		result[keyword] = sortedIndices
 	}
-	return result, nil
+
+	result := make(map[string][]int, len(merged))
+	for keyword, indices := range merged {
+		sorted := make([]int, 0, len(indices))
+		for idx := range indices {
+			sorted = append(sorted, idx)
+		}
+		sort.Ints(sorted)
+		result[keyword] = sorted
+	}
+	return result
 }

--- a/pkg/acor/redis_backed_ops.go
+++ b/pkg/acor/redis_backed_ops.go
@@ -156,6 +156,13 @@ func (ac *redisBackedAC) find(ctx context.Context, text string) ([]string, error
 	if err != nil {
 		return nil, err
 	}
+
+	// Honor a canceled ctx at the match boundary; the in-memory scan itself isn't
+	// ctx-threaded, and loadEngine returns without touching Redis on a warm engine.
+	// Mirrors v2Operations.find.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	return e.Find(text), nil
 }
 
@@ -168,6 +175,11 @@ func (ac *redisBackedAC) findIndex(ctx context.Context, text string) (map[string
 
 	e, err := ac.loadEngine(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	// See find: honor an already-canceled/expired ctx before the in-memory match.
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 	return e.FindIndex(text), nil


### PR DESCRIPTION
# Pull Request

## Description

`parallel.go` and `batch.go` each built the same thing out of a `sync.WaitGroup` and a buffered-channel semaphore, and `parallel.go` then shipped results over two more channels and sorted them back into chunk order. `golang.org/x/sync` is **already a direct dependency**, so `errgroup.SetLimit` does the bounded fan-out and writing into a pre-sized slice keeps chunk order for free — no channels, no sort.

- **`scanChunks`** is one generic fan-out for both parallel scans, replacing `runStringWorkers`, `runStringWorkersCtx`, `runIndexWorkers`, `runIndexWorkersCtx`, `collectOrderedStringResults`, `collectIndexResults`, `indexedResult` and `indexedStringResult`.
- **`rollbackBatch`** replaces `rollbackAdded` and `rollbackRemoved`, which differed only in which operation they undid.
- `FindParallel` / `FindIndexParallel` now delegate to their `Context` forms instead of keeping a second copy of the body.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — skip for internal-only changes (CI, tests, refactors); see [RELEASE.md](../RELEASE.md)
- [x] Commit messages follow guidelines