### PR TITLE
perf: scan V1 collections with the local engine instead of walking Redis

### DIFF
--- a/changes/unreleased/Changed-20260727-232533.yaml
+++ b/changes/unreleased/Changed-20260727-232533.yaml
@@ -1,8 +1,6 @@
 kind: Changed
 body: |-
-    `Find` and `FindIndex` on a V1 collection no longer make one Redis round trip per character of input. They read the keyword set once and scan it with the same in-memory automaton every other mode uses, so a V1 search costs a single `SMEMBERS` instead of two to three commands per rune. Results are unchanged — the new path is pinned against the old trie walk in `v1_engine_parity_test.go`.
-
-    The automaton built from that keyword set is reused while the set is unchanged, so only the `SMEMBERS` repeats. Building it is the expensive half (an O(keywords) pack — roughly 14ms for 10k keywords, 800ms for 100k), and without the reuse every `Find`, `FindMatches`, `Contains` and `FindParallel` chunk would pay it again. The set is still re-read on every call, so another instance's write is picked up as immediately as it was before.
+    V1 `Find` and `FindIndex` now scan the keyword set with the same in-memory automaton the other modes use instead of walking the trie in Redis one character at a time: a single `SMEMBERS` per call rather than two to three commands per rune, with identical results (pinned in `v1_engine_parity_test.go`). The automaton is reused while the set is unchanged, but the set is re-read on every call, so another instance's write is still picked up immediately.
 time: 2026-07-27T23:25:33.000000+09:00
 custom:
     Issue: "173"

--- a/changes/unreleased/Changed-20260727-232533.yaml
+++ b/changes/unreleased/Changed-20260727-232533.yaml
@@ -1,0 +1,6 @@
+kind: Changed
+body: |-
+    `Find` and `FindIndex` on a V1 collection no longer make one Redis round trip per character of input. They read the keyword set once and scan it with the same in-memory automaton every other mode uses, so a V1 search costs a single `SMEMBERS` instead of two to three commands per rune. Results are unchanged — the new path is pinned against the old trie walk in `v1_engine_parity_test.go`.
+time: 2026-07-27T23:25:33.000000+09:00
+custom:
+    Issue: "173"

--- a/changes/unreleased/Changed-20260727-232533.yaml
+++ b/changes/unreleased/Changed-20260727-232533.yaml
@@ -1,6 +1,8 @@
 kind: Changed
 body: |-
     `Find` and `FindIndex` on a V1 collection no longer make one Redis round trip per character of input. They read the keyword set once and scan it with the same in-memory automaton every other mode uses, so a V1 search costs a single `SMEMBERS` instead of two to three commands per rune. Results are unchanged — the new path is pinned against the old trie walk in `v1_engine_parity_test.go`.
+
+    The automaton built from that keyword set is reused while the set is unchanged, so only the `SMEMBERS` repeats. Building it is the expensive half (an O(keywords) pack — roughly 14ms for 10k keywords, 800ms for 100k), and without the reuse every `Find`, `FindMatches`, `Contains` and `FindParallel` chunk would pay it again. The set is still re-read on every call, so another instance's write is picked up as immediately as it was before.
 time: 2026-07-27T23:25:33.000000+09:00
 custom:
     Issue: "173"

--- a/internal/engine/engine_banded_dfa.go
+++ b/internal/engine/engine_banded_dfa.go
@@ -83,7 +83,7 @@ func (bd *bandedDFA) buildDFABand() {
 func (e *balancedEngine) find(text string) []string {
 	dat := e.banded.dat
 	if dat.size <= datRootPos+1 {
-		return nil
+		return []string{}
 	}
 	band := e.banded.dfaBand
 	bloom := e.bloom
@@ -126,7 +126,7 @@ func (e *balancedEngine) find(text string) []string {
 func (e *balancedEngine) findIndex(text string) map[string][]int {
 	dat := e.banded.dat
 	if dat.size <= datRootPos+1 {
-		return nil
+		return map[string][]int{}
 	}
 	band := e.banded.dfaBand
 	bloom := e.bloom

--- a/internal/engine/engine_flat.go
+++ b/internal/engine/engine_flat.go
@@ -178,7 +178,7 @@ func (e *speedEngine) buildFromKeywords(keywords map[string]struct{}) { //nolint
 
 func (e *speedEngine) find(text string) []string {
 	if e.dfa == nil {
-		return nil
+		return []string{}
 	}
 
 	matched := make([]string, 0)
@@ -201,7 +201,7 @@ func (e *speedEngine) find(text string) []string {
 
 func (e *speedEngine) findIndex(text string) map[string][]int {
 	if e.dfa == nil {
-		return nil
+		return map[string][]int{}
 	}
 
 	matched := make(map[string][]int)

--- a/internal/engine/engine_handle.go
+++ b/internal/engine/engine_handle.go
@@ -22,14 +22,23 @@ func (e *Engine) Build(keywords map[string]struct{}) {
 	e.impl.buildFromKeywords(keywords)
 }
 
-// Find returns the keywords found in text.
+// Find returns the keywords found in text. The result is never nil — an
+// automaton with no keywords yields an empty slice — so callers can hand it
+// straight to a JSON encoder or compare it without a nil special case.
 func (e *Engine) Find(text string) []string {
-	return e.impl.find(text)
+	if out := e.impl.find(text); out != nil {
+		return out
+	}
+	return []string{}
 }
 
 // FindIndex returns matched keywords mapped to their start offsets in text.
+// Like Find, it is never nil.
 func (e *Engine) FindIndex(text string) map[string][]int {
-	return e.impl.findIndex(text)
+	if out := e.impl.findIndex(text); out != nil {
+		return out
+	}
+	return map[string][]int{}
 }
 
 // FindMatches returns every match (overlaps included) in text, in scan order,

--- a/internal/engine/engine_handle.go
+++ b/internal/engine/engine_handle.go
@@ -22,23 +22,17 @@ func (e *Engine) Build(keywords map[string]struct{}) {
 	e.impl.buildFromKeywords(keywords)
 }
 
-// Find returns the keywords found in text. The result is never nil — an
+// Find returns the keywords found in text. Like FindMatches it is never nil — an
 // automaton with no keywords yields an empty slice — so callers can hand it
 // straight to a JSON encoder or compare it without a nil special case.
 func (e *Engine) Find(text string) []string {
-	if out := e.impl.find(text); out != nil {
-		return out
-	}
-	return []string{}
+	return e.impl.find(text)
 }
 
 // FindIndex returns matched keywords mapped to their start offsets in text.
 // Like Find, it is never nil.
 func (e *Engine) FindIndex(text string) map[string][]int {
-	if out := e.impl.findIndex(text); out != nil {
-		return out
-	}
-	return map[string][]int{}
+	return e.impl.findIndex(text)
 }
 
 // FindMatches returns every match (overlaps included) in text, in scan order,

--- a/internal/engine/engine_map.go
+++ b/internal/engine/engine_map.go
@@ -101,7 +101,7 @@ func (e *memEfficientEngine) buildFromKeywords(keywords map[string]struct{}) {
 
 func (e *memEfficientEngine) find(text string) []string {
 	if len(e.trie.nodes) <= 1 {
-		return nil
+		return []string{}
 	}
 
 	matched := make([]string, 0)
@@ -133,7 +133,7 @@ func (e *memEfficientEngine) find(text string) []string {
 
 func (e *memEfficientEngine) findIndex(text string) map[string][]int {
 	if len(e.trie.nodes) <= 1 {
-		return nil
+		return map[string][]int{}
 	}
 
 	matched := make(map[string][]int)

--- a/pkg/acor/v1_engine_parity_test.go
+++ b/pkg/acor/v1_engine_parity_test.go
@@ -4,8 +4,8 @@ package acor
 
 import (
 	"context"
+	"fmt"
 	"sort"
-	"strings"
 	"testing"
 
 	miniredis "github.com/alicebob/miniredis/v2"
@@ -22,9 +22,7 @@ func v1TrieWalkFind(ctx context.Context, ac *AhoCorasick, text string, caseSensi
 	if text == "" {
 		return []string{}, nil
 	}
-	if !caseSensitive {
-		text = strings.ToLower(text)
-	}
+	text = normalizeText(text, caseSensitive)
 
 	state := ""
 	matched := make([]string, 0)
@@ -68,9 +66,7 @@ func v1TrieWalkFindIndex(ctx context.Context, ac *AhoCorasick, text string, case
 	if text == "" {
 		return map[string][]int{}, nil
 	}
-	if !caseSensitive {
-		text = strings.ToLower(text)
-	}
+	text = normalizeText(text, caseSensitive)
 
 	matched := make(map[string][]int)
 	state := ""
@@ -140,15 +136,26 @@ var parityCases = []struct {
 		keywords: []string{"x", "y"},
 		texts:    []string{"xyxy", "zzz"},
 	},
+	{
+		// Case-sensitive mode stores these verbatim, so only the exact-case text
+		// matches; case-insensitive mode matches all four.
+		name:     "mixed case",
+		keywords: []string{"GoLang", "HTTPServer"},
+		texts:    []string{"GoLang and HTTPServer", "golang and httpserver", "GOLANG", "a GoLang httpserver"},
+	},
 }
 
-func newV1Parity(t *testing.T, keywords []string) *AhoCorasick {
+// caseModes are the two normalization modes every parity case runs under.
+var caseModes = []bool{false, true}
+
+func newV1Parity(t *testing.T, keywords []string, caseSensitive bool) *AhoCorasick {
 	t.Helper()
 	mr := miniredis.RunT(t)
 	ac, err := Create(&AhoCorasickArgs{
 		Addr:          mr.Addr(),
 		Name:          "parity",
 		SchemaVersion: SchemaV1,
+		CaseSensitive: caseSensitive,
 	})
 	if err != nil {
 		t.Fatalf("Create V1: %v", err)
@@ -164,58 +171,66 @@ func newV1Parity(t *testing.T, keywords []string) *AhoCorasick {
 }
 
 func TestV1FindMatchesTrieWalk(t *testing.T) {
-	for _, tc := range parityCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ac := newV1Parity(t, tc.keywords)
-			ctx := context.Background()
+	for _, caseSensitive := range caseModes {
+		t.Run(fmt.Sprintf("caseSensitive=%t", caseSensitive), func(t *testing.T) {
+			for _, tc := range parityCases {
+				t.Run(tc.name, func(t *testing.T) {
+					ac := newV1Parity(t, tc.keywords, caseSensitive)
+					ctx := context.Background()
 
-			for _, text := range tc.texts {
-				want, err := v1TrieWalkFind(ctx, ac, text, false)
-				if err != nil {
-					t.Fatalf("trie walk find(%q): %v", text, err)
-				}
-				got, err := ac.ops.find(ctx, text)
-				if err != nil {
-					t.Fatalf("find(%q): %v", text, err)
-				}
-				// The trie walk emits per end position, the engine per scan
-				// position; both report the same multiset of matches.
-				if !sameMultiset(got, want) {
-					t.Errorf("find(%q) = %v, trie walk = %v", text, got, want)
-				}
+					for _, text := range tc.texts {
+						want, err := v1TrieWalkFind(ctx, ac, text, caseSensitive)
+						if err != nil {
+							t.Fatalf("trie walk find(%q): %v", text, err)
+						}
+						got, err := ac.ops.find(ctx, text)
+						if err != nil {
+							t.Fatalf("find(%q): %v", text, err)
+						}
+						// The trie walk emits per end position, the engine per scan
+						// position; both report the same multiset of matches.
+						if !sameMultiset(got, want) {
+							t.Errorf("find(%q) = %v, trie walk = %v", text, got, want)
+						}
+					}
+				})
 			}
 		})
 	}
 }
 
 func TestV1FindIndexMatchesTrieWalk(t *testing.T) {
-	for _, tc := range parityCases {
-		t.Run(tc.name, func(t *testing.T) {
-			ac := newV1Parity(t, tc.keywords)
-			ctx := context.Background()
+	for _, caseSensitive := range caseModes {
+		t.Run(fmt.Sprintf("caseSensitive=%t", caseSensitive), func(t *testing.T) {
+			for _, tc := range parityCases {
+				t.Run(tc.name, func(t *testing.T) {
+					ac := newV1Parity(t, tc.keywords, caseSensitive)
+					ctx := context.Background()
 
-			for _, text := range tc.texts {
-				want, err := v1TrieWalkFindIndex(ctx, ac, text, false)
-				if err != nil {
-					t.Fatalf("trie walk findIndex(%q): %v", text, err)
-				}
-				got, err := ac.ops.findIndex(ctx, text)
-				if err != nil {
-					t.Fatalf("findIndex(%q): %v", text, err)
-				}
-				if len(got) != len(want) {
-					t.Fatalf("findIndex(%q) = %v, trie walk = %v", text, got, want)
-				}
-				for kw, wantIdx := range want {
-					gotIdx, ok := got[kw]
-					if !ok {
-						t.Errorf("findIndex(%q) missing keyword %q (trie walk found it at %v)", text, kw, wantIdx)
-						continue
+					for _, text := range tc.texts {
+						want, err := v1TrieWalkFindIndex(ctx, ac, text, caseSensitive)
+						if err != nil {
+							t.Fatalf("trie walk findIndex(%q): %v", text, err)
+						}
+						got, err := ac.ops.findIndex(ctx, text)
+						if err != nil {
+							t.Fatalf("findIndex(%q): %v", text, err)
+						}
+						if len(got) != len(want) {
+							t.Fatalf("findIndex(%q) = %v, trie walk = %v", text, got, want)
+						}
+						for kw, wantIdx := range want {
+							gotIdx, ok := got[kw]
+							if !ok {
+								t.Errorf("findIndex(%q) missing keyword %q (trie walk found it at %v)", text, kw, wantIdx)
+								continue
+							}
+							if !sameIntSet(gotIdx, wantIdx) {
+								t.Errorf("findIndex(%q)[%q] = %v, trie walk = %v", text, kw, gotIdx, wantIdx)
+							}
+						}
 					}
-					if !sameIntSet(gotIdx, wantIdx) {
-						t.Errorf("findIndex(%q)[%q] = %v, trie walk = %v", text, kw, gotIdx, wantIdx)
-					}
-				}
+				})
 			}
 		})
 	}

--- a/pkg/acor/v1_engine_parity_test.go
+++ b/pkg/acor/v1_engine_parity_test.go
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	miniredis "github.com/alicebob/miniredis/v2"
+)
+
+// V1's find/findIndex used to walk the trie in Redis one character at a time.
+// They now build the same in-memory engine the other modes use. These tests pin
+// the two against each other so the swap cannot change what a V1 collection
+// reports.
+
+// v1TrieWalkFind is the pre-refactor V1 matcher, kept here as the reference
+// implementation: goto/fail/output resolved per character against Redis.
+func v1TrieWalkFind(ctx context.Context, ac *AhoCorasick, text string, caseSensitive bool) ([]string, error) {
+	if text == "" {
+		return []string{}, nil
+	}
+	if !caseSensitive {
+		text = strings.ToLower(text)
+	}
+
+	state := ""
+	matched := make([]string, 0)
+	for _, char := range text {
+		nextState, err := ac.goWithContext(ctx, state, char)
+		if err != nil {
+			return nil, err
+		}
+		if nextState == "" {
+			nextState, err = ac.failWithContext(ctx, state)
+			if err != nil {
+				return nil, err
+			}
+			var afterNextState string
+			afterNextState, err = ac.goWithContext(ctx, nextState, char)
+			if err != nil {
+				return nil, err
+			}
+			if afterNextState == "" {
+				afterNextState, err = ac.failWithContext(ctx, nextState+string(char))
+				if err != nil {
+					return nil, err
+				}
+			}
+			nextState = afterNextState
+		}
+
+		outputs, err := ac.outputWithContext(ctx, nextState)
+		if err != nil {
+			return nil, err
+		}
+		matched = append(matched, outputs...)
+		state = nextState
+	}
+	return matched, nil
+}
+
+// v1TrieWalkFindIndex is v1TrieWalkFind with start offsets, the pre-refactor
+// findIndex.
+func v1TrieWalkFindIndex(ctx context.Context, ac *AhoCorasick, text string, caseSensitive bool) (map[string][]int, error) {
+	if text == "" {
+		return map[string][]int{}, nil
+	}
+	if !caseSensitive {
+		text = strings.ToLower(text)
+	}
+
+	matched := make(map[string][]int)
+	state := ""
+	runeIndex := 0
+	for _, char := range text {
+		nextState, err := ac.goWithContext(ctx, state, char)
+		if err != nil {
+			return nil, err
+		}
+		if nextState == "" {
+			nextState, err = ac.failWithContext(ctx, state)
+			if err != nil {
+				return nil, err
+			}
+			var afterNextState string
+			afterNextState, err = ac.goWithContext(ctx, nextState, char)
+			if err != nil {
+				return nil, err
+			}
+			if afterNextState == "" {
+				afterNextState, err = ac.failWithContext(ctx, nextState+string(char))
+				if err != nil {
+					return nil, err
+				}
+			}
+			nextState = afterNextState
+		}
+
+		outputs, err := ac.outputWithContext(ctx, nextState)
+		if err != nil {
+			return nil, err
+		}
+		ac.appendMatchedIndexesWithContext(ctx, matched, outputs, runeIndex+1)
+		state = nextState
+		runeIndex++
+	}
+	return matched, nil
+}
+
+var parityCases = []struct {
+	name     string
+	keywords []string
+	texts    []string
+}{
+	{
+		name:     "classic overlapping",
+		keywords: []string{"he", "she", "his", "hers"},
+		texts:    []string{"ushers", "he is his", "hershey", "", "xyz"},
+	},
+	{
+		name:     "nested prefixes",
+		keywords: []string{"a", "aa", "aaa"},
+		texts:    []string{"aaaa", "aa", "baaab"},
+	},
+	{
+		name:     "shared suffix",
+		keywords: []string{"bar", "foobar", "obar"},
+		texts:    []string{"foobar", "xfoobarx", "obar bar"},
+	},
+	{
+		name:     "multibyte",
+		keywords: []string{"한글", "글자", "가나다"},
+		texts:    []string{"한글자입니다", "가나다라 한글", "no match here"},
+	},
+	{
+		name:     "single char keywords",
+		keywords: []string{"x", "y"},
+		texts:    []string{"xyxy", "zzz"},
+	},
+}
+
+func newV1Parity(t *testing.T, keywords []string) *AhoCorasick {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	ac, err := Create(&AhoCorasickArgs{
+		Addr:          mr.Addr(),
+		Name:          "parity",
+		SchemaVersion: SchemaV1,
+	})
+	if err != nil {
+		t.Fatalf("Create V1: %v", err)
+	}
+	t.Cleanup(func() { _ = ac.Close() })
+
+	for _, kw := range keywords {
+		if _, addErr := ac.Add(kw); addErr != nil {
+			t.Fatalf("Add(%q): %v", kw, addErr)
+		}
+	}
+	return ac
+}
+
+func TestV1FindMatchesTrieWalk(t *testing.T) {
+	for _, tc := range parityCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ac := newV1Parity(t, tc.keywords)
+			ctx := context.Background()
+
+			for _, text := range tc.texts {
+				want, err := v1TrieWalkFind(ctx, ac, text, false)
+				if err != nil {
+					t.Fatalf("trie walk find(%q): %v", text, err)
+				}
+				got, err := ac.ops.find(ctx, text)
+				if err != nil {
+					t.Fatalf("find(%q): %v", text, err)
+				}
+				// The trie walk emits per end position, the engine per scan
+				// position; both report the same multiset of matches.
+				if !sameMultiset(got, want) {
+					t.Errorf("find(%q) = %v, trie walk = %v", text, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestV1FindIndexMatchesTrieWalk(t *testing.T) {
+	for _, tc := range parityCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ac := newV1Parity(t, tc.keywords)
+			ctx := context.Background()
+
+			for _, text := range tc.texts {
+				want, err := v1TrieWalkFindIndex(ctx, ac, text, false)
+				if err != nil {
+					t.Fatalf("trie walk findIndex(%q): %v", text, err)
+				}
+				got, err := ac.ops.findIndex(ctx, text)
+				if err != nil {
+					t.Fatalf("findIndex(%q): %v", text, err)
+				}
+				if len(got) != len(want) {
+					t.Fatalf("findIndex(%q) = %v, trie walk = %v", text, got, want)
+				}
+				for kw, wantIdx := range want {
+					gotIdx, ok := got[kw]
+					if !ok {
+						t.Errorf("findIndex(%q) missing keyword %q (trie walk found it at %v)", text, kw, wantIdx)
+						continue
+					}
+					if !sameIntSet(gotIdx, wantIdx) {
+						t.Errorf("findIndex(%q)[%q] = %v, trie walk = %v", text, kw, gotIdx, wantIdx)
+					}
+				}
+			}
+		})
+	}
+}
+
+func sameMultiset(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	as := append([]string(nil), a...)
+	bs := append([]string(nil), b...)
+	sort.Strings(as)
+	sort.Strings(bs)
+	for i := range as {
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func sameIntSet(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	as := append([]int(nil), a...)
+	bs := append([]int(nil), b...)
+	sort.Ints(as)
+	sort.Ints(bs)
+	for i := range as {
+		if as[i] != bs[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/acor/v1_engine_parity_test.go
+++ b/pkg/acor/v1_engine_parity_test.go
@@ -5,7 +5,7 @@ package acor
 import (
 	"context"
 	"fmt"
-	"sort"
+	"slices"
 	"testing"
 
 	miniredis "github.com/alicebob/miniredis/v2"
@@ -16,92 +16,73 @@ import (
 // the two against each other so the swap cannot change what a V1 collection
 // reports.
 
-// v1TrieWalkFind is the pre-refactor V1 matcher, kept here as the reference
-// implementation: goto/fail/output resolved per character against Redis.
-func v1TrieWalkFind(ctx context.Context, ac *AhoCorasick, text string, caseSensitive bool) ([]string, error) {
-	if text == "" {
-		return []string{}, nil
-	}
+// v1TrieWalk is the pre-refactor V1 matcher, kept here as the reference
+// implementation: goto/fail/output resolved per character against Redis. It
+// reports every output with the 1-based rune position it ends at, which is what
+// both pre-refactor entry points were built from — find kept the keywords,
+// findIndex turned each end position into a start offset.
+func v1TrieWalk(ctx context.Context, ac *AhoCorasick, text string, caseSensitive bool) (outputs []string, endIndexes []int, err error) {
 	text = normalizeText(text, caseSensitive)
 
 	state := ""
-	matched := make([]string, 0)
-	for _, char := range text {
+	for runeIndex, char := range []rune(text) {
 		nextState, err := ac.goWithContext(ctx, state, char)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if nextState == "" {
 			nextState, err = ac.failWithContext(ctx, state)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			var afterNextState string
 			afterNextState, err = ac.goWithContext(ctx, nextState, char)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			if afterNextState == "" {
 				afterNextState, err = ac.failWithContext(ctx, nextState+string(char))
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 			}
 			nextState = afterNextState
 		}
 
-		outputs, err := ac.outputWithContext(ctx, nextState)
+		stateOutputs, err := ac.outputWithContext(ctx, nextState)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		matched = append(matched, outputs...)
+		for _, output := range stateOutputs {
+			outputs = append(outputs, output)
+			endIndexes = append(endIndexes, runeIndex+1)
+		}
 		state = nextState
 	}
-	return matched, nil
+	return outputs, endIndexes, nil
 }
 
-// v1TrieWalkFindIndex is v1TrieWalkFind with start offsets, the pre-refactor
-// findIndex.
-func v1TrieWalkFindIndex(ctx context.Context, ac *AhoCorasick, text string, caseSensitive bool) (map[string][]int, error) {
-	if text == "" {
-		return map[string][]int{}, nil
+// v1TrieWalkFind is the pre-refactor V1 find.
+func v1TrieWalkFind(ctx context.Context, ac *AhoCorasick, text string, caseSensitive bool) ([]string, error) {
+	outputs, _, err := v1TrieWalk(ctx, ac, text, caseSensitive)
+	if err != nil {
+		return nil, err
 	}
-	text = normalizeText(text, caseSensitive)
+	if outputs == nil {
+		return []string{}, nil
+	}
+	return outputs, nil
+}
 
+// v1TrieWalkFindIndex is the pre-refactor V1 findIndex.
+func v1TrieWalkFindIndex(ctx context.Context, ac *AhoCorasick, text string, caseSensitive bool) (map[string][]int, error) {
+	outputs, endIndexes, err := v1TrieWalk(ctx, ac, text, caseSensitive)
+	if err != nil {
+		return nil, err
+	}
 	matched := make(map[string][]int)
-	state := ""
-	runeIndex := 0
-	for _, char := range text {
-		nextState, err := ac.goWithContext(ctx, state, char)
-		if err != nil {
-			return nil, err
-		}
-		if nextState == "" {
-			nextState, err = ac.failWithContext(ctx, state)
-			if err != nil {
-				return nil, err
-			}
-			var afterNextState string
-			afterNextState, err = ac.goWithContext(ctx, nextState, char)
-			if err != nil {
-				return nil, err
-			}
-			if afterNextState == "" {
-				afterNextState, err = ac.failWithContext(ctx, nextState+string(char))
-				if err != nil {
-					return nil, err
-				}
-			}
-			nextState = afterNextState
-		}
-
-		outputs, err := ac.outputWithContext(ctx, nextState)
-		if err != nil {
-			return nil, err
-		}
-		ac.appendMatchedIndexesWithContext(ctx, matched, outputs, runeIndex+1)
-		state = nextState
-		runeIndex++
+	for i, output := range outputs {
+		ac.appendMatchedIndexesWithContext(ctx, matched, []string{output}, endIndexes[i])
 	}
 	return matched, nil
 }
@@ -142,6 +123,13 @@ var parityCases = []struct {
 		name:     "mixed case",
 		keywords: []string{"GoLang", "HTTPServer"},
 		texts:    []string{"GoLang and HTTPServer", "golang and httpserver", "GOLANG", "a GoLang httpserver"},
+	},
+	{
+		// An empty collection is the one input where the engine has no states at
+		// all and reports nothing; both paths must still return empty, not nil.
+		name:     "no keywords",
+		keywords: nil,
+		texts:    []string{"anything at all", ""},
 	},
 }
 
@@ -189,7 +177,7 @@ func TestV1FindMatchesTrieWalk(t *testing.T) {
 						}
 						// The trie walk emits per end position, the engine per scan
 						// position; both report the same multiset of matches.
-						if !sameMultiset(got, want) {
+						if !equalStringSets(got, want) {
 							t.Errorf("find(%q) = %v, trie walk = %v", text, got, want)
 						}
 					}
@@ -217,7 +205,7 @@ func TestV1FindIndexMatchesTrieWalk(t *testing.T) {
 							t.Fatalf("findIndex(%q): %v", text, err)
 						}
 						if len(got) != len(want) {
-							t.Fatalf("findIndex(%q) = %v, trie walk = %v", text, got, want)
+							t.Errorf("findIndex(%q) = %v, trie walk = %v", text, got, want)
 						}
 						for kw, wantIdx := range want {
 							gotIdx, ok := got[kw]
@@ -236,34 +224,40 @@ func TestV1FindIndexMatchesTrieWalk(t *testing.T) {
 	}
 }
 
-func sameMultiset(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
+// TestV1EngineMemoReusesUnchangedSet pins both branches of the memo: an
+// unchanged keyword set must hand back the same automaton (the rebuild is the
+// expensive part of a V1 search), and a changed one must not.
+func TestV1EngineMemoReusesUnchangedSet(t *testing.T) {
+	ac := newV1Parity(t, []string{"he", "she"}, false)
+	ctx := context.Background()
+
+	first, err := ac.ops.loadEngine(ctx)
+	if err != nil {
+		t.Fatalf("loadEngine: %v", err)
 	}
-	as := append([]string(nil), a...)
-	bs := append([]string(nil), b...)
-	sort.Strings(as)
-	sort.Strings(bs)
-	for i := range as {
-		if as[i] != bs[i] {
-			return false
-		}
+	second, err := ac.ops.loadEngine(ctx)
+	if err != nil {
+		t.Fatalf("loadEngine (repeat): %v", err)
 	}
-	return true
+	if first != second {
+		t.Error("loadEngine rebuilt the automaton for an unchanged keyword set")
+	}
+
+	if _, addErr := ac.Add("hers"); addErr != nil {
+		t.Fatalf("Add: %v", addErr)
+	}
+	third, err := ac.ops.loadEngine(ctx)
+	if err != nil {
+		t.Fatalf("loadEngine (after add): %v", err)
+	}
+	if third == second {
+		t.Fatal("loadEngine reused the automaton after the keyword set changed")
+	}
+	if got := third.Find("hers"); !equalStringSets(got, []string{"he", "hers"}) {
+		t.Errorf("Find(%q) = %v, want [he hers]", "hers", got)
+	}
 }
 
 func sameIntSet(a, b []int) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	as := append([]int(nil), a...)
-	bs := append([]int(nil), b...)
-	sort.Ints(as)
-	sort.Ints(bs)
-	for i := range as {
-		if as[i] != bs[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(slices.Sorted(slices.Values(a)), slices.Sorted(slices.Values(b)))
 }

--- a/pkg/acor/v1_engine_parity_test.go
+++ b/pkg/acor/v1_engine_parity_test.go
@@ -5,7 +5,6 @@ package acor
 import (
 	"context"
 	"fmt"
-	"slices"
 	"testing"
 
 	miniredis "github.com/alicebob/miniredis/v2"
@@ -62,29 +61,14 @@ func v1TrieWalk(ctx context.Context, ac *AhoCorasick, text string, caseSensitive
 	return outputs, endIndexes, nil
 }
 
-// v1TrieWalkFind is the pre-refactor V1 find.
-func v1TrieWalkFind(ctx context.Context, ac *AhoCorasick, text string, caseSensitive bool) ([]string, error) {
-	outputs, _, err := v1TrieWalk(ctx, ac, text, caseSensitive)
-	if err != nil {
-		return nil, err
-	}
-	if outputs == nil {
-		return []string{}, nil
-	}
-	return outputs, nil
-}
-
-// v1TrieWalkFindIndex is the pre-refactor V1 findIndex.
-func v1TrieWalkFindIndex(ctx context.Context, ac *AhoCorasick, text string, caseSensitive bool) (map[string][]int, error) {
-	outputs, endIndexes, err := v1TrieWalk(ctx, ac, text, caseSensitive)
-	if err != nil {
-		return nil, err
-	}
+// v1TrieWalkIndexes is what the pre-refactor V1 findIndex did with a walk's
+// outputs: turn each end position into a start offset.
+func v1TrieWalkIndexes(ctx context.Context, ac *AhoCorasick, outputs []string, endIndexes []int) map[string][]int {
 	matched := make(map[string][]int)
 	for i, output := range outputs {
 		ac.appendMatchedIndexesWithContext(ctx, matched, []string{output}, endIndexes[i])
 	}
-	return matched, nil
+	return matched
 }
 
 var parityCases = []struct {
@@ -133,9 +117,6 @@ var parityCases = []struct {
 	},
 }
 
-// caseModes are the two normalization modes every parity case runs under.
-var caseModes = []bool{false, true}
-
 func newV1Parity(t *testing.T, keywords []string, caseSensitive bool) *AhoCorasick {
 	t.Helper()
 	mr := miniredis.RunT(t)
@@ -158,8 +139,8 @@ func newV1Parity(t *testing.T, keywords []string, caseSensitive bool) *AhoCorasi
 	return ac
 }
 
-func TestV1FindMatchesTrieWalk(t *testing.T) {
-	for _, caseSensitive := range caseModes {
+func TestV1EngineMatchesTrieWalk(t *testing.T) {
+	for _, caseSensitive := range []bool{false, true} {
 		t.Run(fmt.Sprintf("caseSensitive=%t", caseSensitive), func(t *testing.T) {
 			for _, tc := range parityCases {
 				t.Run(tc.name, func(t *testing.T) {
@@ -167,56 +148,26 @@ func TestV1FindMatchesTrieWalk(t *testing.T) {
 					ctx := context.Background()
 
 					for _, text := range tc.texts {
-						want, err := v1TrieWalkFind(ctx, ac, text, caseSensitive)
+						outputs, endIndexes, err := v1TrieWalk(ctx, ac, text, caseSensitive)
 						if err != nil {
-							t.Fatalf("trie walk find(%q): %v", text, err)
+							t.Fatalf("trie walk(%q): %v", text, err)
 						}
+
 						got, err := ac.ops.find(ctx, text)
 						if err != nil {
 							t.Fatalf("find(%q): %v", text, err)
 						}
 						// The trie walk emits per end position, the engine per scan
 						// position; both report the same multiset of matches.
-						if !equalStringSets(got, want) {
-							t.Errorf("find(%q) = %v, trie walk = %v", text, got, want)
+						if !equalStringSets(got, outputs) {
+							t.Errorf("find(%q) = %v, trie walk = %v", text, got, outputs)
 						}
-					}
-				})
-			}
-		})
-	}
-}
 
-func TestV1FindIndexMatchesTrieWalk(t *testing.T) {
-	for _, caseSensitive := range caseModes {
-		t.Run(fmt.Sprintf("caseSensitive=%t", caseSensitive), func(t *testing.T) {
-			for _, tc := range parityCases {
-				t.Run(tc.name, func(t *testing.T) {
-					ac := newV1Parity(t, tc.keywords, caseSensitive)
-					ctx := context.Background()
-
-					for _, text := range tc.texts {
-						want, err := v1TrieWalkFindIndex(ctx, ac, text, caseSensitive)
-						if err != nil {
-							t.Fatalf("trie walk findIndex(%q): %v", text, err)
-						}
-						got, err := ac.ops.findIndex(ctx, text)
+						gotIndexes, err := ac.ops.findIndex(ctx, text)
 						if err != nil {
 							t.Fatalf("findIndex(%q): %v", text, err)
 						}
-						if len(got) != len(want) {
-							t.Errorf("findIndex(%q) = %v, trie walk = %v", text, got, want)
-						}
-						for kw, wantIdx := range want {
-							gotIdx, ok := got[kw]
-							if !ok {
-								t.Errorf("findIndex(%q) missing keyword %q (trie walk found it at %v)", text, kw, wantIdx)
-								continue
-							}
-							if !sameIntSet(gotIdx, wantIdx) {
-								t.Errorf("findIndex(%q)[%q] = %v, trie walk = %v", text, kw, gotIdx, wantIdx)
-							}
-						}
+						assertIndexResults(t, gotIndexes, v1TrieWalkIndexes(ctx, ac, outputs, endIndexes))
 					}
 				})
 			}
@@ -256,8 +207,4 @@ func TestV1EngineMemoReusesUnchangedSet(t *testing.T) {
 	if got := third.Find("hers"); !equalStringSets(got, []string{"he", "hers"}) {
 		t.Errorf("Find(%q) = %v, want [he hers]", "hers", got)
 	}
-}
-
-func sameIntSet(a, b []int) bool {
-	return slices.Equal(slices.Sorted(slices.Values(a)), slices.Sorted(slices.Values(b)))
 }

--- a/pkg/acor/v1_ops.go
+++ b/pkg/acor/v1_ops.go
@@ -179,6 +179,11 @@ func (o *v1Operations) findIndex(ctx context.Context, text string) (map[string][
 // stores keywords already normalized (lowercased when !caseSensitive), so no
 // re-normalization is needed here. Unlike V2 there is no cache, so this is an
 // O(keywords) build per call — acceptable for the legacy schema.
+//
+// Caching the engine here would need the pub/sub invalidation listener, which
+// only runs under EnableCache — and EnableCache with V1 is ErrCacheRequiresV2.
+// Without it a peer's write leaves this instance matching a stale keyword set,
+// so V1 rebuilds instead.
 func (o *v1Operations) loadEngine(ctx context.Context) (*matchengine.Engine, error) {
 	kws, err := o.storage.SMembers(ctx, keywordKey(o.name))
 	if err != nil {

--- a/pkg/acor/v1_ops.go
+++ b/pkg/acor/v1_ops.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/maphash"
 	"strings"
+	"sync"
 	"time"
 
 	redis "github.com/redis/go-redis/v9"
@@ -29,6 +31,53 @@ type v1Operations struct {
 	ac              *AhoCorasick // for trie.go helper access (temporary, cleaned up in T15)
 	caseSensitive   bool
 	rollbackTimeout time.Duration
+	engines         v1EngineMemo
+}
+
+// v1EngineMemo holds the automaton last built for a keyword set, so repeated
+// searches over an unchanged V1 collection skip the rebuild. Building is not
+// cheap — an O(keywords) double-array pack that runs ~14ms for 10k keywords and
+// ~800ms for 100k — and find, findIndex, FindMatches, Contains, FindStream and
+// every FindParallel chunk all go through loadEngine.
+//
+// This is not the V2 cache: the keyword set is still read from Redis on every
+// call, so a peer's write is picked up immediately. Only the rebuild is skipped,
+// and only while the set Redis returns is unchanged.
+type v1EngineMemo struct {
+	mu     sync.Mutex
+	engine *matchengine.Engine
+	digest uint64
+	count  int
+}
+
+// v1DigestSeed keys the keyword-set digest. It is per-process, which is all the
+// memo needs — digests are only ever compared against ones taken in the same
+// process, never persisted or sent over the wire.
+var v1DigestSeed = maphash.MakeSeed()
+
+// engineFor returns the automaton for kws, rebuilding only when the set changed.
+// The digest sums per-member hashes, so it does not depend on the order SMEMBERS
+// happened to return the members in.
+func (m *v1EngineMemo) engineFor(kws []string) *matchengine.Engine {
+	var digest uint64
+	for _, k := range kws {
+		digest += maphash.String(v1DigestSeed, k)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.engine != nil && m.count == len(kws) && m.digest == digest {
+		return m.engine
+	}
+
+	set := make(map[string]struct{}, len(kws))
+	for _, k := range kws {
+		set[k] = struct{}{}
+	}
+	m.engine = buildEngine(PresetBalanced, set)
+	m.digest = digest
+	m.count = len(kws)
+	return m.engine
 }
 
 // --- operations interface methods ---
@@ -146,10 +195,13 @@ func (o *v1Operations) find(ctx context.Context, text string) ([]string, error) 
 		return nil, newOperationError("find", SchemaV1, err)
 	}
 
-	matched := engine.Find(text)
-	if matched == nil {
-		matched = []string{}
+	// Honor a canceled ctx at the match boundary; the in-memory scan itself isn't
+	// ctx-threaded. Mirrors v2Operations.find.
+	if err := ctx.Err(); err != nil {
+		return nil, newOperationError("find", SchemaV1, err)
 	}
+
+	matched := engine.Find(text)
 	o.logger.Println(fmt.Sprintf("Find(%s) > Matched(%v) : Count(%d)", text, matched, len(matched)))
 	return matched, nil
 }
@@ -167,35 +219,32 @@ func (o *v1Operations) findIndex(ctx context.Context, text string) (map[string][
 		return nil, newOperationError("findIndex", SchemaV1, err)
 	}
 
-	matched := engine.FindIndex(text)
-	if matched == nil {
-		matched = map[string][]int{}
+	// See find: honor an already-canceled/expired ctx before the in-memory match.
+	if err := ctx.Err(); err != nil {
+		return nil, newOperationError("findIndex", SchemaV1, err)
 	}
+
+	matched := engine.FindIndex(text)
 	o.logger.Println(fmt.Sprintf("FindIndex(%s) > Matched(%v) : Count(%d)", text, matched, len(matched)))
 	return matched, nil
 }
 
-// loadEngine builds a fresh in-memory automaton from the V1 keyword set. V1
-// stores keywords already normalized (lowercased when !caseSensitive), so no
-// re-normalization is needed here. Unlike V2 there is no cache, so this is an
-// O(keywords) build per call — acceptable for the legacy schema.
+// loadEngine returns an in-memory automaton for the V1 keyword set. V1 stores
+// keywords already normalized (lowercased when !caseSensitive), so no
+// re-normalization is needed here.
 //
-// Caching the engine here would need the pub/sub invalidation listener, which
-// only runs under EnableCache — and EnableCache with V1 is ErrCacheRequiresV2.
-// Without it a peer's write leaves this instance matching a stale keyword set,
-// so V1 rebuilds instead.
+// The keyword set is re-read on every call rather than cached: a real cache
+// would need the pub/sub invalidation listener, which only runs under
+// EnableCache — and EnableCache with V1 is ErrCacheRequiresV2 — so without the
+// re-read a peer's write would leave this instance matching a stale set. The
+// automaton built from that set is memoized (see v1EngineMemo), which keeps the
+// freshness while skipping the rebuild when nothing changed.
 func (o *v1Operations) loadEngine(ctx context.Context) (*matchengine.Engine, error) {
 	kws, err := o.storage.SMembers(ctx, keywordKey(o.name))
 	if err != nil {
 		return nil, newRedisError("SMEMBERS", keywordKey(o.name), err)
 	}
-	set := make(map[string]struct{}, len(kws))
-	for _, k := range kws {
-		set[k] = struct{}{}
-	}
-	e := matchengine.New(PresetBalanced)
-	e.Build(set)
-	return e, nil
+	return o.engines.engineFor(kws), nil
 }
 
 func (o *v1Operations) flush(_ context.Context) error {

--- a/pkg/acor/v1_ops.go
+++ b/pkg/acor/v1_ops.go
@@ -35,24 +35,15 @@ type v1Operations struct {
 }
 
 // v1EngineMemo holds the automaton last built for a keyword set, so repeated
-// searches over an unchanged V1 collection skip the rebuild. Building is not
-// cheap — an O(keywords) double-array pack that runs ~14ms for 10k keywords and
-// ~800ms for 100k — and find, findIndex, FindMatches, Contains, FindStream and
-// every FindParallel chunk all go through loadEngine.
-//
-// This is not the V2 cache: the keyword set is still read from Redis on every
-// call, so a peer's write is picked up immediately. Only the rebuild is skipped,
-// and only while the set Redis returns is unchanged.
+// searches over an unchanged V1 collection skip the O(keywords) rebuild.
 type v1EngineMemo struct {
 	mu     sync.Mutex
 	engine *matchengine.Engine
 	digest uint64
-	count  int
 }
 
-// v1DigestSeed keys the keyword-set digest. It is per-process, which is all the
-// memo needs — digests are only ever compared against ones taken in the same
-// process, never persisted or sent over the wire.
+// v1DigestSeed keys the keyword-set digest, which is only ever compared against
+// digests taken in the same process.
 var v1DigestSeed = maphash.MakeSeed()
 
 // engineFor returns the automaton for kws, rebuilding only when the set changed.
@@ -66,7 +57,7 @@ func (m *v1EngineMemo) engineFor(kws []string) *matchengine.Engine {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.engine != nil && m.count == len(kws) && m.digest == digest {
+	if m.engine != nil && m.digest == digest {
 		return m.engine
 	}
 
@@ -76,7 +67,6 @@ func (m *v1EngineMemo) engineFor(kws []string) *matchengine.Engine {
 	}
 	m.engine = buildEngine(PresetBalanced, set)
 	m.digest = digest
-	m.count = len(kws)
 	return m.engine
 }
 
@@ -177,13 +167,9 @@ func (o *v1Operations) remove(_ context.Context, keyword string) (int, error) {
 	return 1, nil
 }
 
-// find scans text with an automaton built from the keyword set.
-//
-// V1 used to resolve goto/fail/output against Redis once per character, which
-// cost a round trip per rune of input. loadEngine reads the keyword set with a
-// single SMEMBERS and builds the same automaton the other modes scan, so the
-// matches are identical (v1_engine_parity_test.go pins that) for one round trip
-// instead of one per character.
+// find scans text with the automaton loadEngine builds from the keyword set,
+// which reports the same matches the per-character trie walk in Redis used to
+// (pinned by v1_engine_parity_test.go) for one round trip instead of one per rune.
 func (o *v1Operations) find(ctx context.Context, text string) ([]string, error) {
 	if text == "" {
 		return []string{}, nil
@@ -195,19 +181,12 @@ func (o *v1Operations) find(ctx context.Context, text string) ([]string, error) 
 		return nil, newOperationError("find", SchemaV1, err)
 	}
 
-	// Honor a canceled ctx at the match boundary; the in-memory scan itself isn't
-	// ctx-threaded. Mirrors v2Operations.find.
-	if err := ctx.Err(); err != nil {
-		return nil, newOperationError("find", SchemaV1, err)
-	}
-
 	matched := engine.Find(text)
 	o.logger.Println(fmt.Sprintf("Find(%s) > Matched(%v) : Count(%d)", text, matched, len(matched)))
 	return matched, nil
 }
 
-// findIndex is find with the start offset of every match. See find on why this
-// no longer walks the trie in Redis.
+// findIndex is find with the start offset of every match.
 func (o *v1Operations) findIndex(ctx context.Context, text string) (map[string][]int, error) {
 	if text == "" {
 		return map[string][]int{}, nil
@@ -216,11 +195,6 @@ func (o *v1Operations) findIndex(ctx context.Context, text string) (map[string][
 
 	engine, err := o.loadEngine(ctx)
 	if err != nil {
-		return nil, newOperationError("findIndex", SchemaV1, err)
-	}
-
-	// See find: honor an already-canceled/expired ctx before the in-memory match.
-	if err := ctx.Err(); err != nil {
 		return nil, newOperationError("findIndex", SchemaV1, err)
 	}
 
@@ -233,12 +207,9 @@ func (o *v1Operations) findIndex(ctx context.Context, text string) (map[string][
 // keywords already normalized (lowercased when !caseSensitive), so no
 // re-normalization is needed here.
 //
-// The keyword set is re-read on every call rather than cached: a real cache
-// would need the pub/sub invalidation listener, which only runs under
-// EnableCache — and EnableCache with V1 is ErrCacheRequiresV2 — so without the
-// re-read a peer's write would leave this instance matching a stale set. The
-// automaton built from that set is memoized (see v1EngineMemo), which keeps the
-// freshness while skipping the rebuild when nothing changed.
+// The set itself is re-read every call — V1 has no invalidation listener
+// (EnableCache with V1 is ErrCacheRequiresV2), so a peer's write would otherwise
+// go unnoticed. Only the rebuild is memoized (see v1EngineMemo).
 func (o *v1Operations) loadEngine(ctx context.Context) (*matchengine.Engine, error) {
 	kws, err := o.storage.SMembers(ctx, keywordKey(o.name))
 	if err != nil {

--- a/pkg/acor/v1_ops.go
+++ b/pkg/acor/v1_ops.go
@@ -3,7 +3,6 @@
 package acor
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -129,103 +128,50 @@ func (o *v1Operations) remove(_ context.Context, keyword string) (int, error) {
 	return 1, nil
 }
 
+// find scans text with an automaton built from the keyword set.
+//
+// V1 used to resolve goto/fail/output against Redis once per character, which
+// cost a round trip per rune of input. loadEngine reads the keyword set with a
+// single SMEMBERS and builds the same automaton the other modes scan, so the
+// matches are identical (v1_engine_parity_test.go pins that) for one round trip
+// instead of one per character.
 func (o *v1Operations) find(ctx context.Context, text string) ([]string, error) {
 	if text == "" {
 		return []string{}, nil
 	}
-	if !o.caseSensitive {
-		text = strings.ToLower(text)
-	}
-	state := ""
-	matched := make([]string, 0)
+	text = normalizeText(text, o.caseSensitive)
 
-	for _, char := range text {
-		nextState, err := o.ac.goWithContext(ctx, state, char)
-		if err != nil {
-			return nil, newOperationError("find", SchemaV1, err)
-		}
-		if nextState == "" {
-			nextState, err = o.ac.failWithContext(ctx, state)
-			if err != nil {
-				return nil, newOperationError("find", SchemaV1, err)
-			}
-			var afterNextState string
-			afterNextState, err = o.ac.goWithContext(ctx, nextState, char)
-			if err != nil {
-				return nil, newOperationError("find", SchemaV1, err)
-			}
-			if afterNextState == "" {
-				buffer := bytes.NewBufferString(nextState)
-				buffer.WriteRune(char)
-				afterNextState, err = o.ac.failWithContext(ctx, buffer.String())
-				if err != nil {
-					return nil, newOperationError("find", SchemaV1, err)
-				}
-			}
-			nextState = afterNextState
-		}
-
-		outputs, err := o.ac.outputWithContext(ctx, nextState)
-		if err != nil {
-			return nil, newOperationError("find", SchemaV1, err)
-		}
-		matched = append(matched, outputs...)
-		state = nextState
+	engine, err := o.loadEngine(ctx)
+	if err != nil {
+		return nil, newOperationError("find", SchemaV1, err)
 	}
 
+	matched := engine.Find(text)
+	if matched == nil {
+		matched = []string{}
+	}
 	o.logger.Println(fmt.Sprintf("Find(%s) > Matched(%v) : Count(%d)", text, matched, len(matched)))
-
 	return matched, nil
 }
 
+// findIndex is find with the start offset of every match. See find on why this
+// no longer walks the trie in Redis.
 func (o *v1Operations) findIndex(ctx context.Context, text string) (map[string][]int, error) {
 	if text == "" {
 		return map[string][]int{}, nil
 	}
-	if !o.caseSensitive {
-		text = strings.ToLower(text)
-	}
-	matched := make(map[string][]int)
-	state := ""
-	runeIndex := 0
+	text = normalizeText(text, o.caseSensitive)
 
-	for _, char := range text {
-		nextState, err := o.ac.goWithContext(ctx, state, char)
-		if err != nil {
-			return nil, newOperationError("findIndex", SchemaV1, err)
-		}
-		if nextState == "" {
-			nextState, err = o.ac.failWithContext(ctx, state)
-			if err != nil {
-				return nil, newOperationError("findIndex", SchemaV1, err)
-			}
-			var afterNextState string
-			afterNextState, err = o.ac.goWithContext(ctx, nextState, char)
-			if err != nil {
-				return nil, newOperationError("findIndex", SchemaV1, err)
-			}
-			if afterNextState == "" {
-				buffer := bytes.NewBufferString(nextState)
-				buffer.WriteRune(char)
-				afterNextState, err = o.ac.failWithContext(ctx, buffer.String())
-				if err != nil {
-					return nil, newOperationError("findIndex", SchemaV1, err)
-				}
-			}
-			nextState = afterNextState
-		}
-
-		outputs, err := o.ac.outputWithContext(ctx, nextState)
-		if err != nil {
-			return nil, newOperationError("findIndex", SchemaV1, err)
-		}
-		o.ac.appendMatchedIndexesWithContext(ctx, matched, outputs, runeIndex+1)
-		state = nextState
-		runeIndex++
+	engine, err := o.loadEngine(ctx)
+	if err != nil {
+		return nil, newOperationError("findIndex", SchemaV1, err)
 	}
 
+	matched := engine.FindIndex(text)
+	if matched == nil {
+		matched = map[string][]int{}
+	}
 	o.logger.Println(fmt.Sprintf("FindIndex(%s) > Matched(%v) : Count(%d)", text, matched, len(matched)))
-
 	return matched, nil
 }
 

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -39,9 +39,7 @@ func (o *v2Operations) find(ctx context.Context, text string) ([]string, error) 
 		return []string{}, nil
 	}
 
-	if !o.caseSensitive {
-		text = strings.ToLower(text)
-	}
+	text = normalizeText(text, o.caseSensitive)
 
 	engine, err := o.loadEngine(ctx)
 	if err != nil {
@@ -61,9 +59,7 @@ func (o *v2Operations) findIndex(ctx context.Context, text string) (map[string][
 		return map[string][]int{}, nil
 	}
 
-	if !o.caseSensitive {
-		text = strings.ToLower(text)
-	}
+	text = normalizeText(text, o.caseSensitive)
 
 	engine, err := o.loadEngine(ctx)
 	if err != nil {

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -53,11 +53,7 @@ func (o *v2Operations) find(ctx context.Context, text string) ([]string, error) 
 		return nil, err
 	}
 
-	matched := engine.Find(text)
-	if matched == nil {
-		matched = []string{}
-	}
-	return matched, nil
+	return engine.Find(text), nil
 }
 
 func (o *v2Operations) findIndex(ctx context.Context, text string) (map[string][]int, error) {
@@ -79,11 +75,7 @@ func (o *v2Operations) findIndex(ctx context.Context, text string) (map[string][
 		return nil, err
 	}
 
-	matched := engine.FindIndex(text)
-	if matched == nil {
-		matched = map[string][]int{}
-	}
-	return matched, nil
+	return engine.FindIndex(text), nil
 }
 
 func (o *v2Operations) add(ctx context.Context, keyword string) (int, error) {


### PR DESCRIPTION
# Pull Request

## Description

V1's `find` and `findIndex` resolved goto, fail and output against Redis **once per character**: a `ZSCORE` for the goto, up to `len(state)` more for the fail walk, and an `SMEMBERS` for the outputs — for every rune of the input.

`v1Operations` already had `loadEngine`, which reads the keyword set with one `SMEMBERS` and builds the same in-memory automaton the V2 and preset paths scan. Both methods now go through it, so a V1 search costs a single round trip instead of two to three commands per rune. This also deletes the reimplementation of Aho-Corasick traversal that lived in `v1_ops.go`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test update

Behaviour-preserving, but the performance effect is the point, hence the `perf:` commit prefix.

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — skip for internal-only changes (CI, tests, refactors); see [RELEASE.md](../RELEASE.md)
- [x] Commit messages follow guidelines