### PR TITLE
docs: warn that the exported key-format constants are not the real keys

### DIFF
--- a/pkg/acor/keys.go
+++ b/pkg/acor/keys.go
@@ -4,19 +4,26 @@ package acor
 
 import "time"
 
-// Key format constants define the Redis key patterns used by the V1 schema.
-// These constants use %s as a placeholder for the collection name.
-// For V2 schema, fewer keys are used (see trieKey, outputsKey, nodesKey).
+// Key format constants for the V1 schema, using %s as a placeholder for the
+// collection name.
+//
+// These do not produce the keys ACOR actually writes. A collection name is
+// wrapped in a Redis hash tag so all of a collection's keys hash to one cluster
+// slot, making the real key "{mycoll}:keyword" while
+// fmt.Sprintf(KeywordKey, "mycoll") yields "mycoll:keyword". Nothing in ACOR
+// reads these constants; the key builders hold the correct format. Treat them
+// as informational only — reading Redis directly with a key built from them
+// will not find anything.
 const (
-	// KeywordKey is the format for the keywords set key: "{name}:keyword"
+	// KeywordKey is the suffix pattern for the keywords set. Real key: "{name}:keyword".
 	KeywordKey = "%s:keyword"
-	// PrefixKey is the format for the prefixes sorted set key: "{name}:prefix"
+	// PrefixKey is the suffix pattern for the prefixes sorted set. Real key: "{name}:prefix".
 	PrefixKey = "%s:prefix"
-	// SuffixKey is the format for the suffixes sorted set key: "{name}:suffix"
+	// SuffixKey is the suffix pattern for the suffixes sorted set. Real key: "{name}:suffix".
 	SuffixKey = "%s:suffix"
-	// OutputKey is the format for output set keys: "{name}:output:{state}"
+	// OutputKey is the suffix pattern for output sets. Real key: "{name}:output:{state}".
 	OutputKey = "%s:output"
-	// NodeKey is the format for node set keys: "{name}:node:{keyword}"
+	// NodeKey is the suffix pattern for node sets. Real key: "{name}:node:{keyword}".
 	NodeKey = "%s:node"
 )
 


### PR DESCRIPTION
# Pull Request

## Description

`acor.KeywordKey` and its four siblings are documented as producing `"{name}:keyword"`, but the values are `"%s:keyword"` — the hash tag that groups a collection's keys onto one cluster slot is missing. `fmt.Sprintf(acor.KeywordKey, "mycoll")` yields `mycoll:keyword`, while the key ACOR actually writes is `{mycoll}:keyword`.

Nothing in ACOR reads these constants — the key builders in `keys.go` hold the correct format — so the mismatch has never surfaced internally. A consumer that used one to read Redis directly would query a key that does not exist.

This PR documents the discrepancy on each constant and on the group comment.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — skip for internal-only changes (CI, tests, refactors); see [RELEASE.md](../RELEASE.md)
- [x] Commit messages follow guidelines

No changelog fragment: doc comments only, no behaviour or value change.