### PR TITLE
test: disable go-redis retry backoff in Redis test clients

### DIFF
--- a/pkg/acor/batch_coalesce_test.go
+++ b/pkg/acor/batch_coalesce_test.go
@@ -32,7 +32,7 @@ func createPresetAC(t *testing.T) (*AhoCorasick, *miniredis.Miniredis) {
 func countInvalidations(t *testing.T, mr *miniredis.Miniredis, during func()) int {
 	t.Helper()
 	ctx := context.Background()
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer client.Close()
 
 	sub := client.Subscribe(ctx, invalidateChannelPrefix+"test")
@@ -197,7 +197,7 @@ func TestInvalidationPoll_DetectsMissedWrite(t *testing.T) {
 
 	// Simulate a write on another node whose invalidation never arrived: write a
 	// valid trie state directly to Redis with a distinct version and DO NOT publish.
-	raw := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	raw := newTestRedisClient(mr.Addr())
 	defer raw.Close()
 	ctx := context.Background()
 	if err := raw.HSet(ctx, trieKey("test"), map[string]interface{}{

--- a/pkg/acor/batch_debug_test.go
+++ b/pkg/acor/batch_debug_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	redis "github.com/redis/go-redis/v9"
 )
 
 func TestV2Debug(t *testing.T) {
@@ -106,7 +105,7 @@ func TestDebugV1WithNoData(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	ac := &AhoCorasick{
@@ -129,7 +128,7 @@ func TestDebugV1WithNoData(t *testing.T) {
 func TestDebugV1WithClosedRedis(t *testing.T) {
 	mr := miniredis.RunT(t)
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	ac := &AhoCorasick{
@@ -155,7 +154,7 @@ func TestDebugV2WithData(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	ctx := context.Background()
@@ -192,7 +191,7 @@ func TestDebugV2WithData(t *testing.T) {
 func TestDebugV2WithClosedRedis(t *testing.T) {
 	mr := miniredis.RunT(t)
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	ac := &AhoCorasick{
@@ -217,7 +216,7 @@ func TestDebugV2WithClosedRedis(t *testing.T) {
 func TestInitV2HSetError(t *testing.T) {
 	mr := miniredis.RunT(t)
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	mr.Close()
@@ -238,7 +237,7 @@ func TestInitV2HSetError(t *testing.T) {
 
 func TestInitV1ZAddError(t *testing.T) {
 	mr := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	mr.Close()

--- a/pkg/acor/batch_migration_test.go
+++ b/pkg/acor/batch_migration_test.go
@@ -93,7 +93,7 @@ func TestMigrationLockAlreadyHeld(t *testing.T) {
 
 func TestMigrationInProgress(t *testing.T) {
 	s := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	client := newTestRedisClient(s.Addr())
 	defer func() { _ = client.Close() }()
 
 	// Seed V1 data so migration doesn't fail for other reasons

--- a/pkg/acor/batch_rollback_test.go
+++ b/pkg/acor/batch_rollback_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	redis "github.com/redis/go-redis/v9"
 )
 
 func TestRollbackRemovedWithLogger(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	log := &testLogger{}
@@ -43,7 +42,7 @@ func TestRollbackAddedWithLogger(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	log := &testLogger{}

--- a/pkg/acor/batch_v2_error_test.go
+++ b/pkg/acor/batch_v2_error_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	redis "github.com/redis/go-redis/v9"
 )
 
 func TestV2TryAddBadKeywordsJSON(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -36,7 +35,7 @@ func TestV2TryRemoveBadKeywordsJSON(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -58,7 +57,7 @@ func TestV2TryRemoveVersionFallback(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -80,7 +79,7 @@ func TestV2TryAddVersionFallback(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -103,8 +102,8 @@ func TestV2FindIndexError(t *testing.T) {
 	mr.Close()
 
 	ops := &v2Operations{
-		storage: newRedisStorage(redis.NewClient(&redis.Options{Addr: "localhost:1"})),
-		client:  redis.NewClient(&redis.Options{Addr: "localhost:1"}),
+		storage: newRedisStorage(newTestRedisClient("localhost:1")),
+		client:  newTestRedisClient("localhost:1"),
 		name:    "test",
 		cache:   nil,
 		logger:  &testLogger{},
@@ -123,8 +122,8 @@ func TestV2GetOrLoadEngineError(t *testing.T) {
 
 	cache := &trieCache{}
 	ops := &v2Operations{
-		storage: newRedisStorage(redis.NewClient(&redis.Options{Addr: "localhost:1"})),
-		client:  redis.NewClient(&redis.Options{Addr: "localhost:1"}),
+		storage: newRedisStorage(newTestRedisClient("localhost:1")),
+		client:  newTestRedisClient("localhost:1"),
 		name:    "test",
 		cache:   cache,
 		logger:  &testLogger{},
@@ -142,8 +141,8 @@ func TestV2FlushError(t *testing.T) {
 	mr.Close()
 
 	ops := &v2Operations{
-		storage: newRedisStorage(redis.NewClient(&redis.Options{Addr: "localhost:1"})),
-		client:  redis.NewClient(&redis.Options{Addr: "localhost:1"}),
+		storage: newRedisStorage(newTestRedisClient("localhost:1")),
+		client:  newTestRedisClient("localhost:1"),
 		name:    "test",
 		cache:   &trieCache{},
 		logger:  &testLogger{},
@@ -160,7 +159,7 @@ func TestV2InfoBadPrefixesJSON(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -183,8 +182,8 @@ func TestV2SuggestError(t *testing.T) {
 	mr.Close()
 
 	ops := &v2Operations{
-		storage: newRedisStorage(redis.NewClient(&redis.Options{Addr: addr})),
-		client:  redis.NewClient(&redis.Options{Addr: addr}),
+		storage: newRedisStorage(newTestRedisClient(addr)),
+		client:  newTestRedisClient(addr),
 		name:    "test",
 		logger:  &testLogger{},
 	}
@@ -202,8 +201,8 @@ func TestV2SuggestIndexError(t *testing.T) {
 	mr.Close()
 
 	ops := &v2Operations{
-		storage: newRedisStorage(redis.NewClient(&redis.Options{Addr: addr})),
-		client:  redis.NewClient(&redis.Options{Addr: addr}),
+		storage: newRedisStorage(newTestRedisClient(addr)),
+		client:  newTestRedisClient(addr),
 		name:    "test",
 		logger:  &testLogger{},
 	}

--- a/pkg/acor/benchmark_test.go
+++ b/pkg/acor/benchmark_test.go
@@ -27,7 +27,7 @@ func toJSONOrFatal(tb testing.TB, v interface{}) string {
 func BenchmarkFindV1(b *testing.B) {
 	mr := miniredis.RunT(b)
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	_ = client.ZAdd(context.Background(), "{bench}:prefix", redis.Z{Score: 0, Member: ""}).Err()
 	_ = client.Close()
 
@@ -58,7 +58,7 @@ func BenchmarkFindV1(b *testing.B) {
 
 func BenchmarkFindV2(b *testing.B) {
 	mr := miniredis.RunT(b)
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	keywords := []string{"he", "she", "his", "hers", "hello", "world", "benchmark"}
@@ -106,7 +106,7 @@ func BenchmarkFindV2(b *testing.B) {
 func BenchmarkAddV1(b *testing.B) {
 	mr := miniredis.RunT(b)
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	_ = client.ZAdd(context.Background(), "{bench}:prefix", redis.Z{Score: 0, Member: ""}).Err()
 	_ = client.Close()
 
@@ -142,7 +142,7 @@ func BenchmarkAddV2(b *testing.B) {
 	}
 	defer func() { _ = ac.Close() }()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	_ = client.HSet(context.Background(), "{bench}:trie", map[string]interface{}{
 		"keywords": "[]",
 		"prefixes": `[""]`,

--- a/pkg/acor/info_test.go
+++ b/pkg/acor/info_test.go
@@ -126,7 +126,7 @@ func TestV1V2Compatibility(t *testing.T) {
 		"ushers",
 	}
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	if err := client.ZAdd(context.Background(), "{v1test}:prefix", redis.Z{Score: 0, Member: ""}).Err(); err != nil {
 		t.Fatalf("failed to seed V1 prefix: %v", err)
 	}

--- a/pkg/acor/integration_test.go
+++ b/pkg/acor/integration_test.go
@@ -173,7 +173,7 @@ func TestIntegrationMigration(t *testing.T) {
 	addr := integrationAddr(t)
 	const name = "acor-it-migrate"
 
-	client := redis.NewClient(&redis.Options{Addr: addr})
+	client := newTestRedisClient(addr)
 	defer func() { _ = client.Close() }()
 	ctx := context.Background()
 

--- a/pkg/acor/migration_test.go
+++ b/pkg/acor/migration_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestMigrateV1ToV2(t *testing.T) {
 	s := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	client := newTestRedisClient(s.Addr())
 	defer func() { _ = client.Close() }()
 
 	ctx := context.Background()
@@ -90,7 +90,7 @@ func TestMigrateV1ToV2(t *testing.T) {
 
 func TestMigrateAlreadyV2(t *testing.T) {
 	s := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	client := newTestRedisClient(s.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", "version", "123")
@@ -109,7 +109,7 @@ func TestMigrateAlreadyV2(t *testing.T) {
 
 func TestMigrateNoData(t *testing.T) {
 	s := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	client := newTestRedisClient(s.Addr())
 	defer func() { _ = client.Close() }()
 
 	ac := &AhoCorasick{
@@ -126,7 +126,7 @@ func TestMigrateNoData(t *testing.T) {
 
 func TestMigrationProgress(t *testing.T) {
 	s := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	client := newTestRedisClient(s.Addr())
 	defer func() { _ = client.Close() }()
 
 	ctx := context.Background()
@@ -163,7 +163,7 @@ func TestMigrationProgress(t *testing.T) {
 
 func TestRollbackToV1(t *testing.T) {
 	s := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	client := newTestRedisClient(s.Addr())
 	defer func() { _ = client.Close() }()
 
 	ctx := context.Background()
@@ -206,7 +206,7 @@ func TestRollbackToV1(t *testing.T) {
 
 func TestRollbackToV1NoV1Keys(t *testing.T) {
 	s := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: s.Addr()})
+	client := newTestRedisClient(s.Addr())
 	defer func() { _ = client.Close() }()
 
 	ctx := context.Background()

--- a/pkg/acor/test_helpers_test.go
+++ b/pkg/acor/test_helpers_test.go
@@ -20,6 +20,13 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// newTestRedisClient builds a Redis client with command retries disabled and a
+// single pooled connection. Against a closed miniredis the go-redis defaults
+// (MaxRetries 3, pool-sized dial retries) cost ~1.6s per failing command.
+func newTestRedisClient(addr string) *redis.Client {
+	return redis.NewClient(&redis.Options{Addr: addr, MaxRetries: -1, PoolSize: 1, DialerRetries: 1})
+}
+
 // testLogger is a no-op Logger implementation for tests.
 type testLogger struct{}
 
@@ -51,11 +58,13 @@ func createAhoCorasick(t *testing.T) (*AhoCorasick, *miniredis.Miniredis) {
 
 	mr := createTestRedisServer(t)
 	ac, err := Create(&AhoCorasickArgs{
-		Addr:     mr.Addr(),
-		Password: "",
-		DB:       0,
-		Name:     "test",
-		Debug:    false,
+		Addr:       mr.Addr(),
+		Password:   "",
+		DB:         0,
+		Name:       "test",
+		Debug:      false,
+		MaxRetries: -1,
+		PoolSize:   1,
 	})
 	if err != nil {
 		mr.Close()
@@ -69,7 +78,7 @@ func createAhoCorasickV1(t *testing.T) (*AhoCorasick, *miniredis.Miniredis) {
 	t.Helper()
 
 	mr := createTestRedisServer(t)
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	if err := client.ZAdd(context.Background(), "{test}:prefix", redis.Z{Score: 0, Member: ""}).Err(); err != nil {
 		mr.Close()
 		t.Fatalf("failed to seed V1 prefix data: %v", err)
@@ -86,6 +95,8 @@ func createAhoCorasickV1(t *testing.T) (*AhoCorasick, *miniredis.Miniredis) {
 		Name:          "test",
 		Debug:         false,
 		SchemaVersion: SchemaV1,
+		MaxRetries:    -1,
+		PoolSize:      1,
 	})
 	if err != nil {
 		mr.Close()

--- a/pkg/acor/topology_test.go
+++ b/pkg/acor/topology_test.go
@@ -179,7 +179,7 @@ func TestStorageAdapterMethods(t *testing.T) {
 	}
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	storage := newRedisStorage(client)
@@ -291,7 +291,7 @@ func TestStorageDel(t *testing.T) {
 	}
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	storage := newRedisStorage(client)

--- a/pkg/acor/v1_errors_test.go
+++ b/pkg/acor/v1_errors_test.go
@@ -16,7 +16,7 @@ func setupV1WithError(t *testing.T) *AhoCorasick {
 	t.Helper()
 
 	mr := createTestRedisServer(t)
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 
 	// Seed some V1 data so operations can start before the server closes
 	if err := client.SAdd(context.Background(), keywordKey("test"), "he", "she").Err(); err != nil {

--- a/pkg/acor/v2_cache_test.go
+++ b/pkg/acor/v2_cache_test.go
@@ -7,14 +7,13 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	redis "github.com/redis/go-redis/v9"
 )
 
 func TestV2GetOrLoadEngineNoCache(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	ops := &v2Operations{
@@ -50,7 +49,7 @@ func TestV2PublishInvalidate(t *testing.T) {
 	cache := &trieCache{}
 	cache.set(map[string][]string{"a": {"a"}})
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	ops := &v2Operations{
@@ -73,7 +72,7 @@ func TestV2FetchTrieData(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -109,7 +108,7 @@ func TestV2LoadCache(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -155,7 +154,7 @@ func TestV2GetOrLoadEngineDoubleCheck(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -202,8 +201,8 @@ func TestV2PublishInvalidateWithPublishError(t *testing.T) {
 	cache.set(map[string][]string{"a": {"a"}})
 
 	ops := &v2Operations{
-		storage: newRedisStorage(redis.NewClient(&redis.Options{Addr: "localhost:1"})),
-		client:  redis.NewClient(&redis.Options{Addr: "localhost:1"}),
+		storage: newRedisStorage(newTestRedisClient("localhost:1")),
+		client:  newTestRedisClient("localhost:1"),
 		name:    "test",
 		cache:   cache,
 		logger:  &testLogger{},
@@ -221,7 +220,7 @@ func TestV2PublishInvalidateWithPublishError(t *testing.T) {
 func TestV2LoadCacheError(t *testing.T) {
 	mr := miniredis.RunT(t)
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	cache := &trieCache{}
 	ops := &v2Operations{
 		storage: newRedisStorage(client),

--- a/pkg/acor/v2_errors_test.go
+++ b/pkg/acor/v2_errors_test.go
@@ -8,15 +8,13 @@ import (
 	"io"
 	"log"
 	"testing"
-
-	redis "github.com/redis/go-redis/v9"
 )
 
 func setupV2WithError(t *testing.T) *AhoCorasick {
 	t.Helper()
 
 	mr := createTestRedisServer(t)
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 
 	if err := client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
 		"keywords": `["he","she"]`,

--- a/pkg/acor/v2_integration_test.go
+++ b/pkg/acor/v2_integration_test.go
@@ -7,13 +7,12 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	redis "github.com/redis/go-redis/v9"
 )
 
 func newTestV2Ops(t *testing.T, mr *miniredis.Miniredis) *v2Operations {
 	t.Helper()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	store := newRedisStorage(client)
 
 	return &v2Operations{
@@ -28,7 +27,7 @@ func newTestV2Ops(t *testing.T, mr *miniredis.Miniredis) *v2Operations {
 func seedV2Trie(t *testing.T, mr *miniredis.Miniredis, keywords []string) {
 	t.Helper()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	ops := newTestV2Ops(t, mr)
@@ -401,7 +400,7 @@ func TestV2FlushWithNodes(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -562,7 +561,7 @@ func TestV2FetchTrieDataBadJSON(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -587,7 +586,7 @@ func TestV2FetchTrieDataBadOutputsJSON(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -616,7 +615,7 @@ func TestV2TryAddBadPrefixesJSON(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -644,7 +643,7 @@ func TestV2LegacySuffixesFieldIgnored(t *testing.T) {
 
 	ctx := context.Background()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(ctx, "{test}:trie", map[string]interface{}{
@@ -695,7 +694,7 @@ func TestPresetFlushDropsLegacySuffixes(t *testing.T) {
 	}
 	defer func() { _ = ac.Close() }()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	if hsetErr := client.HSet(ctx, "{test}:trie", "suffixes", "not-json").Err(); hsetErr != nil {
@@ -719,7 +718,7 @@ func TestV2TryRemoveBadPrefixesJSON(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -741,7 +740,7 @@ func TestV2InfoBadJSON(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{
@@ -762,7 +761,7 @@ func TestV2SuggestBadJSON(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	client.HSet(context.Background(), "{test}:trie", map[string]interface{}{

--- a/pkg/acor/v2_lua_test.go
+++ b/pkg/acor/v2_lua_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	redis "github.com/redis/go-redis/v9"
 )
 
 // largeVersionAbove2to53 is a version value above 2^53 used by int64 safety tests.
@@ -95,7 +94,7 @@ func TestLuaScriptInt64SafetyAdd(t *testing.T) {
 	ctx := context.Background()
 	seedV2Trie(t, mr, []string{"he", "she"})
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 	if err := client.HSet(ctx, trieKey("test"), "version", largeVersionAbove2to53).Err(); err != nil {
 		t.Fatal(err)
@@ -133,7 +132,7 @@ func TestLuaScriptInt64SafetyRemove(t *testing.T) {
 	ctx := context.Background()
 	seedV2Trie(t, mr, []string{"he", "she"})
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 	if err := client.HSet(ctx, trieKey("test"), "version", largeVersionAbove2to53).Err(); err != nil {
 		t.Fatal(err)

--- a/pkg/acor/v2_ops_test.go
+++ b/pkg/acor/v2_ops_test.go
@@ -7,13 +7,11 @@ import (
 	"io"
 	"log"
 	"testing"
-
-	redis "github.com/redis/go-redis/v9"
 )
 
 func TestV2Find(t *testing.T) {
 	mr := createTestRedisServer(t)
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	storage := newRedisStorage(client)

--- a/pkg/acor/version_precision_test.go
+++ b/pkg/acor/version_precision_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	redis "github.com/redis/go-redis/v9"
 )
 
 func TestGenerateVersionBasic(t *testing.T) {
@@ -62,7 +61,7 @@ func TestLuaVersionComparisonAbove2to53(t *testing.T) {
 	largeNewVersion := int64(9007199254740994) // 2^53 + 2
 
 	// Set the trie version to largeOldVersion in Redis directly
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 	if hErr := client.HSet(ctx, trieKey("test"), "version", largeOldVersion).Err(); hErr != nil {
 		t.Fatal(hErr)
@@ -157,7 +156,7 @@ func TestLuaVersionStringComparison(t *testing.T) {
 			seedV2Trie(t, mr, []string{"he"})
 
 			// Set version in Redis
-			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			client := newTestRedisClient(mr.Addr())
 			defer func() { _ = client.Close() }()
 			if err := client.HSet(ctx, trieKey("test"), "version", tt.storedVersion).Err(); err != nil {
 				t.Fatal(err)
@@ -211,7 +210,7 @@ func TestLuaVersionRemoveScriptPrecision(t *testing.T) {
 	ctx := context.Background()
 	seedV2Trie(t, mr, []string{"he", "she"})
 
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
 	largeVersion := int64(9007199254740993)


### PR DESCRIPTION
## Why

`pre-commit` could never pass on a `.go` commit, so commits were going through with `--no-verify`.

The `go-unit-tests` hook comes from `dnephin/pre-commit-golang` v0.5.1, whose script hardcodes the timeout:

```bash
go test -tags=unit -timeout 30s -short -v ${FILES}
```

The script ignores `$@`, so `args:` in `.pre-commit-config.yaml` cannot change it. Meanwhile `pkg/acor` alone took **72.7s**.

## Root cause

~35 error-path tests point a client at a **closed** miniredis and assert an error comes back. Three go-redis defaults compound there:

| Default | Effect |
|---|---|
| `MaxRetries: 3` | every command retry re-dials the pool |
| `PoolSize: 10×NumCPU` | pool short-circuits only after `PoolSize` dial failures |
| `DialerRetries: 5` × `DialerRetryTimeout: 100ms` | 400ms per dial sequence |

Net cost: **~1.6s per failing command** — while a raw TCP dial to that port refuses in **38µs**. All of it is library-internal backoff, none of it is exercising acor.

## Change

One helper, and the 68 raw client constructions in tests route through it:

```go
func newTestRedisClient(addr string) *redis.Client {
	return redis.NewClient(&redis.Options{Addr: addr, MaxRetries: -1, PoolSize: 1, DialerRetries: 1})
}
```

No production code touched. The assertions are unchanged — these tests assert *that* an error is returned, which the retry count does not affect.

## Result

| | before | after |
|---|---|---|
| `pkg/acor` | 72.7s | **10.3s** |
| root module (`./...`) | 74s | **10.9s** |

`pre-commit` now passes end to end without `--no-verify` for the first time.

## Verification

- `make lint` — 0 issues, both modules
- `go vet ./...` — clean
- `make race` — clean, both modules
- `go test -count=3 ./pkg/acor` — stable, no flakes (guards against `PoolSize: 1` connection contention)
- `make docs-verify` — 12/12 blocks compile
- `make build` — ok

## Notes for review

- Tests that assert *retry behaviour itself* (`v2_retry_test.go`, `client_resilience_test.go`) do not use this pattern and are untouched, so retry semantics are not masked.
- `createAhoCorasick*` go through `Create(&AhoCorasickArgs{...})`, which does not expose `DialerRetries`; they get `MaxRetries: -1, PoolSize: 1` only and so keep a ~0.4s floor. Left as is rather than widening the public args struct for a test concern.