### PR TITLE
docs: correct the streaming case-fold caveat and pin the parity

### DIFF
--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -273,6 +273,11 @@ type AhoCorasickArgs struct {
 	// When false (default), keywords are lowercased on Add/Remove and search text
 	// is lowercased in Find/FindIndex/Suggest, providing case-insensitive matching.
 	// When true, keywords and search text are matched as-is for full case-sensitive matching.
+	//
+	// Case-insensitive matching uses Go's simple, locale-independent lowercasing
+	// (strings.ToLower), not full Unicode case folding: "ß" does not match "SS",
+	// and Turkish dotted/dotless i follow the default mapping. Pre-fold the
+	// keywords and text yourself if you need either.
 	CaseSensitive bool
 	// RollbackTimeout controls the timeout for V1 rollback operations when buildTrie
 	// fails after a keyword has been added. Defaults to 10 seconds if unset or zero.

--- a/pkg/acor/matches.go
+++ b/pkg/acor/matches.go
@@ -180,9 +180,10 @@ func (ac *AhoCorasick) FindStreamContext(ctx context.Context, r io.Reader, onMat
 			return 0, false
 		}
 		if caseInsensitive {
-			// Per-rune lowering is the streaming equivalent of strings.ToLower;
-			// they agree on ASCII (the common case). ponytail: per-rune fold, use
-			// x/text/cases if locale-correct multi-rune folding is ever needed.
+			// Exactly the fold the in-memory path applies: strings.ToLower is
+			// strings.Map(unicode.ToLower, s), so this agrees rune for rune over the
+			// whole Unicode range, not just ASCII. TestFindStream_CaseFoldParity
+			// guards the agreement.
 			ru = unicode.ToLower(ru)
 		}
 		return ru, true

--- a/pkg/acor/matches_test.go
+++ b/pkg/acor/matches_test.go
@@ -209,6 +209,41 @@ func TestFindStream_NoBoundaryLoss(t *testing.T) {
 	}
 }
 
+// TestFindStream_CaseFoldParity pins the claim in FindStreamContext: the
+// per-rune fold used while streaming is the same fold strings.ToLower applies to
+// an in-memory string, including for non-ASCII runes whose lowercase form is a
+// different byte length (U+212A KELVIN SIGN, U+0130 LATIN CAPITAL I WITH DOT).
+// Swapping either side for a different folding scheme breaks this.
+func TestFindStream_CaseFoldParity(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	addAll(t, ac, "café", "kelvin", "istanbul")
+	// Escaped, not literal: \u212a and \u0130 both fold to a shorter ASCII rune
+	// and are indistinguishable from "K" and "I" in an editor.
+	text := "le CAF\u00c9, \u212aELVIN and \u0130STANBUL"
+
+	want, err := ac.FindMatches(text, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(want) != 3 {
+		t.Fatalf("FindMatches = %v, want 3 matches (test text no longer exercises the fold)", want)
+	}
+
+	got := []Match{}
+	if err := ac.FindStream(strings.NewReader(text), func(m Match) bool {
+		got = append(got, m)
+		return true
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("FindStream = %v, want in-memory parity %v", got, want)
+	}
+}
+
 func TestFindStream_EarlyStop(t *testing.T) {
 	ac, mr := createAhoCorasick(t)
 	defer mr.Close()

--- a/pkg/acor/matches_test.go
+++ b/pkg/acor/matches_test.go
@@ -244,6 +244,78 @@ func TestFindStream_CaseFoldParity(t *testing.T) {
 	}
 }
 
+// TestCaseFold_DocumentedLimits pins the two limitations the CaseSensitive godoc
+// promises: matching folds with Go's simple, locale-independent lowercasing, so
+// "ß" does not match "SS" and Turkish dotted/dotless i follow the default
+// mapping rather than tr locale rules. Every row is asserted against both the
+// in-memory and the streaming path, so a future switch to full folding or to a
+// locale-aware fold fails here and the godoc cannot drift.
+//
+// Non-ASCII is written as escapes throughout: ß/ẞ and i/ı/İ are near
+// indistinguishable in an editor, and a silent substitution would quietly gut
+// the test.
+func TestCaseFold_DocumentedLimits(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	// \u00df is U+00DF SMALL SHARP S, \u0131 is U+0131 SMALL DOTLESS I;
+	// \u1e9e below is U+1E9E CAPITAL SHARP S.
+	addAll(t, ac, "stra\u00dfe", "strasse", "i", "\u0131")
+
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		// The documented "ß" vs "SS" limitation, from both directions: simple
+		// mapping never expands one rune into two, so neither spelling reaches the
+		// other. Full case folding would match "straße" here.
+		{"SS does not fold to sharp s", "STRASSE", []string{"strasse"}},
+		{"sharp s does not fold to SS", "STRA\u00dfE", []string{"stra\u00dfe"}},
+		// Control for the two rows above: capital sharp s does fold, so their
+		// misses are about the SS expansion, not about ß going unhandled.
+		{"capital sharp s folds to sharp s", "STRA\u1e9eE", []string{"stra\u00dfe"}},
+		// Turkish dotted/dotless i under the default mapping. tr rules would fold
+		// U+0130 to "i̇" and ASCII "I" to dotless "ı"; Go sends both to plain "i",
+		// leaving "ı" reachable only from itself.
+		{"dotted capital I folds to ASCII i", "\u0130", []string{"i"}},
+		{"ASCII I folds to ASCII i, not dotless", "I", []string{"i"}},
+		{"dotless i stays dotless", "\u0131", []string{"\u0131"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inMemory, err := ac.FindMatches(tt.text, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := matchKeywords(inMemory); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FindMatches(%+q) = %q, want %q", tt.text, got, tt.want)
+			}
+
+			streamed := []Match{}
+			if err := ac.FindStream(strings.NewReader(tt.text), func(m Match) bool {
+				streamed = append(streamed, m)
+				return true
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(streamed, inMemory) {
+				t.Errorf("FindStream(%+q) = %v, want in-memory parity %v", tt.text, streamed, inMemory)
+			}
+		})
+	}
+}
+
+func matchKeywords(ms []Match) []string {
+	out := []string{}
+	for _, m := range ms {
+		out = append(out, m.Keyword)
+	}
+	return out
+}
+
 func TestFindStream_EarlyStop(t *testing.T) {
 	ac, mr := createAhoCorasick(t)
 	defer mr.Close()


### PR DESCRIPTION
# Pull Request

## Description

`FindStreamContext` cannot call `strings.ToLower` on the input — there is no whole
string to lower — so it folds each rune with `unicode.ToLower` as it reads. The
code carried a comment saying that this only agrees with the in-memory path *on
ASCII*, and named `x/text/cases` as the upgrade path if non-ASCII accuracy were
ever needed.

That premise is wrong. For non-ASCII input `strings.ToLower` is
`strings.Map(unicode.ToLower, s)` — already per-rune — so the streaming fold and
the in-memory fold are identical for every rune, not just ASCII. Sweeping the
whole Unicode range (`0..U+10FFFF`) and comparing `strings.ToLower(string(r))`
against `string(unicode.ToLower(r))` finds **zero** divergent runes. There is no
approximation here and no dependency to add.

A real limitation does exist, but it is a different one: ACOR uses Go's simple,
locale-independent lowercasing rather than full Unicode case folding, so `"ß"`
does not match `"SS"`. That applies to `normalizeText` and the stream **equally**
— it is not a shortcut taken by the streaming path — and it is something callers
want to know before choosing a mode. So it moves from a stream-internal comment
to the `CaseSensitive` godoc.

Changes:

- `pkg/acor/matches.go` — replace the incorrect ASCII-only caveat with the actual
  invariant, and drop the now-pointless `x/text/cases` upgrade note.
- `pkg/acor/acor.go` — document the genuine, shared limitation on `CaseSensitive`.
- `pkg/acor/matches_test.go` — `TestFindStream_CaseFoldParity` asserts streaming
  and `FindMatches` return identical matches for mixed-case non-ASCII text.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

No behavior change: `matches.go` is comment-only, `acor.go` is godoc-only.

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [ ] Changelog fragment added (`changie new`) — deliberately skipped; no shipped
      behavior changes, and this follows #175, a godoc-only correction that also
      shipped without a fragment
- [x] Commit messages follow guidelines

## Additional Notes

The new test is mutation-checked rather than merely green: constraining the fold
to `if ru < 128` (i.e. making the old comment's claim true) fails it with an empty
result set, and the real code passes. The fixture uses `K` KELVIN SIGN and
`İ` LATIN CAPITAL LETTER I WITH DOT ABOVE, both of which fold to a *shorter*
byte sequence — exactly where an ASCII-only fold diverges. They are written as
escapes because they are visually indistinguishable from `K` and `I` in an editor.

Found by auditing the repo's deliberate-shortcut markers; this was the only one,
and it turned out to mark a shortcut that was never taken.
