### PR TITLE
ci: publish the Homebrew formula to skyoo2003/homebrew-tap

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,16 @@ jobs:
           echo "::error::Run 'changie batch ${{ github.ref_name }}' and 'changie merge' before pushing the tag."
           exit 1
         fi
+    # Short-lived token scoped to skyoo2003/homebrew-tap only, for the brews
+    # section. Expires with the job, so nothing long-lived is stored anywhere.
+    - name: Mint a Homebrew tap token
+      id: tap_token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # create-github-app-token v3.2.0
+      with:
+        app-id: ${{ secrets.TAP_APP_ID }}
+        private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+        owner: skyoo2003
+        repositories: homebrew-tap
     - name: Execute GoReleaser
       uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # goreleaser-action v7
       with:
@@ -45,3 +55,4 @@ jobs:
         args: release --clean --release-notes changes/${{ github.ref_name }}.md
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HOMEBREW_TAP_TOKEN: ${{ steps.tap_token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,15 +37,16 @@ jobs:
           echo "::error::Run 'changie batch ${{ github.ref_name }}' and 'changie merge' before pushing the tag."
           exit 1
         fi
-    # Short-lived token scoped to skyoo2003/homebrew-tap only, for the brews
-    # section. Expires with the job, so nothing long-lived is stored anywhere.
+    # Short-lived token scoped to the homebrew-tap repository only, for the
+    # brews section in .goreleaser.yaml, which owns the tap coordinates. The
+    # owner defaults to this repository's owner. Expires with the job, so
+    # nothing long-lived is stored anywhere.
     - name: Mint a Homebrew tap token
       id: tap_token
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # create-github-app-token v3.2.0
       with:
         app-id: ${{ secrets.TAP_APP_ID }}
         private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
-        owner: skyoo2003
         repositories: homebrew-tap
     - name: Execute GoReleaser
       uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # goreleaser-action v7

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,10 +35,10 @@ builds:
 
 archives:
 - id: acor
-  format: tar.gz
+  formats: [ tar.gz ]
   format_overrides:
   - goos: windows
-    format: zip
+    formats: [ zip ]
   files:
     - LICENSE
     - README.md
@@ -51,6 +51,26 @@ changelog:
 checksum:
   algorithm: sha256
   name_template: 'CHECKSUMS'
+
+# Publishes Formula/acor.rb to skyoo2003/homebrew-tap. The token comes from a
+# GitHub App installed only on that repository: the job's own GITHUB_TOKEN
+# cannot write to another repo.
+brews:
+- ids:
+  - acor
+  repository:
+    owner: skyoo2003
+    name: homebrew-tap
+    token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+  homepage: "https://github.com/skyoo2003/acor"
+  description: "Aho-Corasick automaton working On Redis/Valkey"
+  license: "Apache-2.0"
+  install: |
+    bin.install "acor"
+  # acor has no version command, and every real command needs a Redis/Valkey
+  # server, so the usage text on exit code 2 is all that can be asserted here.
+  test: |
+    assert_match "Usage:", shell_output("#{bin}/acor 2>&1", 2)
 
 dockers_v2:
 - images:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,7 +63,7 @@ brews:
     name: homebrew-tap
     token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
   homepage: "https://github.com/skyoo2003/acor"
-  description: "Aho-Corasick automaton working On Redis/Valkey"
+  description: "Aho-Corasick multi-pattern string matching on Redis or Valkey"
   license: "Apache-2.0"
   install: |
     bin.install "acor"

--- a/changes/unreleased/Added-20260731-001220.yaml
+++ b/changes/unreleased/Added-20260731-001220.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: Homebrew installation via `brew install skyoo2003/tap/acor`, published to the tap on each release
+time: 2026-07-31T00:12:20.82073+09:00
+custom:
+    Issue: "181"


### PR DESCRIPTION
## Why

`brew install skyoo2003/tap/acor` does not work today — the tap only carries `kvs`. The release already builds every archive a formula needs, so this only adds the publishing step.

## What

- `.goreleaser.yaml`: `brews` section writing `Formula/acor.rb` to `skyoo2003/homebrew-tap`.
- `release.yaml`: mint the cross-repo token with `actions/create-github-app-token`, scoped to `homebrew-tap` only and expiring with the job — no long-lived PAT (see skyoo2003/kvs#228).
- `archives`: `format:` → `formats:`, deprecated since GoReleaser v2.6.

Requires repository secrets `TAP_APP_ID` and `TAP_APP_PRIVATE_KEY`.

## Verified locally

- `goreleaser release --snapshot --skip=docker` generates `dist/homebrew/acor.rb` with the correct darwin/linux amd64+arm64 matrix (linux 386/armv7 are dropped, as Homebrew supports neither), and succeeds **without** `HOMEBREW_TAP_TOKEN` — snapshots never publish, so no CI path needs the secret.
- `ruby -c` on the generated formula: syntax OK.
- The `test do` assertion matches reality: `acor` with no arguments prints `Usage:` and exits 2.

## Note

`brews` is deprecated (removal in GoReleaser v3); `homebrew_casks` is not a drop-in replacement because casks are macOS-only. At v3 this moves to a generator in the tap repository.