### PR TITLE
perf: memoize the uncached V2 read path instead of rebuilding per call

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,13 +145,14 @@ Round trips are exact and enforced by tests. Timings are from Apple M4 with Redi
 | Find() round trips | 1 | 1 |
 | Add() round trips | grows with keyword length (53 at 5 chars, 507 at 26) | 2 |
 | Add() time | baseline | **~12x faster** |
-| Find() time, no cache | baseline | ~9x **slower** |
+| Find() time, no cache | baseline | ~1.7x **slower** |
 | Find() time, `EnableCache` | n/a | ~15x faster |
-| Find() time, `PresetBalanced` | n/a | ~60x faster |
+| Find() time, `PresetBalanced` | n/a | ~58x faster |
 
-Uncached V2 `Find()` rebuilds its match engine on every call, so it is slower
-than V1 on reads. The large read speedups come from `EnableCache` or a `Preset`,
-not from the schema alone. For read-heavy workloads, enable one of them.
+Uncached V2 `Find()` reads an outputs hash with one entry per trie state, where
+V1 reads only the keyword set, so it stays slightly slower on reads at one round
+trip each. The large read speedups come from `EnableCache` or a `Preset`, not
+from the schema alone. For read-heavy workloads, enable one of them.
 
 ### Migration
 

--- a/changes/unreleased/Fixed-20260801-000002.yaml
+++ b/changes/unreleased/Fixed-20260801-000002.yaml
@@ -1,0 +1,11 @@
+kind: Fixed
+body: >-
+  Uncached V2 `Find()` no longer re-parses and rebuilds the match engine on every
+  call, and reads only the outputs hash instead of also pipelining the unused trie
+  hash. At 1000 keywords this is 1,163,098 -> 221,253 ns/op and 11,704 -> 2,063
+  allocs/op, taking uncached V2 from ~9x slower than V1 to ~1.7x. Freshness is
+  unchanged, because the read still happens on every call so a peer's write is
+  never missed
+time: 2026-08-01T10:00:02.000000+09:00
+custom:
+    Issue: "183"

--- a/docs/content/reference/benchmarks.md
+++ b/docs/content/reference/benchmarks.md
@@ -60,47 +60,48 @@ several minutes and its timings are not published — see the caveats below.
 
 | Configuration | ns/op | B/op | allocs/op | vs V1 |
 |---|---|---|---|---|
-| V1 | 135,067 | 39,631 | 1,073 | baseline |
-| V2, no cache | 1,163,098 | 1,264,718 | 11,704 | **~9x slower** |
-| V2 + `EnableCache`, warm | 8,281 | 8,472 | 65 | ~15x faster |
-| `PresetBalanced` | 2,076 | 2,160 | 7 | **~60x faster** |
+| V1 | 128,828 | 39,651 | 1,073 | baseline |
+| V2, no cache | 221,253 | 121,255 | 2,063 | ~1.7x slower |
+| V2 + `EnableCache`, warm | 8,561 | 8,010 | 65 | ~15x faster |
+| `PresetBalanced` | 2,224 | 2,160 | 7 | **~58x faster** |
 
 ### Find, 100 keywords
 
 | Configuration | ns/op | B/op | allocs/op | vs V1 |
 |---|---|---|---|---|
-| V1 | 71,497 | 8,258 | 161 | baseline |
-| V2, no cache | 177,541 | 169,224 | 1,302 | ~2.5x slower |
-| V2 + `EnableCache`, warm | 2,942 | 2,995 | 13 | ~24x faster |
-| `PresetBalanced` | 1,927 | 2,160 | 7 | ~37x faster |
+| V1 | 71,928 | 8,238 | 161 | baseline |
+| V2, no cache | 79,853 | 11,256 | 222 | ~1.1x slower |
+| V2 + `EnableCache`, warm | 2,772 | 2,969 | 13 | ~26x faster |
+| `PresetBalanced` | 2,135 | 2,160 | 7 | ~34x faster |
 
 ### Add
 
 | Configuration | ns/op | vs V1 |
 |---|---|---|
-| V1 | 4,979,354 | baseline |
-| V2 | 385,242 | **~12x faster** |
+| V1 | 4,951,188 | baseline |
+| V2 | 391,556 | **~12x faster** |
 
 ### Run-to-run variance
 
-The `ns/op` columns above are one run. A second run on the same idle-ish laptop
-produced 167,907 / 1,567,861 / 11,207 / 2,924 ns/op for the 1000-keyword Find
-cases — every absolute number about 20-25% higher, while the ratios moved by
-under 15% (9.3x slower, 15.0x faster, 57x faster).
+The `ns/op` columns are one run. Repeat runs on the same idle-ish laptop moved
+every absolute number by 20-25% while the ratios held to within about 15%.
 
-This is the reason the ratios are stated approximately and the raw numbers are
-labelled as a sample. If your absolute figures differ from ours, that is
-expected. If your *ratios* differ substantially, that is worth reporting as an
-issue.
+This is why the ratios are stated approximately and the raw numbers are labelled
+as a sample. If your absolute figures differ from ours, that is expected. If your
+*ratios* differ substantially, that is worth reporting as an issue.
 
 ## What these numbers mean
 
-**V2 without caching is slower than V1 on reads.** Uncached V2 `Find()` fetches
-the full trie and outputs hashes and rebuilds the match engine on every call —
-1.26 MB and 11,704 allocations per operation at 1000 keywords. V1 fetches only
-the keyword set and memoizes the engine it builds from it, which amounts to a
-local cache V2 does not get by default. Both cost one round trip; the difference
-is payload and rebuild work, which round-trip counting cannot see.
+**V2 without caching is still somewhat slower than V1 on reads**, and the reason
+is payload rather than round trips. Both cost one trip, but V1's `SMEMBERS`
+returns just the keyword set while V2 must read an outputs hash carrying one
+entry per trie state. That gap widens with the dictionary: roughly parity at 100
+keywords, ~1.7x at 1000.
+
+Both schemas memoize the automaton, so an unchanged collection is not re-parsed
+or rebuilt between reads. Uncached V2 was ~9x slower than V1 before that
+memoization landed; the remainder is inherent to reading the whole outputs hash,
+and `EnableCache` is the fix for it.
 
 **The large read speedups come from caching, not from the schema.** 16x to 65x
 belongs to `EnableCache` and the `Preset` engines. Attributing it to V2 alone

--- a/pkg/acor/engine_memo.go
+++ b/pkg/acor/engine_memo.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import (
+	"hash/maphash"
+	"sync"
+
+	matchengine "github.com/skyoo2003/acor/internal/engine"
+)
+
+// engineMemo holds the automaton last built for a collection, so repeated
+// searches over unchanged data skip the O(keywords) rebuild. Both schemas use
+// it: V1 keys on the keyword set from SMEMBERS, V2 on the outputs map from its
+// trie fetch.
+//
+// It does not remove the read that checks Redis for changes — freshness still
+// costs a round trip. It removes only the rebuild that a read repeats when
+// nothing changed.
+type engineMemo struct {
+	mu     sync.Mutex
+	engine *matchengine.Engine
+	digest uint64
+}
+
+// engineDigestSeed keys the digests, which are only ever compared against
+// digests taken in the same process.
+var engineDigestSeed = maphash.MakeSeed()
+
+// engineFor returns the memoized automaton when digest is unchanged, and
+// otherwise builds a fresh one and memoizes it.
+//
+// Callers compute the digest from the rawest form of the data they have, so a
+// hit skips not just the automaton build but any parsing behind it. build runs
+// under the lock, so a burst of concurrent misses rebuilds once.
+func (m *engineMemo) engineFor(digest uint64, build func() (*matchengine.Engine, error)) (*matchengine.Engine, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.engine != nil && m.digest == digest {
+		return m.engine, nil
+	}
+	engine, err := build()
+	if err != nil {
+		return nil, err
+	}
+	m.engine = engine
+	m.digest = digest
+	return m.engine, nil
+}
+
+// digestKeywords fingerprints a keyword set. Summing per-member hashes makes it
+// independent of the order SMEMBERS happened to return the members in.
+func digestKeywords(kws []string) uint64 {
+	var digest uint64
+	for _, k := range kws {
+		digest += maphash.String(engineDigestSeed, k)
+	}
+	return digest
+}
+
+// digestRawOutputs fingerprints the V2 outputs hash exactly as Redis returned
+// it, before any JSON is parsed. Digesting the raw payload is what lets a hit
+// skip the per-state unmarshal, which costs more than the automaton build it
+// feeds. Map iteration order is random, so entries are summed rather than
+// combined in sequence.
+//
+// Over-sensitivity here would cost at most one extra rebuild; under-sensitivity
+// would serve a stale automaton, which is not a trade worth making.
+func digestRawOutputs(raw map[string]string) uint64 {
+	var digest uint64
+	for state, jsonArr := range raw {
+		digest += maphash.String(engineDigestSeed, state)
+		digest += maphash.String(engineDigestSeed, jsonArr)
+	}
+	return digest
+}

--- a/pkg/acor/engine_memo_test.go
+++ b/pkg/acor/engine_memo_test.go
@@ -3,8 +3,11 @@
 package acor //nolint:errcheck // memoization tests focus on engine identity
 
 import (
+	"errors"
 	"fmt"
 	"testing"
+
+	matchengine "github.com/skyoo2003/acor/internal/engine"
 )
 
 // The memo skips rebuilding the automaton when the fetched data is unchanged.
@@ -163,6 +166,96 @@ func TestDigestRawOutputsDetectsChanges(t *testing.T) {
 				t.Fatalf("digestRawOutputs(%v) == digestRawOutputs(base) is %v, want %v", tc.raw, got == want, tc.same)
 			}
 		})
+	}
+}
+
+// TestEngineMemoPropagatesBuildError pins the failure behavior of engineFor.
+//
+// The build callback can fail for real: the V2 uncached path parses JSON inside
+// it. Two things must hold, and neither is visible through the public API —
+// the error has to reach the caller rather than being swallowed into a nil
+// engine, and a failed build must not be memoized, or one corrupt read would
+// poison every later read of the same data.
+func TestEngineMemoPropagatesBuildError(t *testing.T) {
+	buildErr := errors.New("synthetic build failure")
+	engineFor := func(m *engineMemo, digest uint64, e *matchengine.Engine, err error) (*matchengine.Engine, error) {
+		return m.engineFor(digest, func() (*matchengine.Engine, error) { return e, err })
+	}
+
+	t.Run("error reaches the caller", func(t *testing.T) {
+		var m engineMemo
+		engine, err := engineFor(&m, 1, nil, buildErr)
+		if !errors.Is(err, buildErr) {
+			t.Fatalf("engineFor() error = %v, want %v", err, buildErr)
+		}
+		if engine != nil {
+			t.Fatalf("engineFor() = %v, want nil engine alongside the error", engine)
+		}
+	})
+
+	t.Run("failure is not memoized", func(t *testing.T) {
+		var m engineMemo
+		if _, err := engineFor(&m, 1, nil, buildErr); err == nil {
+			t.Fatal("expected the first build to fail")
+		}
+
+		want := buildEngine(PresetBalanced, map[string]struct{}{"hello": {}})
+		got, err := engineFor(&m, 1, want, nil)
+		if err != nil {
+			t.Fatalf("engineFor() after a failed build = %v, want the retry to succeed", err)
+		}
+		if got != want {
+			t.Fatal("engineFor() did not memoize the successful retry for a digest that previously failed")
+		}
+	})
+
+	t.Run("a failed build leaves the previous engine intact", func(t *testing.T) {
+		var m engineMemo
+		first := buildEngine(PresetBalanced, map[string]struct{}{"hello": {}})
+		if _, err := engineFor(&m, 1, first, nil); err != nil {
+			t.Fatalf("engineFor() error: %v", err)
+		}
+
+		// A different digest fails to build.
+		if _, err := engineFor(&m, 2, nil, buildErr); !errors.Is(err, buildErr) {
+			t.Fatalf("engineFor() error = %v, want %v", err, buildErr)
+		}
+
+		// The original digest must still be served from the memo, without
+		// rebuilding — the callback below would fail the test if it ran.
+		got, err := m.engineFor(1, func() (*matchengine.Engine, error) {
+			t.Error("engineFor rebuilt digest 1; the failed build for digest 2 evicted a good engine")
+			return nil, nil
+		})
+		if err != nil {
+			t.Fatalf("engineFor() error: %v", err)
+		}
+		if got != first {
+			t.Fatal("engineFor() no longer returns the engine memoized before the failed build")
+		}
+	})
+}
+
+// TestV2UncachedFindSurfacesParseError is the production shape of the same
+// concern: unparseable data in Redis must surface as an error from Find, not as
+// an empty match list that a caller would read as "no keywords present".
+func TestV2UncachedFindSurfacesParseError(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	if _, err := ac.Add("hello"); err != nil {
+		t.Fatalf("Add() error: %v", err)
+	}
+	if _, err := ac.Find("hello world"); err != nil {
+		t.Fatalf("Find() before corruption error: %v", err)
+	}
+
+	// Corrupt one state's output list behind ACOR's back.
+	mr.HSet(outputsKey("test"), "1", "{not-json")
+
+	if _, err := ac.Find("hello world"); err == nil {
+		t.Fatal("Find() returned no error over unparseable outputs; a corrupt read must not look like an empty dictionary")
 	}
 }
 

--- a/pkg/acor/engine_memo_test.go
+++ b/pkg/acor/engine_memo_test.go
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor //nolint:errcheck // memoization tests focus on engine identity
+
+import (
+	"fmt"
+	"testing"
+)
+
+// The memo skips rebuilding the automaton when the fetched data is unchanged.
+// It must never skip noticing that the data *did* change: without EnableCache
+// there is no invalidation listener, so correctness rests entirely on the fetch
+// still happening every read and the digest actually tracking the payload.
+
+func v2Ops(t *testing.T, ac *AhoCorasick) *v2Operations {
+	t.Helper()
+	o, ok := ac.ops.(*v2Operations)
+	if !ok {
+		t.Fatalf("expected *v2Operations, got %T", ac.ops)
+	}
+	return o
+}
+
+// TestV2UncachedEngineIsMemoized pins the fix: repeated reads over unchanged
+// data reuse one automaton instead of rebuilding it per call.
+func TestV2UncachedEngineIsMemoized(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	for _, kw := range []string{"he", "her", "him"} {
+		if _, err := ac.Add(kw); err != nil {
+			t.Fatalf("Add(%q) error: %v", kw, err)
+		}
+	}
+
+	o := v2Ops(t, ac)
+	if o.cache != nil {
+		t.Fatal("expected the uncached path; this test is meaningless with EnableCache")
+	}
+
+	first, err := o.loadEngine(ac.ctx)
+	if err != nil {
+		t.Fatalf("loadEngine() error: %v", err)
+	}
+	second, err := o.loadEngine(ac.ctx)
+	if err != nil {
+		t.Fatalf("loadEngine() error: %v", err)
+	}
+
+	if first != second {
+		t.Fatal("uncached V2 rebuilt the engine for unchanged data; the memo is not working")
+	}
+}
+
+// TestV2UncachedEngineRebuildsOnChange is the half that matters for
+// correctness. A memo that never invalidates would pass the test above and
+// serve stale results forever.
+func TestV2UncachedEngineRebuildsOnChange(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	if _, err := ac.Add("he"); err != nil {
+		t.Fatalf("Add() error: %v", err)
+	}
+
+	o := v2Ops(t, ac)
+	before, err := o.loadEngine(ac.ctx)
+	if err != nil {
+		t.Fatalf("loadEngine() error: %v", err)
+	}
+
+	if _, addErr := ac.Add("him"); addErr != nil {
+		t.Fatalf("Add() error: %v", addErr)
+	}
+
+	after, err := o.loadEngine(ac.ctx)
+	if err != nil {
+		t.Fatalf("loadEngine() error: %v", err)
+	}
+
+	if before == after {
+		t.Fatal("uncached V2 reused a stale engine after the collection changed")
+	}
+
+	matched, err := ac.Find("he is him")
+	if err != nil {
+		t.Fatalf("Find() error: %v", err)
+	}
+	if len(matched) != 2 {
+		t.Fatalf("Find() = %v, want both 'he' and 'him'; memoization dropped a keyword", matched)
+	}
+}
+
+// TestV2UncachedSeesExternalWrites guards the case the memo could plausibly
+// break: another instance writes to the same collection, and this instance must
+// still notice on its next read. There is no Pub/Sub listener on the uncached
+// path, so this works only because the fetch is not memoized alongside the
+// rebuild.
+func TestV2UncachedSeesExternalWrites(t *testing.T) {
+	mr := createTestRedisServer(t)
+	defer mr.Close()
+
+	reader, err := Create(&AhoCorasickArgs{Addr: mr.Addr(), Name: "shared"})
+	if err != nil {
+		t.Fatalf("Create(reader) error: %v", err)
+	}
+	defer reader.Close()
+
+	writer, err := Create(&AhoCorasickArgs{Addr: mr.Addr(), Name: "shared"})
+	if err != nil {
+		t.Fatalf("Create(writer) error: %v", err)
+	}
+	defer writer.Close()
+
+	if _, addErr := writer.Add("alpha"); addErr != nil {
+		t.Fatalf("writer.Add() error: %v", addErr)
+	}
+	if matched, findErr := reader.Find("alpha beta"); findErr != nil {
+		t.Fatalf("reader.Find() error: %v", findErr)
+	} else if len(matched) != 1 {
+		t.Fatalf("reader.Find() = %v, want [alpha]", matched)
+	}
+
+	// Second instance writes; the reader's memo must not mask it.
+	if _, addErr := writer.Add("beta"); addErr != nil {
+		t.Fatalf("writer.Add() error: %v", addErr)
+	}
+	matched, err := reader.Find("alpha beta")
+	if err != nil {
+		t.Fatalf("reader.Find() error: %v", err)
+	}
+	if len(matched) != 2 {
+		t.Fatalf("reader.Find() = %v, want both keywords; the memo masked a peer's write", matched)
+	}
+}
+
+// TestDigestRawOutputsDetectsChanges checks the digest directly, since every
+// staleness guarantee above reduces to it. Inputs are raw Redis hash values —
+// per-state JSON arrays, unparsed.
+func TestDigestRawOutputsDetectsChanges(t *testing.T) {
+	base := map[string]string{"1": `["he"]`, "2": `["him"]`}
+
+	cases := []struct {
+		name string
+		raw  map[string]string
+		same bool
+	}{
+		{"identical", map[string]string{"1": `["he"]`, "2": `["him"]`}, true},
+		{"reordered states", map[string]string{"2": `["him"]`, "1": `["he"]`}, true},
+		{"added state", map[string]string{"1": `["he"]`, "2": `["him"]`, "3": `["her"]`}, false},
+		{"removed state", map[string]string{"1": `["he"]`}, false},
+		{"changed keyword", map[string]string{"1": `["he"]`, "2": `["her"]`}, false},
+		{"keyword appended to a state", map[string]string{"1": `["he"]`, "2": `["him","her"]`}, false},
+	}
+
+	want := digestRawOutputs(base)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := digestRawOutputs(tc.raw)
+			if (got == want) != tc.same {
+				t.Fatalf("digestRawOutputs(%v) == digestRawOutputs(base) is %v, want %v", tc.raw, got == want, tc.same)
+			}
+		})
+	}
+}
+
+// TestDigestKeywordsIsOrderIndependent pins the property V1 relies on: SMEMBERS
+// makes no ordering promise.
+func TestDigestKeywordsIsOrderIndependent(t *testing.T) {
+	if digestKeywords([]string{"he", "her", "him"}) != digestKeywords([]string{"him", "he", "her"}) {
+		t.Fatal("digestKeywords depends on order; SMEMBERS does not guarantee one")
+	}
+	if digestKeywords([]string{"he", "her"}) == digestKeywords([]string{"he", "her", "him"}) {
+		t.Fatal("digestKeywords did not change when a keyword was added")
+	}
+}
+
+// TestV1EngineStillMemoized guards the refactor: V1 shared its memo with V2 and
+// must keep the behavior it already had.
+func TestV1EngineStillMemoized(t *testing.T) {
+	ac, mr := createAhoCorasickV1(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	if _, err := ac.Add("he"); err != nil {
+		t.Fatalf("Add() error: %v", err)
+	}
+
+	o, ok := ac.ops.(*v1Operations)
+	if !ok {
+		t.Fatalf("expected *v1Operations, got %T", ac.ops)
+	}
+
+	first, err := o.loadEngine(ac.ctx)
+	if err != nil {
+		t.Fatalf("loadEngine() error: %v", err)
+	}
+	second, err := o.loadEngine(ac.ctx)
+	if err != nil {
+		t.Fatalf("loadEngine() error: %v", err)
+	}
+	if first != second {
+		t.Fatal("V1 rebuilt the engine for an unchanged keyword set")
+	}
+
+	if _, addErr := ac.Add("him"); addErr != nil {
+		t.Fatalf("Add() error: %v", addErr)
+	}
+	third, err := o.loadEngine(ac.ctx)
+	if err != nil {
+		t.Fatalf("loadEngine() error: %v", err)
+	}
+	if third == second {
+		t.Fatal("V1 reused a stale engine after the keyword set changed")
+	}
+}
+
+// TestV2UncachedConcurrentReads exercises the shared memo under -race, since
+// callers now receive the same engine pointer rather than a private one.
+func TestV2UncachedConcurrentReads(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	for i := range 50 {
+		if _, err := ac.Add(fmt.Sprintf("keyword%d", i)); err != nil {
+			t.Fatalf("Add() error: %v", err)
+		}
+	}
+
+	done := make(chan error, 8)
+	for range 8 {
+		go func() {
+			for range 20 {
+				if _, err := ac.Find("keyword7 and keyword42"); err != nil {
+					done <- err
+					return
+				}
+			}
+			done <- nil
+		}()
+	}
+	for range 8 {
+		if err := <-done; err != nil {
+			t.Fatalf("concurrent Find() error: %v", err)
+		}
+	}
+}

--- a/pkg/acor/v1_ops.go
+++ b/pkg/acor/v1_ops.go
@@ -6,9 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"hash/maphash"
 	"strings"
-	"sync"
 	"time"
 
 	redis "github.com/redis/go-redis/v9"
@@ -31,43 +29,21 @@ type v1Operations struct {
 	ac              *AhoCorasick // for trie.go helper access (temporary, cleaned up in T15)
 	caseSensitive   bool
 	rollbackTimeout time.Duration
-	engines         v1EngineMemo
+	engines         engineMemo
 }
 
-// v1EngineMemo holds the automaton last built for a keyword set, so repeated
-// searches over an unchanged V1 collection skip the O(keywords) rebuild.
-type v1EngineMemo struct {
-	mu     sync.Mutex
-	engine *matchengine.Engine
-	digest uint64
-}
-
-// v1DigestSeed keys the keyword-set digest, which is only ever compared against
-// digests taken in the same process.
-var v1DigestSeed = maphash.MakeSeed()
-
-// engineFor returns the automaton for kws, rebuilding only when the set changed.
-// The digest sums per-member hashes, so it does not depend on the order SMEMBERS
-// happened to return the members in.
-func (m *v1EngineMemo) engineFor(kws []string) *matchengine.Engine {
-	var digest uint64
-	for _, k := range kws {
-		digest += maphash.String(v1DigestSeed, k)
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.engine != nil && m.digest == digest {
-		return m.engine
-	}
-
-	set := make(map[string]struct{}, len(kws))
-	for _, k := range kws {
-		set[k] = struct{}{}
-	}
-	m.engine = buildEngine(PresetBalanced, set)
-	m.digest = digest
-	return m.engine
+// engineForKeywords returns the automaton for kws, rebuilding only when the set
+// changed. See engineMemo in engine_memo.go, shared with V2.
+func (m *engineMemo) engineForKeywords(kws []string) *matchengine.Engine {
+	// Building from a keyword set cannot fail, so the error is always nil.
+	engine, _ := m.engineFor(digestKeywords(kws), func() (*matchengine.Engine, error) {
+		set := make(map[string]struct{}, len(kws))
+		for _, k := range kws {
+			set[k] = struct{}{}
+		}
+		return buildEngine(PresetBalanced, set), nil
+	})
+	return engine
 }
 
 // --- operations interface methods ---
@@ -209,13 +185,13 @@ func (o *v1Operations) findIndex(ctx context.Context, text string) (map[string][
 //
 // The set itself is re-read every call — V1 has no invalidation listener
 // (EnableCache with V1 is ErrCacheRequiresV2), so a peer's write would otherwise
-// go unnoticed. Only the rebuild is memoized (see v1EngineMemo).
+// go unnoticed. Only the rebuild is memoized (see engineMemo).
 func (o *v1Operations) loadEngine(ctx context.Context) (*matchengine.Engine, error) {
 	kws, err := o.storage.SMembers(ctx, keywordKey(o.name))
 	if err != nil {
 		return nil, newRedisError("SMEMBERS", keywordKey(o.name), err)
 	}
-	return o.engines.engineFor(kws), nil
+	return o.engines.engineForKeywords(kws), nil
 }
 
 func (o *v1Operations) flush(_ context.Context) error {

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -30,6 +30,7 @@ type v2Operations struct {
 	cache         *trieCache
 	logger        Logger
 	caseSensitive bool
+	engines       engineMemo
 }
 
 // --- operations interface methods ---
@@ -188,17 +189,39 @@ func (o *v2Operations) fetchTrieData(ctx context.Context) (prefixes []string, ou
 		}
 	}
 
-	outputsRaw := outputsResult.Val()
-	outputs = make(map[string][]string)
-	for state, jsonArr := range outputsRaw {
+	parsed, parseErr := parseOutputs(outputsResult.Val())
+	if parseErr != nil {
+		return nil, nil, parseErr
+	}
+	outputs = parsed
+
+	return prefixes, outputs, nil
+}
+
+// parseOutputs unmarshals the per-state JSON arrays of the V2 outputs hash.
+func parseOutputs(raw map[string]string) (map[string][]string, error) {
+	outputs := make(map[string][]string, len(raw))
+	for state, jsonArr := range raw {
 		var arr []string
-		if unmarshalErr := json.Unmarshal([]byte(jsonArr), &arr); unmarshalErr != nil {
-			return nil, nil, newOperationError("unmarshal", SchemaV2, unmarshalErr)
+		if err := json.Unmarshal([]byte(jsonArr), &arr); err != nil {
+			return nil, newOperationError("unmarshal", SchemaV2, err)
 		}
 		outputs[state] = arr
 	}
+	return outputs, nil
+}
 
-	return prefixes, outputs, nil
+// fetchRawOutputs reads just the outputs hash, unparsed.
+//
+// The engine is built from the union of the outputs values alone, so the trie
+// hash that fetchTrieData also pipelines is dead weight on the read path. This
+// stays one round trip while transferring and parsing less.
+func (o *v2Operations) fetchRawOutputs(ctx context.Context) (map[string]string, error) {
+	raw, err := o.storage.HGetAll(ctx, outputsKey(o.name))
+	if err != nil {
+		return nil, newRedisError("HGETALL", outputsKey(o.name), err)
+	}
+	return raw, nil
 }
 
 // loadCache fetches trie data and populates the cache.
@@ -215,17 +238,31 @@ func (o *v2Operations) loadCache(ctx context.Context) error {
 // from storage on a cache miss. The engine is built once per cache load (see
 // trieCache.set) and reused across Find calls with no Redis I/O.
 //
-// When caching is disabled (cache == nil) it fetches the trie from Redis and
-// builds a throwaway engine per call. Redis I/O dominates that path, so the
-// extra automaton build is negligible; enabling the cache is the way to avoid
-// both, not per-call engine caching.
+// When caching is disabled (cache == nil) it still reads Redis on every call,
+// because nothing else would notice a peer's write, but memoizes the parse and
+// build behind that read. The assumption that Redis I/O dominated so heavily
+// that the rebuild did not matter turned out to be wrong: rebuilding per call
+// made uncached Find slower than V1, which had memoized its engine all along.
+// EnableCache is still the way to avoid the read itself.
 func (o *v2Operations) loadEngine(ctx context.Context) (*matchengine.Engine, error) {
 	if o.cache == nil {
-		_, outputs, err := o.fetchTrieData(ctx)
+		// Without EnableCache there is no invalidation listener, so the read
+		// still happens on every call to stay fresh — a peer's write must not
+		// go unnoticed. Everything after the read is memoized on the raw
+		// payload: repeating the unmarshal and automaton build over identical
+		// bytes is what made uncached V2 Find slower than V1, which memoizes
+		// its own engine the same way.
+		raw, err := o.fetchRawOutputs(ctx)
 		if err != nil {
 			return nil, err
 		}
-		return buildEngineFromOutputs(outputs), nil
+		return o.engines.engineFor(digestRawOutputs(raw), func() (*matchengine.Engine, error) {
+			outputs, parseErr := parseOutputs(raw)
+			if parseErr != nil {
+				return nil, parseErr
+			}
+			return buildEngineFromOutputs(outputs), nil
+		})
 	}
 
 	if engine, valid := o.cache.getEngine(); valid {


### PR DESCRIPTION
## Description

Publishing measured benchmarks in #182 showed uncached V2 `Find()` was **~9x slower than V1** at 1000 keywords — the opposite of what the README had claimed. V1 had memoized its automaton since the engine rewrite; V2 re-fetched the trie, re-parsed every output array, and rebuilt the automaton on **every read**.

The root cause turned out to be three things, not one. Fixing only the rebuild got to 574,795 ns/op — still 4.5x slower than V1.

The uncached read now:

1. **reads only the outputs hash.** The engine is built from the union of its values, so the trie hash that `fetchTrieData` also pipelined was dead weight — both callers already discarded `prefixes`. Still one round trip.
2. **digests the raw Redis response before any JSON is parsed**, so a hit skips the per-state unmarshal as well as the build.

### Results (Apple M4, Redis 8 on loopback, 1000 keywords)

| | ns/op | allocs/op | vs V1 |
|---|---|---|---|
| before | 1,163,098 | 11,704 | 9x slower |
| rebuild memo only | 574,795 | 9,099 | 4.5x slower |
| **this PR** | **221,253** | **2,063** | **1.7x slower** |

At 100 keywords it is now roughly at parity with V1 (79,853 vs 71,928).

### Where this stops

The remaining gap is payload — V2 reads one entry per trie state where V1 reads the keyword set — and that is inherent to the V2 layout. `EnableCache` is the answer to it, not more memoization. Changing the schema would be well outside this fix.

### Correctness

**The read itself is deliberately not memoized.** Without `EnableCache` there is no invalidation listener, so a peer's write would go unnoticed. Tests cover an external writer on a shared collection, a changed collection, the digest directly, and concurrent reads under `-race`.

V1 and V2 now share one `engineMemo` instead of carrying near-identical copies.

Published benchmark tables in #182 are updated here to the post-fix numbers — leaving them stale would falsify the evidence pack that PR just added.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [ ] Changelog fragment added — added in a follow-up commit once this PR number exists
- [x] Commit messages follow guidelines

## Additional Notes

Round-trip counts are unchanged (`Find()` stays at 1), so the RTT assertions from #182 still pass against both redis and valkey.