### PR TITLE
docs: condense the unreleased changelog fragments

### DIFF
--- a/changes/unreleased/Documentation-20260801-000001.yaml
+++ b/changes/unreleased/Documentation-20260801-000001.yaml
@@ -1,5 +1,9 @@
 kind: Documentation
-body: Corrected the published performance claims to measured values and added a reproducible benchmarks reference page. V2 `Find()` costs 1 round trip (documented as 3), V1 `Find()` also costs 1 (documented as growing with the dictionary), and the "50-60x faster Find()" claim belonged to `EnableCache`/`Preset` rather than the V2 schema. Round-trip counts are now enforced by tests on every CI run
+body: >-
+  Replaced the published performance claims with measured values and a
+  reproducible benchmarks page. Both V1 and V2 `Find()` cost 1 round trip, and
+  the "50-60x faster Find()" belongs to `EnableCache`/`Preset`, not the V2
+  schema. Round-trip counts are now enforced by tests on every CI run
 time: 2026-08-01T10:00:00.000000+09:00
 custom:
     Issue: "182"

--- a/changes/unreleased/Fixed-20260801-000002.yaml
+++ b/changes/unreleased/Fixed-20260801-000002.yaml
@@ -1,11 +1,9 @@
 kind: Fixed
 body: >-
-  Uncached V2 `Find()` no longer re-parses and rebuilds the match engine on every
-  call, and reads only the outputs hash instead of also pipelining the unused trie
-  hash. At 1000 keywords this is 1,163,098 -> 221,253 ns/op and 11,704 -> 2,063
-  allocs/op, taking uncached V2 from ~9x slower than V1 to ~1.7x. Freshness is
-  unchanged, because the read still happens on every call so a peer's write is
-  never missed
+  Uncached V2 `Find()` no longer rebuilds the match engine on every call and
+  reads only the outputs hash. At 1000 keywords: 1,163,098 -> 221,253 ns/op and
+  11,704 -> 2,063 allocs/op, taking uncached V2 from ~9x slower than V1 to ~1.7x.
+  Freshness is unchanged - the read still happens on every call
 time: 2026-08-01T10:00:02.000000+09:00
 custom:
     Issue: "183"


### PR DESCRIPTION
# Pull Request

## Description

Condenses the two long unreleased changelog fragments (#182, #183) so the release notes read at a glance. Text only — no fragment is added or removed, and `kind`/`time`/`custom.Issue` are untouched.

- **Fixed (#183)**: 74 → 46 words. Dropped the unused-trie-hash detail and the freshness rationale clause.
- **Documentation (#182)**: 63 → 45 words. Dropped the parenthetical "documented as ..." values.
- **Added (#181)**: unchanged, already one line.

The removed detail still lives in #182 / #183 and in the commit bodies.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [ ] Tests pass (`make test`) — n/a, no Go files changed
- [ ] Vet/`make vet` — n/a, no Go files changed
- [ ] Linting passes (`make lint`) — n/a, no Go files changed
- [ ] Build succeeds (`make build`) — n/a, no Go files changed
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — n/a, this PR *is* the changelog edit
- [x] Commit messages follow guidelines

## Additional Notes

Verified with `changie batch --dry-run patch` — all three fragments still parse and render under the right sections with their issue links.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).
