### PR TITLE
fix: plan batched writes once and commit them in a single transaction

### DIFF
--- a/changes/unreleased/Fixed-20260802-000001.yaml
+++ b/changes/unreleased/Fixed-20260802-000001.yaml
@@ -1,0 +1,15 @@
+kind: Fixed
+body: >-
+  `AddMany` and `RemoveMany` now plan the whole batch in one pass and commit it in
+  a single transaction instead of reading, replanning and rewriting the entire
+  trie once per keyword. That per-keyword loop made a batch quadratic: adding 1000
+  keywords against a real server took 1,049ms, 427MB and 8.5M allocations, and now
+  takes 2.6ms, 1.7MB and 8.8K allocations - about 400x faster with 970x fewer
+  allocations, at two round trips regardless of batch size. `computeOutputs` also
+  slices suffixes out of the state string rather than rebuilding each from runes,
+  which allocated once per suffix on every write. Applies to V2 and preset modes;
+  V1 keeps its per-keyword path. Transactional batches no longer need rollback,
+  since one compare-and-set write is already all-or-nothing
+time: 2026-08-02T10:00:00.000000+09:00
+custom:
+    Issue: "185"

--- a/changes/unreleased/Fixed-20260802-000001.yaml
+++ b/changes/unreleased/Fixed-20260802-000001.yaml
@@ -1,15 +1,10 @@
 kind: Fixed
 body: >-
-  `AddMany` and `RemoveMany` now plan the whole batch in one pass and commit it in
-  a single transaction instead of reading, replanning and rewriting the entire
-  trie once per keyword. That per-keyword loop made a batch quadratic: adding 1000
-  keywords against a real server took 1,049ms, 427MB and 8.5M allocations, and now
-  takes 2.6ms, 1.7MB and 8.8K allocations - about 400x faster with 970x fewer
-  allocations, at two round trips regardless of batch size. `computeOutputs` also
-  slices suffixes out of the state string rather than rebuilding each from runes,
-  which allocated once per suffix on every write. Applies to V2 and preset modes;
-  V1 keeps its per-keyword path. Transactional batches no longer need rollback,
-  since one compare-and-set write is already all-or-nothing
+  `AddMany` and `RemoveMany` now process V2 and preset batches in one pass and
+  commit them with a single atomic transaction, avoiding per-keyword trie rewrites.
+  Adding 1,000 keywords is about 400x faster with 970x fewer allocations, while
+  server round trips remain fixed at two regardless of batch size. `computeOutputs`
+  also reuses string suffixes to reduce allocations. V1 behavior is unchanged
 time: 2026-08-02T10:00:00.000000+09:00
 custom:
     Issue: "185"

--- a/changes/unreleased/Fixed-20260804-000004.yaml
+++ b/changes/unreleased/Fixed-20260804-000004.yaml
@@ -1,11 +1,9 @@
 kind: Fixed
 body: >-
-  `AddMany`/`RemoveMany` on V2 and preset collections double-counted keywords that
-  differ only in case. Duplicate screening compared the caller's raw spelling while
-  the batched write path reports normalized keywords, so `AddMany(["Foo", "foo"])`
-  on a case-insensitive collection reported both as Added even though one keyword
-  was written. Duplicates are now detected on the normalized form, matching V1 and
-  the single-keyword `Add`/`Remove`: one entry in Added, one in Skipped
+  `AddMany` and `RemoveMany` now detect case-insensitive duplicates using normalized
+  keywords in V2 and preset collections. Inputs such as `["Foo", "foo"]` now report
+  one item as Added and the duplicate as Skipped, matching V1 and single-keyword
+  operations
 time: 2026-08-04T10:00:03.000000+09:00
 custom:
     Issue: "185"

--- a/changes/unreleased/Fixed-20260804-000004.yaml
+++ b/changes/unreleased/Fixed-20260804-000004.yaml
@@ -1,0 +1,11 @@
+kind: Fixed
+body: >-
+  `AddMany`/`RemoveMany` on V2 and preset collections double-counted keywords that
+  differ only in case. Duplicate screening compared the caller's raw spelling while
+  the batched write path reports normalized keywords, so `AddMany(["Foo", "foo"])`
+  on a case-insensitive collection reported both as Added even though one keyword
+  was written. Duplicates are now detected on the normalized form, matching V1 and
+  the single-keyword `Add`/`Remove`: one entry in Added, one in Skipped
+time: 2026-08-04T10:00:03.000000+09:00
+custom:
+    Issue: "185"

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -64,8 +64,10 @@ func (ac *AhoCorasick) AddMany(keywords []string, opts *BatchOptions) (*BatchRes
 
 // screenBatch applies the checks that need no Redis access: blank keywords go to
 // result.Failed, repeats within the same call are skipped, and the survivors are
-// returned in input order alongside their normalized forms. Every batch path
-// shares it, so blanks and duplicates behave the same whichever write path runs.
+// returned in input order alongside their normalized forms. The returned slices
+// are index-aligned: candidates[i] is the caller spelling of normalizedKeywords[i].
+// Every batch path shares it, so blanks and duplicates behave the same whichever
+// write path runs.
 //
 // Duplicates are detected on the normalized form, not the caller's spelling: on a
 // case-insensitive collection "Foo" and "foo" are one keyword, so only one of them
@@ -80,7 +82,9 @@ func (ac *AhoCorasick) screenBatch(keywords []string, result *BatchResult) (
 	candidates, normalizedKeywords []string) {
 	seen := make(map[string]bool, len(keywords))
 	candidates = make([]string, 0, len(keywords))
-	if !ac.caseSensitive {
+	if ac.caseSensitive {
+		normalizedKeywords = candidates
+	} else {
 		normalizedKeywords = make([]string, 0, len(keywords))
 	}
 
@@ -100,14 +104,13 @@ func (ac *AhoCorasick) screenBatch(keywords []string, result *BatchResult) (
 		}
 		seen[normalizedKeyword] = true
 		candidates = append(candidates, keyword)
-		if !ac.caseSensitive {
+		if ac.caseSensitive {
+			normalizedKeywords = candidates
+		} else {
 			normalizedKeywords = append(normalizedKeywords, normalizedKeyword)
 		}
 	}
 
-	if ac.caseSensitive {
-		normalizedKeywords = candidates
-	}
 	return candidates, normalizedKeywords
 }
 
@@ -119,7 +122,7 @@ func (ac *AhoCorasick) screenBatch(keywords []string, result *BatchResult) (
 // spelling, so membership is tested against the normalized slice computed during
 // screening. Comparing raw against normalized reported every keyword with an
 // uppercase rune as Skipped on a case-insensitive collection, even though it had
-// just been written.
+// just been written. candidates and normalized must have matching indexes.
 func partitionApplied(candidates, normalized, applied []string) (changed, unchanged []string) {
 	appliedSet := make(map[string]struct{}, len(applied))
 	for _, kw := range applied {

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -62,9 +62,23 @@ func (ac *AhoCorasick) AddMany(keywords []string, opts *BatchOptions) (*BatchRes
 	return ac.AddManyContext(ac.ctx, keywords, opts)
 }
 
-func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
-	seen := make(map[string]bool)
-	add, commit := ac.batchAddFns()
+// screenBatch applies the checks that need no Redis access: blank keywords go to
+// result.Failed, repeats within the same call are skipped, and the survivors are
+// returned in input order. Every batch path shares it, so blanks and duplicates
+// behave the same whichever write path runs.
+//
+// Duplicates are detected on the normalized form, not the caller's spelling: on a
+// case-insensitive collection "Foo" and "foo" are one keyword, so only one of them
+// can be added. Screening on the raw spelling let both through, and partitionApplied
+// then matched both against the single applied keyword and reported two additions
+// for one write.
+//
+// ErrEmptyKeyword is the only error it records, so a transactional caller — which
+// must abort the batch on a blank rather than record it — tests
+// len(result.Failed) > 0 and discards result.
+func (ac *AhoCorasick) screenBatch(keywords []string, result *BatchResult) []string {
+	seen := make(map[string]bool, len(keywords))
+	candidates := make([]string, 0, len(keywords))
 
 	for _, keyword := range keywords {
 		keyword = strings.TrimSpace(keyword)
@@ -75,13 +89,66 @@ func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string,
 			})
 			continue
 		}
-
-		if seen[keyword] {
+		normalized := normalizeKeyword(keyword, ac.caseSensitive)
+		if seen[normalized] {
 			result.Skipped = append(result.Skipped, keyword)
 			continue
 		}
-		seen[keyword] = true
+		seen[normalized] = true
+		candidates = append(candidates, keyword)
+	}
 
+	return candidates
+}
+
+// partitionApplied splits screened candidates by what the write actually
+// changed. applied is what the write path reports as having taken effect;
+// everything else was already in the desired state.
+//
+// The write path reports normalized keywords (lowercased unless the collection is
+// case-sensitive) while candidates keep the caller's spelling, so membership is
+// tested on the normalized form. Comparing raw against normalized reported every
+// keyword with an uppercase rune as Skipped on a case-insensitive collection, even
+// though it had just been written.
+func (ac *AhoCorasick) partitionApplied(candidates, applied []string) (changed, unchanged []string) {
+	appliedSet := make(map[string]struct{}, len(applied))
+	for _, kw := range applied {
+		appliedSet[kw] = struct{}{}
+	}
+	for _, kw := range candidates {
+		if _, ok := appliedSet[normalizeKeyword(kw, ac.caseSensitive)]; ok {
+			changed = append(changed, kw)
+		} else {
+			unchanged = append(unchanged, kw)
+		}
+	}
+	return changed, unchanged
+}
+
+func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
+	candidates := ac.screenBatch(keywords, result)
+
+	if bp, ok := ac.ops.(batchPlanner); ok {
+		if len(candidates) == 0 {
+			return result, nil
+		}
+		added, err := bp.addManyAtomic(ctx, candidates)
+		if err != nil {
+			// One transaction means one outcome: nothing was written, so every
+			// candidate failed. A partial success cannot happen here.
+			for _, keyword := range candidates {
+				result.Failed = append(result.Failed, KeywordError{Keyword: keyword, Error: err})
+			}
+			return result, nil
+		}
+		changed, unchanged := ac.partitionApplied(candidates, added)
+		result.Added = append(result.Added, changed...)
+		result.Skipped = append(result.Skipped, unchanged...)
+		return result, nil
+	}
+
+	add, commit := ac.batchAddFns()
+	for _, keyword := range candidates {
 		count, err := add(ctx, keyword)
 		if err != nil {
 			result.Failed = append(result.Failed, KeywordError{
@@ -106,6 +173,29 @@ func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string,
 }
 
 func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
+	if bp, ok := ac.ops.(batchPlanner); ok {
+		candidates := ac.screenBatch(keywords, result)
+		if len(result.Failed) > 0 {
+			// Transactional means all-or-nothing, so a blank keyword aborts the
+			// batch instead of being recorded alongside successful writes.
+			return nil, ErrEmptyKeyword
+		}
+		if len(candidates) == 0 {
+			result.Added = []string{}
+			return result, nil
+		}
+		// A single CAS write is already all-or-nothing, so there is nothing to
+		// roll back: either the whole batch committed or none of it did.
+		applied, err := bp.addManyAtomic(ctx, candidates)
+		if err != nil {
+			return nil, fmt.Errorf("batch add failed: %w", err)
+		}
+		changed, unchanged := ac.partitionApplied(candidates, applied)
+		result.Added = append(result.Added, changed...)
+		result.Skipped = append(result.Skipped, unchanged...)
+		return result, nil
+	}
+
 	added := make([]string, 0)
 	seen := make(map[string]bool)
 	add, commit := ac.batchAddFns()
@@ -213,25 +303,27 @@ func (ac *AhoCorasick) RemoveManyWithOptions(keywords []string, opts *BatchOptio
 }
 
 func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
-	seen := make(map[string]bool)
+	candidates := ac.screenBatch(keywords, result)
+
+	if bp, ok := ac.ops.(batchPlanner); ok {
+		if len(candidates) == 0 {
+			return result, nil
+		}
+		removed, err := bp.removeManyAtomic(ctx, candidates)
+		if err != nil {
+			for _, keyword := range candidates {
+				result.Failed = append(result.Failed, KeywordError{Keyword: keyword, Error: err})
+			}
+			return result, nil
+		}
+		changed, unchanged := ac.partitionApplied(candidates, removed)
+		result.Removed = append(result.Removed, changed...)
+		result.Skipped = append(result.Skipped, unchanged...)
+		return result, nil
+	}
+
 	remove, commit := ac.batchRemoveFns()
-
-	for _, keyword := range keywords {
-		keyword = strings.TrimSpace(keyword)
-		if keyword == "" {
-			result.Failed = append(result.Failed, KeywordError{
-				Keyword: keyword,
-				Error:   ErrEmptyKeyword,
-			})
-			continue
-		}
-
-		if seen[keyword] {
-			result.Skipped = append(result.Skipped, keyword)
-			continue
-		}
-		seen[keyword] = true
-
+	for _, keyword := range candidates {
 		count, err := remove(ctx, keyword)
 		if err != nil {
 			result.Failed = append(result.Failed, KeywordError{
@@ -259,6 +351,27 @@ func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []stri
 }
 
 func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
+	if bp, ok := ac.ops.(batchPlanner); ok {
+		candidates := ac.screenBatch(keywords, result)
+		if len(result.Failed) > 0 {
+			// See addManyTransactional: a blank aborts rather than being recorded.
+			return nil, ErrEmptyKeyword
+		}
+		if len(candidates) == 0 {
+			result.Removed = []string{}
+			return result, nil
+		}
+		// As in addManyTransactional: one CAS write is already atomic.
+		applied, err := bp.removeManyAtomic(ctx, candidates)
+		if err != nil {
+			return nil, fmt.Errorf("batch remove failed: %w", err)
+		}
+		changed, unchanged := ac.partitionApplied(candidates, applied)
+		result.Removed = append(result.Removed, changed...)
+		result.Skipped = append(result.Skipped, unchanged...)
+		return result, nil
+	}
+
 	removed := make([]string, 0)
 	seen := make(map[string]bool)
 	remove, commit := ac.batchRemoveFns()

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -64,8 +64,8 @@ func (ac *AhoCorasick) AddMany(keywords []string, opts *BatchOptions) (*BatchRes
 
 // screenBatch applies the checks that need no Redis access: blank keywords go to
 // result.Failed, repeats within the same call are skipped, and the survivors are
-// returned in input order. Every batch path shares it, so blanks and duplicates
-// behave the same whichever write path runs.
+// returned in input order alongside their normalized forms. Every batch path
+// shares it, so blanks and duplicates behave the same whichever write path runs.
 //
 // Duplicates are detected on the normalized form, not the caller's spelling: on a
 // case-insensitive collection "Foo" and "foo" are one keyword, so only one of them
@@ -76,9 +76,13 @@ func (ac *AhoCorasick) AddMany(keywords []string, opts *BatchOptions) (*BatchRes
 // ErrEmptyKeyword is the only error it records, so a transactional caller — which
 // must abort the batch on a blank rather than record it — tests
 // len(result.Failed) > 0 and discards result.
-func (ac *AhoCorasick) screenBatch(keywords []string, result *BatchResult) []string {
+func (ac *AhoCorasick) screenBatch(keywords []string, result *BatchResult) (
+	candidates, normalizedKeywords []string) {
 	seen := make(map[string]bool, len(keywords))
-	candidates := make([]string, 0, len(keywords))
+	candidates = make([]string, 0, len(keywords))
+	if !ac.caseSensitive {
+		normalizedKeywords = make([]string, 0, len(keywords))
+	}
 
 	for _, keyword := range keywords {
 		keyword = strings.TrimSpace(keyword)
@@ -89,34 +93,40 @@ func (ac *AhoCorasick) screenBatch(keywords []string, result *BatchResult) []str
 			})
 			continue
 		}
-		normalized := normalizeKeyword(keyword, ac.caseSensitive)
-		if seen[normalized] {
+		normalizedKeyword := normalizeKeyword(keyword, ac.caseSensitive)
+		if seen[normalizedKeyword] {
 			result.Skipped = append(result.Skipped, keyword)
 			continue
 		}
-		seen[normalized] = true
+		seen[normalizedKeyword] = true
 		candidates = append(candidates, keyword)
+		if !ac.caseSensitive {
+			normalizedKeywords = append(normalizedKeywords, normalizedKeyword)
+		}
 	}
 
-	return candidates
+	if ac.caseSensitive {
+		normalizedKeywords = candidates
+	}
+	return candidates, normalizedKeywords
 }
 
 // partitionApplied splits screened candidates by what the write actually
 // changed. applied is what the write path reports as having taken effect;
 // everything else was already in the desired state.
 //
-// The write path reports normalized keywords (lowercased unless the collection is
-// case-sensitive) while candidates keep the caller's spelling, so membership is
-// tested on the normalized form. Comparing raw against normalized reported every
-// keyword with an uppercase rune as Skipped on a case-insensitive collection, even
-// though it had just been written.
-func (ac *AhoCorasick) partitionApplied(candidates, applied []string) (changed, unchanged []string) {
+// The write path reports normalized keywords while candidates keep the caller's
+// spelling, so membership is tested against the normalized slice computed during
+// screening. Comparing raw against normalized reported every keyword with an
+// uppercase rune as Skipped on a case-insensitive collection, even though it had
+// just been written.
+func partitionApplied(candidates, normalized, applied []string) (changed, unchanged []string) {
 	appliedSet := make(map[string]struct{}, len(applied))
 	for _, kw := range applied {
 		appliedSet[kw] = struct{}{}
 	}
-	for _, kw := range candidates {
-		if _, ok := appliedSet[normalizeKeyword(kw, ac.caseSensitive)]; ok {
+	for i, kw := range candidates {
+		if _, ok := appliedSet[normalized[i]]; ok {
 			changed = append(changed, kw)
 		} else {
 			unchanged = append(unchanged, kw)
@@ -126,13 +136,13 @@ func (ac *AhoCorasick) partitionApplied(candidates, applied []string) (changed, 
 }
 
 func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
-	candidates := ac.screenBatch(keywords, result)
+	candidates, normalized := ac.screenBatch(keywords, result)
 
 	if bp, ok := ac.ops.(batchPlanner); ok {
 		if len(candidates) == 0 {
 			return result, nil
 		}
-		added, err := bp.addManyAtomic(ctx, candidates)
+		added, err := bp.addManyAtomic(ctx, normalized)
 		if err != nil {
 			// One transaction means one outcome: nothing was written, so every
 			// candidate failed. A partial success cannot happen here.
@@ -141,7 +151,7 @@ func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string,
 			}
 			return result, nil
 		}
-		changed, unchanged := ac.partitionApplied(candidates, added)
+		changed, unchanged := partitionApplied(candidates, normalized, added)
 		result.Added = append(result.Added, changed...)
 		result.Skipped = append(result.Skipped, unchanged...)
 		return result, nil
@@ -174,7 +184,7 @@ func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string,
 
 func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
 	if bp, ok := ac.ops.(batchPlanner); ok {
-		candidates := ac.screenBatch(keywords, result)
+		candidates, normalized := ac.screenBatch(keywords, result)
 		if len(result.Failed) > 0 {
 			// Transactional means all-or-nothing, so a blank keyword aborts the
 			// batch instead of being recorded alongside successful writes.
@@ -186,11 +196,11 @@ func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []stri
 		}
 		// A single CAS write is already all-or-nothing, so there is nothing to
 		// roll back: either the whole batch committed or none of it did.
-		applied, err := bp.addManyAtomic(ctx, candidates)
+		applied, err := bp.addManyAtomic(ctx, normalized)
 		if err != nil {
 			return nil, fmt.Errorf("batch add failed: %w", err)
 		}
-		changed, unchanged := ac.partitionApplied(candidates, applied)
+		changed, unchanged := partitionApplied(candidates, normalized, applied)
 		result.Added = append(result.Added, changed...)
 		result.Skipped = append(result.Skipped, unchanged...)
 		return result, nil
@@ -303,20 +313,20 @@ func (ac *AhoCorasick) RemoveManyWithOptions(keywords []string, opts *BatchOptio
 }
 
 func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
-	candidates := ac.screenBatch(keywords, result)
+	candidates, normalized := ac.screenBatch(keywords, result)
 
 	if bp, ok := ac.ops.(batchPlanner); ok {
 		if len(candidates) == 0 {
 			return result, nil
 		}
-		removed, err := bp.removeManyAtomic(ctx, candidates)
+		removed, err := bp.removeManyAtomic(ctx, normalized)
 		if err != nil {
 			for _, keyword := range candidates {
 				result.Failed = append(result.Failed, KeywordError{Keyword: keyword, Error: err})
 			}
 			return result, nil
 		}
-		changed, unchanged := ac.partitionApplied(candidates, removed)
+		changed, unchanged := partitionApplied(candidates, normalized, removed)
 		result.Removed = append(result.Removed, changed...)
 		result.Skipped = append(result.Skipped, unchanged...)
 		return result, nil
@@ -352,7 +362,7 @@ func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []stri
 
 func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []string, result *BatchResult) (*BatchResult, error) {
 	if bp, ok := ac.ops.(batchPlanner); ok {
-		candidates := ac.screenBatch(keywords, result)
+		candidates, normalized := ac.screenBatch(keywords, result)
 		if len(result.Failed) > 0 {
 			// See addManyTransactional: a blank aborts rather than being recorded.
 			return nil, ErrEmptyKeyword
@@ -362,11 +372,11 @@ func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []s
 			return result, nil
 		}
 		// As in addManyTransactional: one CAS write is already atomic.
-		applied, err := bp.removeManyAtomic(ctx, candidates)
+		applied, err := bp.removeManyAtomic(ctx, normalized)
 		if err != nil {
 			return nil, fmt.Errorf("batch remove failed: %w", err)
 		}
-		changed, unchanged := ac.partitionApplied(candidates, applied)
+		changed, unchanged := partitionApplied(candidates, normalized, applied)
 		result.Removed = append(result.Removed, changed...)
 		result.Skipped = append(result.Skipped, unchanged...)
 		return result, nil

--- a/pkg/acor/batch_atomic.go
+++ b/pkg/acor/batch_atomic.go
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import "context"
+
+// batchPlanner is implemented by modes that can apply a whole batch of keyword
+// writes in a single Redis transaction instead of one per keyword.
+//
+// Both V2 write paths read the entire trie, replan it, and write it back on every
+// single-keyword call, so a batch of N cost O(N^2): AddMany of 1000 keywords took
+// ~1.05s against a real server. Planning the batch once makes it two round trips
+// regardless of N.
+//
+// V1 does not implement it and keeps the per-keyword loop: its write path walks
+// per trie node, with different economics, and it is the legacy schema.
+type batchPlanner interface {
+	// addManyAtomic inserts every keyword in one transaction and returns those
+	// that were not already present. An error means nothing was written.
+	addManyAtomic(ctx context.Context, keywords []string) ([]string, error)
+	// removeManyAtomic deletes every keyword in one transaction and returns those
+	// that were actually present. An error means nothing was written.
+	removeManyAtomic(ctx context.Context, keywords []string) ([]string, error)
+}
+
+var (
+	_ batchPlanner = (*redisBackedAC)(nil)
+	_ batchPlanner = (*v2Operations)(nil)
+)
+
+// normalizeKeywords applies the same normalization the single-keyword paths do
+// and drops entries that normalize away, so planning never sees an empty string.
+func normalizeKeywords(keywords []string, caseSensitive bool) []string {
+	out := make([]string, 0, len(keywords))
+	for _, kw := range keywords {
+		if n := normalizeKeyword(kw, caseSensitive); n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// --- preset mode ---
+
+func (ac *redisBackedAC) addManyAtomic(ctx context.Context, keywords []string) ([]string, error) {
+	normalized := normalizeKeywords(keywords, ac.caseSensitive)
+	if len(normalized) == 0 {
+		return nil, nil
+	}
+
+	var added []string
+	_, err := retryOnConflict(ctx, func() (int, error) {
+		snap, err := readTrieSnapshot(ctx, ac.storage, ac.name)
+		if err != nil {
+			return 0, err
+		}
+		outputs, newlyAdded := planAddMany(snap, normalized)
+		if len(newlyAdded) == 0 {
+			added = nil
+			return 0, nil
+		}
+		newVersion, err := commitV2Write(ctx, ac.redisClient, ac.name, snap, outputs, false)
+		if err != nil {
+			// A lost CAS race retries from a fresh snapshot, so anything this
+			// attempt staged must not leak into the next one.
+			added = nil
+			return 0, err
+		}
+		added = newlyAdded
+		ac.applyCommittedBatch(snap, newVersion)
+		return len(newlyAdded), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(added) > 0 {
+		ac.publishInvalidate(ctx)
+	}
+	return added, nil
+}
+
+func (ac *redisBackedAC) removeManyAtomic(ctx context.Context, keywords []string) ([]string, error) {
+	normalized := normalizeKeywords(keywords, ac.caseSensitive)
+	if len(normalized) == 0 {
+		return nil, nil
+	}
+
+	var removed []string
+	_, err := retryOnConflict(ctx, func() (int, error) {
+		snap, err := readTrieSnapshot(ctx, ac.storage, ac.name)
+		if err != nil {
+			return 0, err
+		}
+		outputs, gone := planRemoveMany(snap, normalized)
+		if len(gone) == 0 {
+			removed = nil
+			return 0, nil
+		}
+		newVersion, err := commitV2Write(ctx, ac.redisClient, ac.name, snap, outputs, true)
+		if err != nil {
+			removed = nil
+			return 0, err
+		}
+		removed = gone
+		ac.applyCommittedBatch(snap, newVersion)
+		return len(gone), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(removed) > 0 {
+		ac.publishInvalidate(ctx)
+	}
+	return removed, nil
+}
+
+// applyCommittedBatch installs the batch's own committed snapshot as the local
+// view, rebuilding the engine once for the whole batch.
+//
+// It rebuilds from snap rather than the incrementally maintained keywordSet for the
+// reason commitBatch documents: that set can be missing a keyword another node
+// wrote, so clearing stale entries against it would drop that write from local
+// reads until the next invalidation. snap is authoritative instead — the CAS that
+// just succeeded proves Redis was still at snap's version, and planAddMany /
+// planRemoveMany already folded this batch into snap.Keywords.
+func (ac *redisBackedAC) applyCommittedBatch(snap *trieSnapshot, newVersion int64) {
+	ac.mu.Lock()
+	ac.applyReload(snap)
+	ac.localVersion = newVersion
+	ac.mu.Unlock()
+}
+
+// --- V2 mode ---
+
+func (o *v2Operations) addManyAtomic(ctx context.Context, keywords []string) ([]string, error) {
+	normalized := normalizeKeywords(keywords, o.caseSensitive)
+	if len(normalized) == 0 {
+		return nil, nil
+	}
+
+	var added []string
+	_, err := retryOnConflict(ctx, func() (int, error) {
+		snap, err := readTrieSnapshot(ctx, o.storage, o.name)
+		if err != nil {
+			return 0, err
+		}
+		outputs, newlyAdded := planAddMany(snap, normalized)
+		if len(newlyAdded) == 0 {
+			added = nil
+			return 0, nil
+		}
+		if _, err := commitV2Write(ctx, o.client, o.name, snap, outputs, false); err != nil {
+			added = nil
+			return 0, err
+		}
+		added = newlyAdded
+		return len(newlyAdded), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(added) > 0 {
+		o.publishInvalidate(ctx)
+	}
+	return added, nil
+}
+
+func (o *v2Operations) removeManyAtomic(ctx context.Context, keywords []string) ([]string, error) {
+	normalized := normalizeKeywords(keywords, o.caseSensitive)
+	if len(normalized) == 0 {
+		return nil, nil
+	}
+
+	var removed []string
+	_, err := retryOnConflict(ctx, func() (int, error) {
+		snap, err := readTrieSnapshot(ctx, o.storage, o.name)
+		if err != nil {
+			return 0, err
+		}
+		outputs, gone := planRemoveMany(snap, normalized)
+		if len(gone) == 0 {
+			removed = nil
+			return 0, nil
+		}
+		if _, err := commitV2Write(ctx, o.client, o.name, snap, outputs, true); err != nil {
+			removed = nil
+			return 0, err
+		}
+		removed = gone
+		return len(gone), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(removed) > 0 {
+		o.publishInvalidate(ctx)
+	}
+	return removed, nil
+}

--- a/pkg/acor/batch_atomic.go
+++ b/pkg/acor/batch_atomic.go
@@ -2,7 +2,11 @@
 
 package acor
 
-import "context"
+import (
+	"context"
+
+	"github.com/redis/go-redis/v9"
+)
 
 // batchPlanner is implemented by modes that can apply a whole batch of keyword
 // writes in a single Redis transaction instead of one per keyword.
@@ -13,7 +17,8 @@ import "context"
 // regardless of N.
 //
 // V1 does not implement it and keeps the per-keyword loop: its write path walks
-// per trie node, with different economics, and it is the legacy schema.
+// per trie node, with different economics, and it is the legacy schema. Callers
+// pass keywords already screened and normalized.
 type batchPlanner interface {
 	// addManyAtomic inserts every keyword in one transaction and returns those
 	// that were not already present. An error means nothing was written.
@@ -28,90 +33,60 @@ var (
 	_ batchPlanner = (*v2Operations)(nil)
 )
 
-// normalizeKeywords applies the same normalization the single-keyword paths do
-// and drops entries that normalize away, so planning never sees an empty string.
-func normalizeKeywords(keywords []string, caseSensitive bool) []string {
-	out := make([]string, 0, len(keywords))
-	for _, kw := range keywords {
-		if n := normalizeKeyword(kw, caseSensitive); n != "" {
-			out = append(out, n)
+// applyManyAtomic runs the shared V2 snapshot-plan-CAS loop. afterCommit is used
+// by preset mode to install the committed snapshot in its local engine.
+func applyManyAtomic(ctx context.Context, storage KVStorage, client redis.UniversalClient, name string,
+	keywords []string, clearOutputs bool,
+	plan func(*trieSnapshot, []string) (map[string][]string, []string),
+	afterCommit func(*trieSnapshot, int64)) ([]string, error) {
+	var applied []string
+	_, err := retryOnConflict(ctx, func() (int, error) {
+		snap, err := readTrieSnapshot(ctx, storage, name)
+		if err != nil {
+			return 0, err
 		}
+		outputs, changed := plan(snap, keywords)
+		if len(changed) == 0 {
+			applied = nil
+			return 0, nil
+		}
+		newVersion, err := commitV2Write(ctx, client, name, snap, outputs, clearOutputs)
+		if err != nil {
+			// A lost CAS race retries from a fresh snapshot, so anything this
+			// attempt staged must not leak into the next one.
+			applied = nil
+			return 0, err
+		}
+		applied = changed
+		if afterCommit != nil {
+			afterCommit(snap, newVersion)
+		}
+		return len(changed), nil
+	})
+	if err != nil {
+		return nil, err
 	}
-	return out
+	return applied, nil
 }
 
 // --- preset mode ---
 
 func (ac *redisBackedAC) addManyAtomic(ctx context.Context, keywords []string) ([]string, error) {
-	normalized := normalizeKeywords(keywords, ac.caseSensitive)
-	if len(normalized) == 0 {
-		return nil, nil
-	}
-
-	var added []string
-	_, err := retryOnConflict(ctx, func() (int, error) {
-		snap, err := readTrieSnapshot(ctx, ac.storage, ac.name)
-		if err != nil {
-			return 0, err
-		}
-		outputs, newlyAdded := planAddMany(snap, normalized)
-		if len(newlyAdded) == 0 {
-			added = nil
-			return 0, nil
-		}
-		newVersion, err := commitV2Write(ctx, ac.redisClient, ac.name, snap, outputs, false)
-		if err != nil {
-			// A lost CAS race retries from a fresh snapshot, so anything this
-			// attempt staged must not leak into the next one.
-			added = nil
-			return 0, err
-		}
-		added = newlyAdded
-		ac.applyCommittedBatch(snap, newVersion)
-		return len(newlyAdded), nil
-	})
-	if err != nil {
-		return nil, err
-	}
+	added, err := applyManyAtomic(ctx, ac.storage, ac.redisClient, ac.name, keywords,
+		false, planAddMany, ac.applyCommittedBatch)
 	if len(added) > 0 {
 		ac.publishInvalidate(ctx)
 	}
-	return added, nil
+	return added, err
 }
 
 func (ac *redisBackedAC) removeManyAtomic(ctx context.Context, keywords []string) ([]string, error) {
-	normalized := normalizeKeywords(keywords, ac.caseSensitive)
-	if len(normalized) == 0 {
-		return nil, nil
-	}
-
-	var removed []string
-	_, err := retryOnConflict(ctx, func() (int, error) {
-		snap, err := readTrieSnapshot(ctx, ac.storage, ac.name)
-		if err != nil {
-			return 0, err
-		}
-		outputs, gone := planRemoveMany(snap, normalized)
-		if len(gone) == 0 {
-			removed = nil
-			return 0, nil
-		}
-		newVersion, err := commitV2Write(ctx, ac.redisClient, ac.name, snap, outputs, true)
-		if err != nil {
-			removed = nil
-			return 0, err
-		}
-		removed = gone
-		ac.applyCommittedBatch(snap, newVersion)
-		return len(gone), nil
-	})
-	if err != nil {
-		return nil, err
-	}
+	removed, err := applyManyAtomic(ctx, ac.storage, ac.redisClient, ac.name, keywords,
+		true, planRemoveMany, ac.applyCommittedBatch)
 	if len(removed) > 0 {
 		ac.publishInvalidate(ctx)
 	}
-	return removed, nil
+	return removed, err
 }
 
 // applyCommittedBatch installs the batch's own committed snapshot as the local
@@ -133,67 +108,19 @@ func (ac *redisBackedAC) applyCommittedBatch(snap *trieSnapshot, newVersion int6
 // --- V2 mode ---
 
 func (o *v2Operations) addManyAtomic(ctx context.Context, keywords []string) ([]string, error) {
-	normalized := normalizeKeywords(keywords, o.caseSensitive)
-	if len(normalized) == 0 {
-		return nil, nil
-	}
-
-	var added []string
-	_, err := retryOnConflict(ctx, func() (int, error) {
-		snap, err := readTrieSnapshot(ctx, o.storage, o.name)
-		if err != nil {
-			return 0, err
-		}
-		outputs, newlyAdded := planAddMany(snap, normalized)
-		if len(newlyAdded) == 0 {
-			added = nil
-			return 0, nil
-		}
-		if _, err := commitV2Write(ctx, o.client, o.name, snap, outputs, false); err != nil {
-			added = nil
-			return 0, err
-		}
-		added = newlyAdded
-		return len(newlyAdded), nil
-	})
-	if err != nil {
-		return nil, err
-	}
+	added, err := applyManyAtomic(ctx, o.storage, o.client, o.name, keywords,
+		false, planAddMany, nil)
 	if len(added) > 0 {
 		o.publishInvalidate(ctx)
 	}
-	return added, nil
+	return added, err
 }
 
 func (o *v2Operations) removeManyAtomic(ctx context.Context, keywords []string) ([]string, error) {
-	normalized := normalizeKeywords(keywords, o.caseSensitive)
-	if len(normalized) == 0 {
-		return nil, nil
-	}
-
-	var removed []string
-	_, err := retryOnConflict(ctx, func() (int, error) {
-		snap, err := readTrieSnapshot(ctx, o.storage, o.name)
-		if err != nil {
-			return 0, err
-		}
-		outputs, gone := planRemoveMany(snap, normalized)
-		if len(gone) == 0 {
-			removed = nil
-			return 0, nil
-		}
-		if _, err := commitV2Write(ctx, o.client, o.name, snap, outputs, true); err != nil {
-			removed = nil
-			return 0, err
-		}
-		removed = gone
-		return len(gone), nil
-	})
-	if err != nil {
-		return nil, err
-	}
+	removed, err := applyManyAtomic(ctx, o.storage, o.client, o.name, keywords,
+		true, planRemoveMany, nil)
 	if len(removed) > 0 {
 		o.publishInvalidate(ctx)
 	}
-	return removed, nil
+	return removed, err
 }

--- a/pkg/acor/batch_ops_test.go
+++ b/pkg/acor/batch_ops_test.go
@@ -455,10 +455,10 @@ func TestBatchCaseNormalization(t *testing.T) {
 			for _, mode := range []BatchMode{BatchModeBestEffort, BatchModeTransactional} {
 				ac, mr := createAhoCorasickWithOpts(t, schema, caseSensitive)
 				wantChanged := []string{"Foo"}
-				wantSkipped := 1
+				wantSkipped := []string{"foo"}
 				if caseSensitive {
 					wantChanged = []string{"Foo", "foo"}
-					wantSkipped = 0
+					wantSkipped = nil
 				}
 
 				added, err := ac.AddMany([]string{"Foo", "foo"}, &BatchOptions{Mode: mode})
@@ -466,7 +466,7 @@ func TestBatchCaseNormalization(t *testing.T) {
 					t.Fatalf("schema=%d caseSensitive=%t mode=%v: AddMany error: %v",
 						schema, caseSensitive, mode, err)
 				}
-				if !slices.Equal(added.Added, wantChanged) || len(added.Skipped) != wantSkipped {
+				if !slices.Equal(added.Added, wantChanged) || !slices.Equal(added.Skipped, wantSkipped) {
 					t.Errorf("schema=%d caseSensitive=%t mode=%v: AddMany added=%v skipped=%v",
 						schema, caseSensitive, mode, added.Added, added.Skipped)
 				}
@@ -476,7 +476,7 @@ func TestBatchCaseNormalization(t *testing.T) {
 					t.Fatalf("schema=%d caseSensitive=%t mode=%v: RemoveMany error: %v",
 						schema, caseSensitive, mode, err)
 				}
-				if !slices.Equal(removed.Removed, wantChanged) || len(removed.Skipped) != wantSkipped {
+				if !slices.Equal(removed.Removed, wantChanged) || !slices.Equal(removed.Skipped, wantSkipped) {
 					t.Errorf("schema=%d caseSensitive=%t mode=%v: RemoveMany removed=%v skipped=%v",
 						schema, caseSensitive, mode, removed.Removed, removed.Skipped)
 				}

--- a/pkg/acor/batch_ops_test.go
+++ b/pkg/acor/batch_ops_test.go
@@ -446,6 +446,41 @@ func TestRemoveManyTransactionalDuplicate(t *testing.T) {
 	}
 }
 
+// TestBatchCaseDuplicateCountsOnce pins duplicate detection to the normalized
+// keyword. On a case-insensitive collection "Foo" and "foo" are one keyword, so one
+// write happens and exactly one entry may be reported as Added/Removed. Screening
+// the caller's raw spelling let both through, and the batched write path — which
+// reports normalized keywords — then matched both against that single applied
+// keyword and reported two additions for one write.
+func TestBatchCaseDuplicateCountsOnce(t *testing.T) {
+	for _, schema := range []int{SchemaV1, SchemaV2} {
+		for _, mode := range []BatchMode{BatchModeBestEffort, BatchModeTransactional} {
+			ac, mr := createAhoCorasickWithSchema(t, schema)
+
+			added, err := ac.AddMany([]string{"Foo", "foo"}, &BatchOptions{Mode: mode})
+			if err != nil {
+				t.Fatalf("schema=%d mode=%v: AddMany error: %v", schema, mode, err)
+			}
+			if len(added.Added) != 1 || len(added.Skipped) != 1 {
+				t.Errorf("schema=%d mode=%v: AddMany added=%v skipped=%v, want one of each",
+					schema, mode, added.Added, added.Skipped)
+			}
+
+			removed, err := ac.RemoveManyWithOptions([]string{"Foo", "foo"}, &BatchOptions{Mode: mode})
+			if err != nil {
+				t.Fatalf("schema=%d mode=%v: RemoveMany error: %v", schema, mode, err)
+			}
+			if len(removed.Removed) != 1 || len(removed.Skipped) != 1 {
+				t.Errorf("schema=%d mode=%v: RemoveMany removed=%v skipped=%v, want one of each",
+					schema, mode, removed.Removed, removed.Skipped)
+			}
+
+			_ = ac.Close()
+			mr.Close()
+		}
+	}
+}
+
 func TestRemoveManyTransactionalError(t *testing.T) {
 	ac, _ := createAhoCorasick(t)
 	defer func() { _ = ac.Close() }()

--- a/pkg/acor/batch_ops_test.go
+++ b/pkg/acor/batch_ops_test.go
@@ -5,6 +5,7 @@ package acor
 import (
 	"context"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -446,37 +447,43 @@ func TestRemoveManyTransactionalDuplicate(t *testing.T) {
 	}
 }
 
-// TestBatchCaseDuplicateCountsOnce pins duplicate detection to the normalized
-// keyword. On a case-insensitive collection "Foo" and "foo" are one keyword, so one
-// write happens and exactly one entry may be reported as Added/Removed. Screening
-// the caller's raw spelling let both through, and the batched write path — which
-// reports normalized keywords — then matched both against that single applied
-// keyword and reported two additions for one write.
-func TestBatchCaseDuplicateCountsOnce(t *testing.T) {
+// TestBatchCaseNormalization pins duplicate detection to the normalized keyword
+// while preserving the caller's spelling in results.
+func TestBatchCaseNormalization(t *testing.T) {
 	for _, schema := range []int{SchemaV1, SchemaV2} {
-		for _, mode := range []BatchMode{BatchModeBestEffort, BatchModeTransactional} {
-			ac, mr := createAhoCorasickWithSchema(t, schema)
+		for _, caseSensitive := range []bool{false, true} {
+			for _, mode := range []BatchMode{BatchModeBestEffort, BatchModeTransactional} {
+				ac, mr := createAhoCorasickWithOpts(t, schema, caseSensitive)
+				wantChanged := []string{"Foo"}
+				wantSkipped := 1
+				if caseSensitive {
+					wantChanged = []string{"Foo", "foo"}
+					wantSkipped = 0
+				}
 
-			added, err := ac.AddMany([]string{"Foo", "foo"}, &BatchOptions{Mode: mode})
-			if err != nil {
-				t.Fatalf("schema=%d mode=%v: AddMany error: %v", schema, mode, err)
-			}
-			if len(added.Added) != 1 || len(added.Skipped) != 1 {
-				t.Errorf("schema=%d mode=%v: AddMany added=%v skipped=%v, want one of each",
-					schema, mode, added.Added, added.Skipped)
-			}
+				added, err := ac.AddMany([]string{"Foo", "foo"}, &BatchOptions{Mode: mode})
+				if err != nil {
+					t.Fatalf("schema=%d caseSensitive=%t mode=%v: AddMany error: %v",
+						schema, caseSensitive, mode, err)
+				}
+				if !slices.Equal(added.Added, wantChanged) || len(added.Skipped) != wantSkipped {
+					t.Errorf("schema=%d caseSensitive=%t mode=%v: AddMany added=%v skipped=%v",
+						schema, caseSensitive, mode, added.Added, added.Skipped)
+				}
 
-			removed, err := ac.RemoveManyWithOptions([]string{"Foo", "foo"}, &BatchOptions{Mode: mode})
-			if err != nil {
-				t.Fatalf("schema=%d mode=%v: RemoveMany error: %v", schema, mode, err)
-			}
-			if len(removed.Removed) != 1 || len(removed.Skipped) != 1 {
-				t.Errorf("schema=%d mode=%v: RemoveMany removed=%v skipped=%v, want one of each",
-					schema, mode, removed.Removed, removed.Skipped)
-			}
+				removed, err := ac.RemoveManyWithOptions([]string{"Foo", "foo"}, &BatchOptions{Mode: mode})
+				if err != nil {
+					t.Fatalf("schema=%d caseSensitive=%t mode=%v: RemoveMany error: %v",
+						schema, caseSensitive, mode, err)
+				}
+				if !slices.Equal(removed.Removed, wantChanged) || len(removed.Skipped) != wantSkipped {
+					t.Errorf("schema=%d caseSensitive=%t mode=%v: RemoveMany removed=%v skipped=%v",
+						schema, caseSensitive, mode, removed.Removed, removed.Skipped)
+				}
 
-			_ = ac.Close()
-			mr.Close()
+				_ = ac.Close()
+				mr.Close()
+			}
 		}
 	}
 }

--- a/pkg/acor/v2_plan.go
+++ b/pkg/acor/v2_plan.go
@@ -5,48 +5,84 @@ package acor
 import "strings"
 
 // This file holds the pure, side-effect-free half of a V2 write: given a trie
-// snapshot and a keyword, work out the new snapshot and the output lists that
-// changed. Both V2 callers — v2Operations (Redis-resident reads) and
+// snapshot and one or more keywords, work out the new snapshot and the output
+// lists that changed. Both V2 callers — v2Operations (Redis-resident reads) and
 // redisBackedAC (preset mode, local engine) — plan identically and differ only
 // in what they do after the Lua script commits, so the planning lives here once.
+//
+// The *Many variants are the primitives and the single-keyword forms wrap them.
+// Planning a batch in one pass is what keeps AddMany linear: every plan call
+// rebuilds the keyword and prefix sets and recomputes outputs for every existing
+// prefix, so doing that per keyword made a batch quadratic.
 
 // planAdd computes the trie mutation for inserting keyword. On success snap is
 // updated in place and outputs maps each state whose output list changed to its
 // new value. changed is false when the keyword is already present, in which case
 // snap is untouched and no write is needed.
 func planAdd(snap *trieSnapshot, keyword string) (outputs map[string][]string, changed bool) {
-	keywordSet := make(map[string]struct{}, len(snap.Keywords)+1)
+	outputs, added := planAddMany(snap, []string{keyword})
+	return outputs, len(added) > 0
+}
+
+// planAddMany computes one trie mutation covering every keyword in keywords. It
+// returns the states whose output lists changed and the keywords that were
+// actually new; added is empty (and outputs nil) when every keyword was already
+// present, in which case snap is untouched.
+//
+// The result is identical to applying planAdd to each keyword in turn, since the
+// single-keyword path also recomputes every prefix against the final keyword set.
+// Folding N passes into one changes cost, not outcome.
+func planAddMany(snap *trieSnapshot, keywords []string) (outputs map[string][]string, added []string) {
+	keywordSet := make(map[string]struct{}, len(snap.Keywords)+len(keywords))
 	for _, kw := range snap.Keywords {
 		keywordSet[kw] = struct{}{}
 	}
-	if _, exists := keywordSet[keyword]; exists {
-		return nil, false
-	}
-
 	prefixSet := make(map[string]struct{}, len(snap.Prefixes))
 	for _, p := range snap.Prefixes {
 		prefixSet[p] = struct{}{}
 	}
 
-	keywordRunes := []rune(keyword)
 	var newPrefixes []string
-	for i := range keywordRunes {
-		prefix := string(keywordRunes[:i+1])
+	addPrefix := func(prefix string) {
 		if _, exists := prefixSet[prefix]; !exists {
 			newPrefixes = append(newPrefixes, prefix)
 			prefixSet[prefix] = struct{}{}
 		}
 	}
+	for _, keyword := range keywords {
+		if keyword == "" {
+			continue
+		}
+		if _, exists := keywordSet[keyword]; exists {
+			continue
+		}
+		keywordSet[keyword] = struct{}{}
+		added = append(added, keyword)
 
-	keywordSet[keyword] = struct{}{}
+		// Ranging a string yields exactly the rune start offsets, so slicing at each
+		// of them (past 0) plus the whole keyword enumerates every prefix. Not
+		// byteOff+utf8.RuneLen(r): invalid UTF-8 decodes to RuneError, whose RuneLen
+		// is 3, which slices past the end of the string and panics.
+		for byteOff := range keyword {
+			if byteOff == 0 {
+				continue
+			}
+			addPrefix(keyword[:byteOff])
+		}
+		addPrefix(keyword)
+	}
+	if len(added) == 0 {
+		return nil, nil
+	}
+
 	outputs = make(map[string][]string)
 	for _, prefix := range newPrefixes {
 		if outs := computeOutputs(prefix, prefixSet, keywordSet); len(outs) > 0 {
 			outputs[prefix] = outs
 		}
 	}
-	// Pre-existing states can gain an output too: the new keyword may be a
-	// suffix of one of them, so every old prefix is recomputed.
+	// Pre-existing states can gain an output too: a new keyword may be a suffix
+	// of one of them, so every old prefix is recomputed.
 	for _, prefix := range snap.Prefixes {
 		if prefix == "" {
 			continue
@@ -56,9 +92,9 @@ func planAdd(snap *trieSnapshot, keyword string) (outputs map[string][]string, c
 		}
 	}
 
-	snap.Keywords = append(snap.Keywords, keyword)
+	snap.Keywords = append(snap.Keywords, added...)
 	snap.Prefixes = append(snap.Prefixes, newPrefixes...)
-	return outputs, true
+	return outputs, added
 }
 
 // planRemove computes the trie mutation for deleting keyword. On success snap is
@@ -66,17 +102,29 @@ func planAdd(snap *trieSnapshot, keyword string) (outputs map[string][]string, c
 // script clears the outputs hash first, so this is not a delta). changed is false
 // when the keyword is absent.
 func planRemove(snap *trieSnapshot, keyword string) (outputs map[string][]string, changed bool) {
+	outputs, removed := planRemoveMany(snap, []string{keyword})
+	return outputs, len(removed) > 0
+}
+
+// planRemoveMany computes one trie mutation deleting every keyword in keywords,
+// returning the full replacement output set and the keywords actually present.
+// removed is empty (and outputs nil) when none of them were.
+func planRemoveMany(snap *trieSnapshot, keywords []string) (outputs map[string][]string, removed []string) {
+	doomed := make(map[string]struct{}, len(keywords))
+	for _, kw := range keywords {
+		doomed[kw] = struct{}{}
+	}
+
 	newKeywords := make([]string, 0, len(snap.Keywords))
-	found := false
 	for _, kw := range snap.Keywords {
-		if kw == keyword {
-			found = true
+		if _, drop := doomed[kw]; drop {
+			removed = append(removed, kw)
 			continue
 		}
 		newKeywords = append(newKeywords, kw)
 	}
-	if !found {
-		return nil, false
+	if len(removed) == 0 {
+		return nil, nil
 	}
 
 	keywordSet := make(map[string]struct{}, len(newKeywords))
@@ -115,7 +163,7 @@ func planRemove(snap *trieSnapshot, keyword string) (outputs map[string][]string
 
 	snap.Keywords = newKeywords
 	snap.Prefixes = newPrefixes
-	return outputs, true
+	return outputs, removed
 }
 
 // computeOutputs returns every keyword that ends at state: state itself when it
@@ -128,9 +176,15 @@ func computeOutputs(state string, prefixSet, keywordSet map[string]struct{}) []s
 		outputs = append(outputs, state)
 	}
 
-	stateRunes := []rune(state)
-	for i := 1; i < len(stateRunes); i++ {
-		failState := string(stateRunes[i:])
+	// Proper suffixes, sliced out of state rather than rebuilt from its runes. A Go
+	// substring shares the original backing array, so this allocates nothing, where
+	// string([]rune(state)[i:]) allocated a fresh string per suffix — and this
+	// function runs once per prefix on every write.
+	for byteOff := range state {
+		if byteOff == 0 {
+			continue
+		}
+		failState := state[byteOff:]
 		if _, isPrefix := prefixSet[failState]; !isPrefix {
 			continue
 		}


### PR DESCRIPTION
# Pull Request

## Description

`AddMany` and `RemoveMany` looped the single-keyword write path. On V2 and preset
modes that path reads the entire trie, replans it, and writes it back per call, so
a batch of N cost O(N²): adding 1000 keywords against a real server took 1,049ms,
427MB and 8.5M allocations.

The batch now plans in one pass and commits in one transaction:

- a new `batchPlanner` interface, implemented by `redisBackedAC` and `v2Operations`,
  applies the whole batch atomically. V1 does not implement it and keeps the
  per-keyword loop — its write path walks per trie node, with different economics,
  and it is the legacy schema.
- `computeOutputs` slices suffixes out of the state string instead of rebuilding
  each one from runes, which had allocated once per suffix on every write.

At 1000 keywords: **1,049ms → 2.6ms, 427MB → 1.7MB, 8.5M → 8.8K allocations** —
about 400x faster with 970x fewer allocations, at two round trips regardless of
batch size. Transactional batches no longer need rollback, since a single
compare-and-set write is already all-or-nothing.

Also fixes duplicate screening on the same paths. It compared the caller's raw
spelling while the batched write path reports normalized keywords, so on a
case-insensitive collection `AddMany(["Foo", "foo"])` reported both as Added even
though one keyword was written. Duplicates are now detected on the normalized form,
matching V1 and the single-keyword `Add`/`Remove`: one entry in Added, one in
Skipped.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed — the bulk-load figures are published in the docs PR at the top of this stack
- [x] Changelog fragment added (`changie new`) — `Fixed-20260802-000001`, `Fixed-20260804-000004`
- [x] Commit messages follow guidelines

## Additional Notes

Bottom of a 6-PR stack. This one is self-contained: it touches only the `pkg/acor`
write path and has no dependency on the engine work above it, so it can merge on
its own.

The two fixes are bundled because they share the duplicate-screening code — the
case-fold bug is only reachable through the batched write path this PR introduces.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).
