### PR TITLE
refactor: deprecate PresetUltimate as an alias for PresetBalanced

### DIFF
--- a/changes/unreleased/Changed-20260803-000001.yaml
+++ b/changes/unreleased/Changed-20260803-000001.yaml
@@ -1,0 +1,16 @@
+kind: Changed
+body: >-
+  `PresetUltimate` is now a deprecated alias for `PresetBalanced` and its Bloom
+  pre-filter is gone. The filter was meant to skip characters that cannot start
+  any keyword, but the per-character check cost more than the trie work it saved:
+  across every benchmark in the repository it ran 1.7-1.8x slower than
+  `PresetBalanced` on both ASCII and multibyte text. It also forced
+  the scan onto the rune path, blocking the byte-scan fast path an ASCII
+  dictionary can take. Code selecting it keeps compiling and now gets the faster
+  engine. Dropping the filter's nil check from the shared scan loop also sped up
+  `PresetBalanced` itself: `FindIndex` over 1000 ASCII keywords went 8,734 to
+  7,340 ns/op. `PresetMemoryEfficient` keeps its own Bloom pre-filter, which is
+  used differently
+time: 2026-08-03T10:00:00.000000+09:00
+custom:
+    Issue: "186"

--- a/changes/unreleased/Changed-20260803-000001.yaml
+++ b/changes/unreleased/Changed-20260803-000001.yaml
@@ -1,16 +1,10 @@
 kind: Changed
 body: >-
-  `PresetUltimate` is now a deprecated alias for `PresetBalanced` and its Bloom
-  pre-filter is gone. The filter was meant to skip characters that cannot start
-  any keyword, but the per-character check cost more than the trie work it saved:
-  across every benchmark in the repository it ran 1.7-1.8x slower than
-  `PresetBalanced` on both ASCII and multibyte text. It also forced
-  the scan onto the rune path, blocking the byte-scan fast path an ASCII
-  dictionary can take. Code selecting it keeps compiling and now gets the faster
-  engine. Dropping the filter's nil check from the shared scan loop also sped up
-  `PresetBalanced` itself: `FindIndex` over 1000 ASCII keywords went 8,734 to
-  7,340 ns/op. `PresetMemoryEfficient` keeps its own Bloom pre-filter, which is
-  used differently
+  `PresetUltimate` is now a deprecated alias for `PresetBalanced`. Its Bloom
+  pre-filter was removed because it was 1.7-1.8x slower and prevented the ASCII
+  byte-scan fast path. Existing code remains compatible and now uses the faster
+  engine, while `PresetBalanced` also benefits from lower scan overhead.
+  `PresetMemoryEfficient` retains its Bloom pre-filter.
 time: 2026-08-03T10:00:00.000000+09:00
 custom:
     Issue: "186"

--- a/docs/content/guides/preset-engine.md
+++ b/docs/content/guides/preset-engine.md
@@ -58,18 +58,23 @@ Each preset optimizes for a different trade-off between speed, memory, and featu
 | `PresetSpeed` | Full DFA + flat array trie + compact alphabet mapping | Real-time packet inspection, high-speed log scanning, latency-critical paths | Higher memory proportional to states x alphabet size |
 | `PresetBalanced` | Double-Array Trie + Banded DFA + output link compression | General-purpose backend keyword filtering, search engines | Balanced speed and memory |
 | `PresetMemoryEfficient` | Map-based sparse trie + Bloom filter pre-filtering + standard NFA | Large-scale domain blocking, malware signature matching, millions of patterns | Slower search due to failure link traversal and map lookups |
-| `PresetUltimate` | Balanced architecture (Double-Array Trie + Banded DFA) + root-state first-rune Bloom pre-filter | Production systems needing highest throughput | Highest speed at Balanced-level memory |
 
-> Since v0.8.0 `PresetUltimate` shares the `PresetBalanced` engine, adding only a
-> first-rune Bloom pre-filter that skips characters which cannot start any
-> keyword. Match results are identical to `PresetBalanced`.
+> `PresetUltimate` is a deprecated alias for `PresetBalanced`. It used to add a
+> root-state first-rune Bloom pre-filter, which measured 1.7-1.8x slower than
+> `PresetBalanced` on every benchmark in the repository, on ASCII and multibyte text
+> alike: the per-character check cost more than the trie work it skipped. Code using
+> it keeps compiling and now gets the faster engine.
 
 ### Choosing a Preset
 
 - **Start with `PresetBalanced`** — it provides the best speed-to-memory ratio for most workloads.
 - Use `PresetSpeed` when latency is critical and memory is available.
 - Use `PresetMemoryEfficient` when you have millions of patterns and memory is constrained.
-- Use `PresetUltimate` for production systems that need maximum throughput.
+
+`PresetSpeed` measured fastest on every query shape on the
+[benchmarks page](../../reference/benchmarks/), while `PresetBalanced` trades some of
+that for a much smaller transition table. Measure your own corpus rather than
+choosing by name.
 
 ## Case Sensitivity
 

--- a/docs/content/guides/redis-backed-engine.md
+++ b/docs/content/guides/redis-backed-engine.md
@@ -123,7 +123,6 @@ The same [architecture presets](../preset-engine/#architecture-presets) are avai
 | `PresetSpeed` | Latency-critical, memory available |
 | `PresetBalanced` | Default — best speed-to-memory ratio |
 | `PresetMemoryEfficient` | Millions of patterns, memory constrained |
-| `PresetUltimate` | Maximum throughput production systems |
 
 If the `Preset` field is left unset, it defaults to `PresetNone`, which runs the
 original `AhoCorasick` mode (not the preset-optimized engine). You must set
@@ -163,7 +162,7 @@ err := ac.Close()
 | Write latency | Lua script | Lua script + optimistic lock |
 | Cross-instance sync | Pub/Sub cache invalidation | Pub/Sub engine rebuild |
 | Schema | V1 or V2 | V2 only |
-| Presets | N/A | Speed, Balanced, MemoryEfficient, Ultimate |
+| Presets | N/A | Speed, Balanced, MemoryEfficient |
 | Suggest/SuggestIndex | Yes | No (`ErrSuggestRequiresRedis`) |
 | Batch operations | Yes | Yes |
 | Parallel matching | Yes | Yes |

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -259,7 +259,7 @@ const (
     PresetSpeed                         // Full DFA + flat array — max speed, higher memory
     PresetBalanced                      // Double-Array Trie + Banded DFA — best speed-to-memory ratio
     PresetMemoryEfficient               // Map-based + Bloom filter — min memory, slower search
-    PresetUltimate                      // Balanced engine + first-rune Bloom pre-filter — high throughput
+    // PresetUltimate is a deprecated alias for PresetBalanced.
 )
 ```
 
@@ -284,7 +284,7 @@ The `AhoCorasickArgs` struct includes a `Preset` field for the engine mode:
 ```go
 type AhoCorasickArgs struct {
     // ... standard Redis connection fields ...
-    Preset         Preset // Architecture preset: PresetSpeed, PresetBalanced, PresetMemoryEfficient, PresetUltimate
+    Preset         Preset // Architecture preset: PresetSpeed, PresetBalanced, PresetMemoryEfficient
     // ... other fields ...
 }
 ```

--- a/internal/engine/coder.go
+++ b/internal/engine/coder.go
@@ -5,7 +5,7 @@ package engine
 import "unicode/utf8"
 
 // alphabetCoder maps runes to compact alphabet indices with an ASCII fast path.
-// It is embedded by both the Speed (flat) and Balanced/Ultimate (DAT) engines,
+// It is embedded by both the Speed (flat) and Balanced (DAT) engines,
 // which resolve nearly every input character to an index and must agree on the
 // encoding.
 type alphabetCoder struct {

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -31,13 +31,6 @@ const (
 	// Trade-off: slower search due to failure link traversal and map lookups.
 	PresetMemoryEfficient
 
-	// PresetUltimate uses the Balanced architecture (Double-Array Trie with
-	// Banded DFA) plus a root-state first-rune pre-filter (a rune-level Bloom
-	// filter) that skips characters which cannot start any keyword. Best for
-	// production systems that need high
-	// throughput with reasonable memory usage.
-	PresetUltimate
-
 	// PresetDefault is an internal sentinel; not user-selectable.
 	PresetDefault Preset = -1
 )
@@ -52,8 +45,6 @@ func (p Preset) String() string {
 		return "Balanced"
 	case PresetMemoryEfficient:
 		return "MemoryEfficient"
-	case PresetUltimate:
-		return "Ultimate"
 	case PresetDefault:
 		return "Default"
 	default:

--- a/internal/engine/engine_banded_dfa.go
+++ b/internal/engine/engine_banded_dfa.go
@@ -16,11 +16,9 @@ type bandedDFA struct {
 var _ matchEngine = (*balancedEngine)(nil)
 
 // balancedEngine implements matchEngine using a DAT with Banded DFA and output
-// link compression. Used by PresetBalanced. PresetUltimate uses the same engine
-// with an added root-state pre-filter (see newUltimateEngine).
+// link compression. Used by PresetBalanced.
 type balancedEngine struct {
 	banded *bandedDFA
-	bloom  *bloomFilter // root-state first-rune pre-filter; nil disables it (Balanced)
 	preset Preset
 }
 
@@ -34,23 +32,9 @@ func newBalancedEngine(bandDepth int) *balancedEngine {
 	}
 }
 
-// newUltimateEngine returns a balancedEngine with a root-state first-rune
-// pre-filter (a Bloom filter) that skips trie work for characters which cannot
-// start any keyword. The filter never yields false negatives, so match results
-// are identical to PresetBalanced.
-func newUltimateEngine(bandDepth int) *balancedEngine {
-	e := newBalancedEngine(bandDepth)
-	e.preset = PresetUltimate
-	return e
-}
-
 func (e *balancedEngine) buildFromKeywords(keywords map[string]struct{}) {
 	e.banded.dat.buildFromKeywords(keywords)
 	e.banded.buildDFABand()
-
-	if e.preset == PresetUltimate {
-		e.bloom = buildFirstRuneBloom(keywords)
-	}
 }
 
 func (bd *bandedDFA) buildDFABand() {
@@ -86,16 +70,11 @@ func (e *balancedEngine) find(text string) []string {
 		return []string{}
 	}
 	band := e.banded.dfaBand
-	bloom := e.bloom
 
 	matched := make([]string, 0)
 	state := datRootPos
 
 	for _, ch := range text {
-		if bloom != nil && bloom.skipAtRoot(state == datRootPos, ch) {
-			continue
-		}
-
 		code, ok := dat.code(ch)
 		if !ok {
 			state = datRootPos
@@ -129,18 +108,12 @@ func (e *balancedEngine) findIndex(text string) map[string][]int {
 		return map[string][]int{}
 	}
 	band := e.banded.dfaBand
-	bloom := e.bloom
 
 	matched := make(map[string][]int)
 	state := datRootPos
 	runeIndex := 0
 
 	for _, ch := range text {
-		if bloom != nil && bloom.skipAtRoot(state == datRootPos, ch) {
-			runeIndex++
-			continue
-		}
-
 		code, ok := dat.code(ch)
 		if !ok {
 			state = datRootPos
@@ -179,7 +152,6 @@ func (e *balancedEngine) matchStream(next func() (rune, bool), emit func(Match) 
 		return
 	}
 	band := e.banded.dfaBand
-	bloom := e.bloom
 
 	state := datRootPos
 	runeIndex := 0
@@ -188,10 +160,6 @@ func (e *balancedEngine) matchStream(next func() (rune, bool), emit func(Match) 
 		ch, ok := next()
 		if !ok {
 			return
-		}
-		if bloom != nil && bloom.skipAtRoot(state == datRootPos, ch) {
-			runeIndex++
-			continue
 		}
 
 		code, ok := dat.code(ch)
@@ -236,9 +204,6 @@ func (e *balancedEngine) info() *InMemoryInfo {
 		if row != nil {
 			mem += int64(len(row)) * 8
 		}
-	}
-	if e.bloom != nil {
-		mem += e.bloom.memoryBytes()
 	}
 	return &InMemoryInfo{
 		Keywords:    dat.keywordCount(),

--- a/internal/engine/engine_bench_test.go
+++ b/internal/engine/engine_bench_test.go
@@ -31,7 +31,6 @@ var benchPresets = []struct {
 	{"Speed", PresetSpeed},
 	{"Balanced", PresetBalanced},
 	{"MemoryEfficient", PresetMemoryEfficient},
-	{"Ultimate", PresetUltimate},
 }
 
 func benchmarkEngine(b *testing.B, findIndex bool) {

--- a/internal/engine/engine_dat.go
+++ b/internal/engine/engine_dat.go
@@ -6,7 +6,7 @@ import "slices"
 
 // doubleArrayTrie implements a Double-Array Trie using base[] and check[] arrays.
 // Provides O(1) state transitions with near hash-map memory efficiency.
-// Used by PresetBalanced and PresetUltimate.
+// Used by PresetBalanced.
 //
 // Position 0 is unused (sentinel); root is at position 1. This avoids the
 // ambiguity where check[pos]=0 could mean either "empty" or "parent is state 0".

--- a/internal/engine/engine_presets.go
+++ b/internal/engine/engine_presets.go
@@ -2,9 +2,9 @@
 
 package engine
 
-// defaultBandDepth is the trie depth at which Balanced/Ultimate DFA transitions
-// stop and NFA failure-link fallback takes over. Speed uses a full DFA and
-// MemoryEfficient a pure NFA, so neither consults this.
+// defaultBandDepth is the trie depth at which Balanced's DFA transitions stop and
+// NFA failure-link fallback takes over. Speed uses a full DFA and MemoryEfficient
+// a pure NFA, so neither consults it.
 const defaultBandDepth = 3
 
 // newMatchEngine creates the appropriate matchEngine implementation for the given preset.
@@ -14,8 +14,6 @@ func newMatchEngine(preset Preset) matchEngine {
 		return newSpeedEngine()
 	case PresetMemoryEfficient:
 		return newMemEfficientEngine()
-	case PresetUltimate:
-		return newUltimateEngine(defaultBandDepth)
 	case PresetNone, PresetBalanced, PresetDefault:
 		return newBalancedEngine(defaultBandDepth)
 	default:

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 // allPresets is every user-selectable preset. Optimizations must never change
-// match results, so every case below is asserted against all four.
-var allPresets = []Preset{PresetSpeed, PresetBalanced, PresetMemoryEfficient, PresetUltimate}
+// match results, so every case below is asserted against all three.
+var allPresets = []Preset{PresetSpeed, PresetBalanced, PresetMemoryEfficient}
 
 func keywordSet(kws ...string) map[string]struct{} {
 	m := make(map[string]struct{}, len(kws))

--- a/pkg/acor/engine_test.go
+++ b/pkg/acor/engine_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func allPresets() []Preset {
-	return []Preset{PresetSpeed, PresetBalanced, PresetMemoryEfficient, PresetUltimate}
+	return []Preset{PresetSpeed, PresetBalanced, PresetMemoryEfficient}
 }
 
 func createTestPreset(t testing.TB, preset Preset) *AhoCorasick {
@@ -381,19 +381,6 @@ func BenchmarkPresetFindBalanced(b *testing.B) {
 
 func BenchmarkPresetFindMemoryEfficient(b *testing.B) {
 	ac := createTestPreset(b, PresetMemoryEfficient)
-	b.Cleanup(func() { _ = ac.Close() })
-	for _, kw := range []string{"he", "she", "his", "hers", "hello", "world", "benchmark"} {
-		ac.Add(kw)
-	}
-	text := benchmarkInputText
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		ac.Find(text)
-	}
-}
-
-func BenchmarkPresetFindUltimate(b *testing.B) {
-	ac := createTestPreset(b, PresetUltimate)
 	b.Cleanup(func() { _ = ac.Close() })
 	for _, kw := range []string{"he", "she", "his", "hers", "hello", "world", "benchmark"} {
 		ac.Add(kw)

--- a/pkg/acor/preset.go
+++ b/pkg/acor/preset.go
@@ -26,8 +26,15 @@ const (
 	PresetBalanced = engine.PresetBalanced
 	// PresetMemoryEfficient minimizes memory usage (map-based sparse trie + Bloom).
 	PresetMemoryEfficient = engine.PresetMemoryEfficient
-	// PresetUltimate is Balanced plus a root-state first-rune pre-filter.
-	PresetUltimate = engine.PresetUltimate
+	// PresetUltimate is an alias for PresetBalanced. It used to add a root-state
+	// first-rune Bloom pre-filter, which measured 1.7-1.8x slower than Balanced on
+	// every benchmark in the repository, on ASCII and multibyte text alike: the
+	// per-character filter check cost more than the trie work it skipped, and it
+	// blocked the byte-scan fast path an ASCII dictionary can take. Existing code
+	// keeps compiling and now gets the faster engine.
+	//
+	// Deprecated: use PresetBalanced.
+	PresetUltimate = engine.PresetBalanced
 )
 
 // presetDefault is an internal sentinel (-1) meaning "unset"; it behaves

--- a/pkg/acor/redis_backed_test.go
+++ b/pkg/acor/redis_backed_test.go
@@ -80,7 +80,9 @@ func TestPresetAddFind(t *testing.T) {
 			want:     []string{"한글", "일본어"},
 		},
 		{
-			name:     "ultimate preset",
+			// Guards the deprecated PresetUltimate alias: it must keep resolving to a
+			// working engine, or code that still names it breaks silently.
+			name:     "deprecated ultimate alias",
 			preset:   PresetUltimate,
 			keywords: []string{"abc", "bc", "c"},
 			text:     "abc",
@@ -144,7 +146,7 @@ func TestPresetEmptyText(t *testing.T) {
 }
 
 func TestPresetAllPresets(t *testing.T) {
-	presets := []Preset{PresetSpeed, PresetBalanced, PresetMemoryEfficient, PresetUltimate}
+	presets := []Preset{PresetSpeed, PresetBalanced, PresetMemoryEfficient}
 	for _, preset := range presets {
 		t.Run(preset.String(), func(t *testing.T) {
 			ac := newTestPresetRedis(t, preset)


### PR DESCRIPTION
# Pull Request

## Description

`PresetUltimate` was `PresetBalanced` plus a root-state first-rune Bloom pre-filter
meant to skip characters that cannot start any keyword. The filter was never wrong
— it yields no false negatives — but it did not pay for itself: across every
benchmark in the repository it ran **1.7–1.8x slower** than `PresetBalanced`, on
ASCII and multibyte text alike. The per-character check cost more than the trie work
it saved. It also forced the scan onto the rune path, which blocks the byte-scan fast
path an ASCII dictionary can take.

`PresetUltimate` is now an alias for `PresetBalanced` and the filter is gone:

- `acor.PresetUltimate = engine.PresetBalanced`, marked `Deprecated:`. Code naming
  it keeps compiling and now gets the faster engine.
- `engine.PresetUltimate`, `newUltimateEngine` and `balancedEngine.bloom` are
  removed, along with the nil check the shared scan loop paid on every character.
  Dropping that check sped up `PresetBalanced` itself: `FindIndex` over 1000 ASCII
  keywords went **8,734 → 7,340 ns/op**.

`PresetMemoryEfficient` keeps its own Bloom pre-filter, which is used differently —
it filters at every state, not just the root — so `engine_bloom.go` stays.


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed — `preset-engine.md`, `api.md`, `redis-backed-engine.md`
- [x] Changelog fragment added (`changie new`) — `Changed-20260803-000001`
- [x] Commit messages follow guidelines

## Additional Notes

**Not a breaking change**, despite removing a preset: `acor.PresetUltimate` stays
exported and compiling as an alias, so no caller breaks. One Redis-backed test keeps
exercising the alias specifically so code still naming it cannot break silently.

Deliberately placed early in the stack: it is deletion-only, so landing it before the
engine rewrite means that PR does not have to carry the Bloom code through a scan-loop
restructure.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).
