### PR TITLE
perf: flatten the engine transition tables and store each keyword once

### DIFF
--- a/changes/unreleased/Changed-20260802-000005.yaml
+++ b/changes/unreleased/Changed-20260802-000005.yaml
@@ -1,17 +1,8 @@
 kind: Changed
 body: >-
-  Flattened the match engines' transition tables. PresetSpeed's full DFA and
-  PresetBalanced/PresetUltimate's banded DFA were slices of slices, costing the
-  scan a slice-header load and two bounds checks per character; they are now one
-  flat `[]int32` indexed by state and alphabet code, with a bit per entry saying
-  whether the target state carries keywords so the scan skips the output lookup
-  on a miss. Scans over a pure-ASCII dictionary also walk raw bytes instead of
-  decoding UTF-8 for the queries that report no offsets (`Find`, `FindSet`,
-  `Contains`). At 1000 keywords, PresetSpeed `FindSet` goes 1,681 to 1,030 ns/op
-  and PresetBalanced 2,225 to 1,083; positioned `FindMatches` on PresetSpeed goes
-  2,663 to 1,852 ns/op, which is now faster than
-  `petar-dambovaliev/aho-corasick`. A dictionary too large for the packing keeps
-  working on the unpacked path
+  Flattened and packed the DFA transition tables to reduce per-character lookup
+  overhead across presets. `Find`, `FindSet`, and `Contains` also scan raw bytes
+  for ASCII-only dictionaries, improving common matching paths
 time: 2026-08-02T12:00:00.000000+09:00
 custom:
     Issue: "187"

--- a/changes/unreleased/Changed-20260802-000005.yaml
+++ b/changes/unreleased/Changed-20260802-000005.yaml
@@ -1,0 +1,17 @@
+kind: Changed
+body: >-
+  Flattened the match engines' transition tables. PresetSpeed's full DFA and
+  PresetBalanced/PresetUltimate's banded DFA were slices of slices, costing the
+  scan a slice-header load and two bounds checks per character; they are now one
+  flat `[]int32` indexed by state and alphabet code, with a bit per entry saying
+  whether the target state carries keywords so the scan skips the output lookup
+  on a miss. Scans over a pure-ASCII dictionary also walk raw bytes instead of
+  decoding UTF-8 for the queries that report no offsets (`Find`, `FindSet`,
+  `Contains`). At 1000 keywords, PresetSpeed `FindSet` goes 1,681 to 1,030 ns/op
+  and PresetBalanced 2,225 to 1,083; positioned `FindMatches` on PresetSpeed goes
+  2,663 to 1,852 ns/op, which is now faster than
+  `petar-dambovaliev/aho-corasick`. A dictionary too large for the packing keeps
+  working on the unpacked path
+time: 2026-08-02T12:00:00.000000+09:00
+custom:
+    Issue: "187"

--- a/changes/unreleased/Changed-20260804-000001.yaml
+++ b/changes/unreleased/Changed-20260804-000001.yaml
@@ -1,16 +1,8 @@
 kind: Changed
 body: >-
-  Every preset now stores each keyword once and links suffix matches instead of
-  merging them. The build used to copy a state's whole output list into every state
-  that failed to it, which is O(n^2) on a suffix-nested dictionary: 500 keywords
-  where each is a suffix of the next produced 125,250 stored entries (about 2 MB of
-  string headers) where 500 suffice. Each state now holds only the keyword ending
-  there plus a link to the next keyword-carrying state on its failure path, so
-  storage is linear in the dictionary regardless of nesting. `PresetBalanced`'s
-  documented "output link compression" now describes what the code does. Match
-  results are unchanged, including the order overlapping matches are reported in.
-  Measured at 1000 keywords over a 640 B text, `FindMatches` went 2,184 to 1,678
-  ns/op on `PresetSpeed` and 2,580 to 2,126 on `PresetBalanced`
+  Every preset now stores each keyword once and follows output links for suffix
+  matches. This keeps output storage linear for suffix-nested dictionaries while
+  preserving match results and order
 time: 2026-08-04T10:00:00.000000+09:00
 custom:
     Issue: "187"

--- a/changes/unreleased/Changed-20260804-000001.yaml
+++ b/changes/unreleased/Changed-20260804-000001.yaml
@@ -1,0 +1,16 @@
+kind: Changed
+body: >-
+  Every preset now stores each keyword once and links suffix matches instead of
+  merging them. The build used to copy a state's whole output list into every state
+  that failed to it, which is O(n^2) on a suffix-nested dictionary: 500 keywords
+  where each is a suffix of the next produced 125,250 stored entries (about 2 MB of
+  string headers) where 500 suffice. Each state now holds only the keyword ending
+  there plus a link to the next keyword-carrying state on its failure path, so
+  storage is linear in the dictionary regardless of nesting. `PresetBalanced`'s
+  documented "output link compression" now describes what the code does. Match
+  results are unchanged, including the order overlapping matches are reported in.
+  Measured at 1000 keywords over a 640 B text, `FindMatches` went 2,184 to 1,678
+  ns/op on `PresetSpeed` and 2,580 to 2,126 on `PresetBalanced`
+time: 2026-08-04T10:00:00.000000+09:00
+custom:
+    Issue: "187"

--- a/changes/unreleased/Fixed-20260804-000003.yaml
+++ b/changes/unreleased/Fixed-20260804-000003.yaml
@@ -1,11 +1,7 @@
 kind: Fixed
 body: >-
-  `Info().TrieDepth` reported 0 on `PresetSpeed`. That engine computed each node's
-  depth while building the trie and then dropped it instead of recording the
-  maximum, so the field was silently zero for the whole preset while the other two
-  reported it correctly. It is now populated, and recomputed from scratch on every
-  rebuild so a smaller dictionary reports a smaller depth rather than keeping the
-  previous maximum
+  `Info().TrieDepth` now reports the correct value for `PresetSpeed` and is
+  recomputed on every rebuild
 time: 2026-08-04T10:00:02.000000+09:00
 custom:
     Issue: "187"

--- a/changes/unreleased/Fixed-20260804-000003.yaml
+++ b/changes/unreleased/Fixed-20260804-000003.yaml
@@ -1,0 +1,11 @@
+kind: Fixed
+body: >-
+  `Info().TrieDepth` reported 0 on `PresetSpeed`. That engine computed each node's
+  depth while building the trie and then dropped it instead of recording the
+  maximum, so the field was silently zero for the whole preset while the other two
+  reported it correctly. It is now populated, and recomputed from scratch on every
+  rebuild so a smaller dictionary reports a smaller depth rather than keeping the
+  previous maximum
+time: 2026-08-04T10:00:02.000000+09:00
+custom:
+    Issue: "187"

--- a/internal/engine/coder.go
+++ b/internal/engine/coder.go
@@ -5,8 +5,7 @@ package engine
 import "unicode/utf8"
 
 // alphabetCoder maps runes to compact alphabet indices with an ASCII fast path.
-// It is embedded by both the Speed (flat) and Balanced (DAT) engines,
-// which resolve nearly every input character to an index and must agree on the
+// The Speed (flat) and Balanced (DAT) engines both embed it so they share one
 // encoding.
 type alphabetCoder struct {
 	index map[rune]int
@@ -14,18 +13,48 @@ type alphabetCoder struct {
 	// alphabet, asciiCode[r] = index+1 (0 means "not in alphabet"), avoiding a map
 	// hash on nearly every character.
 	asciiCode [128]int32
+	// asciiOnly reports whether every alphabet rune is ASCII. Scans that report no
+	// offsets can then walk raw bytes instead of decoding UTF-8.
+	asciiOnly bool
 }
 
 // build populates the coder from the sorted alphabet runes.
 func (c *alphabetCoder) build(runes []rune) {
 	c.index = make(map[rune]int, len(runes))
 	c.asciiCode = [128]int32{}
+	c.asciiOnly = true
 	for i, r := range runes {
 		c.index[r] = i
 		if r < utf8.RuneSelf {
 			c.asciiCode[r] = int32(i) + 1
+		} else {
+			c.asciiOnly = false
 		}
 	}
+}
+
+// runeLen returns kw's length in runes, used to derive a match's start offset
+// from its end offset.
+//
+// When the alphabet is ASCII-only every keyword is pure ASCII, so its byte length
+// is its rune length. Skipping utf8.RuneCountInString here is worth 9% on
+// matchString over 1000 ASCII keywords, since it runs once per emitted match.
+func runeLen(kw string, asciiOnly bool) int {
+	if asciiOnly {
+		return len(kw)
+	}
+	return utf8.RuneCountInString(kw)
+}
+
+// codeByte resolves a raw byte to its alphabet index. Valid only when asciiOnly
+// is set: a byte >= utf8.RuneSelf then belongs to a rune outside the alphabet, so
+// reporting it absent matches what the rune path does.
+func (c *alphabetCoder) codeByte(b byte) (int, bool) {
+	if b >= utf8.RuneSelf {
+		return 0, false
+	}
+	x := c.asciiCode[b]
+	return int(x) - 1, x != 0
 }
 
 // code resolves a rune to its alphabet index via the ASCII fast path, falling

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -83,9 +83,13 @@ type matchEngine interface {
 	findIndex(text string) map[string][]int
 	// matchStream pulls runes from next until it returns ok=false, emitting every
 	// match (overlaps included) to emit in scan order. It stops early if emit
-	// returns false. This is the shared traversal behind FindMatches, Contains,
-	// and streaming; find/findIndex keep their own tight loops to avoid the
-	// per-rune closure overhead on those hot paths.
+	// returns false. This is the traversal behind streaming, where input arrives
+	// from an io.Reader and there is no string to range over.
 	matchStream(next func() (rune, bool), emit func(Match) bool)
+	// matchString is matchStream over a string already in memory. The pull closure
+	// costs an indirect call per rune, which made FindMatches ~2.9x slower than
+	// find over the same text while it routed through matchStream. Semantics are
+	// identical; only the rune source differs.
+	matchString(text string, emit func(Match) bool)
 	info() *InMemoryInfo
 }

--- a/internal/engine/engine_banded_dfa.go
+++ b/internal/engine/engine_banded_dfa.go
@@ -2,15 +2,38 @@
 
 package engine
 
-import "unicode/utf8"
+import (
+	"math"
+)
 
 // bandedDFA wraps a Double-Array Trie with precomputed DFA transitions for
 // states at shallow depth (band). States beyond the band use standard NFA.
+//
+// The band is one flat slice rather than a slice per state: a [][]int cost the
+// scan loop a slice-header load plus two bounds checks per character, where a
+// flat []int32 indexed by a per-state offset costs two loads and one branch and
+// fits in far fewer cache lines.
 type bandedDFA struct {
-	dat       *doubleArrayTrie
-	dfaBand   [][]int
+	dat *doubleArrayTrie
+	// band holds the DFA rows back to back. For a banded state s the row starts at
+	// bandOff[s], so band[bandOff[s]+code] is the next state, with hasOutputBit set
+	// when that state has outputs. The scan can then skip the output lookup on the
+	// common miss.
+	band []int32
+	// bandOff[s] is s's row offset, or bandNotBanded when s is outside the band
+	// and has to fall back to the NFA walk.
+	bandOff   []int32
 	bandDepth int
 }
+
+const (
+	// hasOutputBit is packed into a band entry alongside the target state. States
+	// are double-array positions, which stay far below 1<<30 for any realistic
+	// dictionary.
+	hasOutputBit int32 = 1 << 30
+	// bandNotBanded marks a state with no precomputed DFA row.
+	bandNotBanded int32 = -1
+)
 
 // Compile-time check that balancedEngine satisfies matchEngine.
 var _ matchEngine = (*balancedEngine)(nil)
@@ -35,33 +58,98 @@ func newBalancedEngine(bandDepth int) *balancedEngine {
 func (e *balancedEngine) buildFromKeywords(keywords map[string]struct{}) {
 	e.banded.dat.buildFromKeywords(keywords)
 	e.banded.buildDFABand()
+	// depth is only used to select the band, and maxDepth reads the value recorded
+	// during the build, so releasing it saves 4 bytes per state.
+	e.banded.dat.depth = nil
 }
 
 func (bd *bandedDFA) buildDFABand() {
 	dat := bd.dat
 	if dat.size <= datRootPos+1 {
-		bd.dfaBand = nil
+		bd.band, bd.bandOff = nil, nil
 		return
 	}
 
 	alphaSize := len(dat.runes)
-	bd.dfaBand = make([][]int, dat.size)
+	bd.bandOff = make([]int32, dat.size)
+	for s := range bd.bandOff {
+		bd.bandOff[s] = bandNotBanded
+	}
 
+	// State ids share an int32 with hasOutputBit, and row offsets must index an
+	// int32-addressed slice. A dictionary too large for either bound still works:
+	// it runs entirely on the NFA path, which needs no packing. Every int32
+	// conversion below is inside this guard.
+	rows := bandRows(dat, bd.bandDepth)
+	if dat.size >= int(hasOutputBit) || alphaSize == 0 || rows > math.MaxInt32/alphaSize {
+		bd.band = nil
+		return
+	}
+
+	// Assign row offsets in the same pass that fills them: a running counter is all
+	// a separate pass would compute.
+	bd.band = make([]int32, rows*alphaSize)
+	off := int32(0)
 	for s := datRootPos; s < dat.size; s++ {
-		// Skip empty double-array slots (gaps in the packing): they are not real
-		// states, are never reached at match time, and have fail=0 — which would
-		// send followFailByCode into an infinite loop walking fail[0]=0.
-		if s != datRootPos && dat.check[s] == 0 {
+		if !inBand(dat, s, bd.bandDepth) {
 			continue
 		}
-		if dat.depth[s] > bd.bandDepth {
-			continue
-		}
-		bd.dfaBand[s] = make([]int, alphaSize)
+		bd.bandOff[s] = off
 		for ai := range dat.runes {
-			bd.dfaBand[s][ai] = dat.followFailByCode(s, ai)
+			next := dat.followFailByCode(s, ai)
+			entry := int32(next) //nolint:gosec // G115: dat.size < hasOutputBit per the guard.
+			if next < len(dat.hasOutput) && dat.hasOutput[next] {
+				entry |= hasOutputBit
+			}
+			bd.band[off+int32(ai)] = entry //nolint:gosec // G115: ai < alphaSize, bounded above.
+		}
+		off += int32(alphaSize) //nolint:gosec // G115: rows*alphaSize fits int32 per the guard.
+	}
+}
+
+// inBand reports whether state s gets a precomputed DFA row.
+//
+// The check[s] == 0 test skips empty double-array slots (gaps in the packing).
+// They are not real states and are never reached at match time, and their fail=0
+// would send followFailByCode into an infinite loop.
+func inBand(dat *doubleArrayTrie, s, bandDepth int) bool {
+	if s != datRootPos && dat.check[s] == 0 {
+		return false
+	}
+	return int(dat.depth[s]) <= bandDepth
+}
+
+// bandRows counts the rows inBand grants, so the caller can check the size before
+// allocating.
+func bandRows(dat *doubleArrayTrie, bandDepth int) int {
+	rows := 0
+	for s := datRootPos; s < dat.size; s++ {
+		if inBand(dat, s, bandDepth) {
+			rows++
 		}
 	}
+	return rows
+}
+
+// step advances one character, returning the next state and whether it carries
+// outputs. Callers then test one bool instead of indexing the output table on
+// every character.
+//
+// Kept small enough to inline: it is the whole per-character cost of a scan.
+func (bd *bandedDFA) step(state, code int) (int, bool) {
+	if off := bd.bandOff[state]; off != bandNotBanded {
+		entry := bd.band[off+int32(code)] //nolint:gosec // G115: code < alphaSize, bounded at build.
+		return int(entry &^ hasOutputBit), entry&hasOutputBit != 0
+	}
+	dat := bd.dat
+	next := dat.gotoStateByCode(state, code)
+	if next == 0 {
+		next = dat.followFailByCode(state, code)
+	}
+	if next == 0 {
+		next = datRootPos
+	}
+	return next, next < len(dat.hasOutput) && dat.hasOutput[next]
 }
 
 func (e *balancedEngine) find(text string) []string {
@@ -69,37 +157,115 @@ func (e *balancedEngine) find(text string) []string {
 	if dat.size <= datRootPos+1 {
 		return []string{}
 	}
-	band := e.banded.dfaBand
 
-	matched := make([]string, 0)
+	// Left nil until something matches: text matching nothing is the common case
+	// for a filter, and preallocating made that path allocate for nothing.
+	var matched []string
+	collect := func(state int) bool {
+		if matched == nil {
+			// Take the whole starting capacity at the first hit instead of letting
+			// append regrow 1,2,4,8. Lazy allocation is for the no-match path and
+			// should not cost the matching one.
+			matched = make([]string, 0, findResultHint)
+		}
+		for s := state; s != outNone; s = int(dat.outLink[s]) {
+			if kw := dat.own[s]; kw != "" {
+				matched = append(matched, kw)
+			}
+		}
+		return true
+	}
+
+	e.scan(text, collect)
+	if matched == nil {
+		// Find never returns nil. A zero-length literal costs no allocation, so the
+		// no-match path stays allocation-free.
+		return []string{}
+	}
+	return matched
+}
+
+// findSet reports which keywords appear, without one entry per occurrence. The
+// dedup bookkeeping lives in setCollector, shared with speedEngine; see it for
+// why the small case scans instead of hashing.
+//
+// Skipping the per-occurrence slice makes this 1.8x faster than Engine.FindSet's
+// generic matchString path at 1000 keywords over a 2.5 KB text (3,434 vs 6,347 ns
+// ASCII; 3,427 vs 7,045 multibyte).
+func (e *balancedEngine) findSet(text string) []string {
+	dat := e.banded.dat
+	if dat.size <= datRootPos+1 {
+		return []string{}
+	}
+
+	var c setCollector
+	e.scan(text, func(state int) bool {
+		if c.addState(state) {
+			for s := state; s != outNone; s = int(dat.outLink[s]) {
+				if kw := dat.own[s]; kw != "" {
+					c.addKeyword(kw)
+				}
+			}
+		}
+		return true
+	})
+	return c.result()
+}
+
+// scan walks text and calls onOutput for every state carrying keywords, stopping
+// when onOutput returns false. It reports whether it stopped early, which is all
+// a presence check needs, and reports no offsets, which lets the ASCII path walk
+// raw bytes.
+//
+// onOutput is one indirect call per matching state, not per character, so it stays
+// off the hot path. That is also why contains shares this loop: its callback
+// captures nothing and so is not heap-boxed.
+func (e *balancedEngine) scan(text string, onOutput func(state int) bool) bool {
+	dat := e.banded.dat
+	bd := e.banded
 	state := datRootPos
 
+	// Byte scan when the dictionary is pure ASCII. Every byte of a multibyte rune
+	// is >= utf8.RuneSelf and so cannot be in the alphabet, so it resets to root
+	// just as the rune scan does for a rune outside the alphabet: same states, same
+	// matches, without decoding UTF-8.
+	if dat.asciiOnly {
+		for i := 0; i < len(text); i++ {
+			code, ok := dat.codeByte(text[i])
+			if !ok {
+				state = datRootPos
+				continue
+			}
+			next, hasOut := bd.step(state, code)
+			state = next
+			if hasOut && !onOutput(state) {
+				return true
+			}
+		}
+		return false
+	}
 	for _, ch := range text {
 		code, ok := dat.code(ch)
 		if !ok {
 			state = datRootPos
 			continue
 		}
-
-		if band[state] != nil {
-			state = band[state][code]
-		} else {
-			if next := dat.gotoStateByCode(state, code); next != 0 {
-				state = next
-			} else {
-				state = dat.followFailByCode(state, code)
-			}
-		}
-		if state == 0 {
-			state = datRootPos
-		}
-
-		if state < len(dat.output) && len(dat.output[state]) > 0 {
-			matched = append(matched, dat.output[state]...)
+		next, hasOut := bd.step(state, code)
+		state = next
+		if hasOut && !onOutput(state) {
+			return true
 		}
 	}
+	return false
+}
 
-	return matched
+// contains reports presence and stops at the first hit. Its callback captures no
+// variables, so it allocates nothing; see Engine.Contains for the generic path.
+func (e *balancedEngine) contains(text string) bool {
+	if e.banded.dat.size <= datRootPos+1 {
+		return false
+	}
+	return e.scan(text, func(int) bool { return false })
 }
 
 func (e *balancedEngine) findIndex(text string) map[string][]int {
@@ -107,12 +273,11 @@ func (e *balancedEngine) findIndex(text string) map[string][]int {
 	if dat.size <= datRootPos+1 {
 		return map[string][]int{}
 	}
-	band := e.banded.dfaBand
+	bd := e.banded
 
 	matched := make(map[string][]int)
 	state := datRootPos
 	runeIndex := 0
-
 	for _, ch := range text {
 		code, ok := dat.code(ch)
 		if !ok {
@@ -121,29 +286,61 @@ func (e *balancedEngine) findIndex(text string) map[string][]int {
 			continue
 		}
 
-		if band[state] != nil {
-			state = band[state][code]
-		} else {
-			if next := dat.gotoStateByCode(state, code); next != 0 {
-				state = next
-			} else {
-				state = dat.followFailByCode(state, code)
-			}
-		}
-		if state == 0 {
-			state = datRootPos
-		}
-
+		next, out := bd.step(state, code)
+		state = next
 		runeIndex++
-		if state < len(dat.output) {
-			for _, out := range dat.output[state] {
-				startIdx := runeIndex - utf8.RuneCountInString(out)
-				matched[out] = append(matched[out], startIdx)
+		if !out {
+			continue
+		}
+		for s := state; s != outNone; s = int(dat.outLink[s]) {
+			kw := dat.own[s]
+			if kw == "" {
+				continue
 			}
+			startIdx := runeIndex - runeLen(kw, dat.asciiOnly)
+			matched[kw] = append(matched[kw], startIdx)
 		}
 	}
 
 	return matched
+}
+
+// matchString is matchStream with the runes read straight off the string. The
+// loop body deliberately duplicates matchStream's instead of sharing a helper
+// that takes a step closure, which would reintroduce the indirect call per rune.
+func (e *balancedEngine) matchString(text string, emit func(Match) bool) {
+	dat := e.banded.dat
+	if dat.size <= datRootPos+1 {
+		return
+	}
+	bd := e.banded
+
+	state := datRootPos
+	runeIndex := 0
+	for _, ch := range text {
+		code, ok := dat.code(ch)
+		if !ok {
+			state = datRootPos
+			runeIndex++
+			continue
+		}
+
+		next, hasOut := bd.step(state, code)
+		state = next
+		runeIndex++
+		if hasOut {
+			for s := state; s != outNone; s = int(dat.outLink[s]) {
+				out := dat.own[s]
+				if out == "" {
+					continue
+				}
+				start := runeIndex - runeLen(out, dat.asciiOnly)
+				if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
+					return
+				}
+			}
+		}
+	}
 }
 
 func (e *balancedEngine) matchStream(next func() (rune, bool), emit func(Match) bool) {
@@ -151,7 +348,7 @@ func (e *balancedEngine) matchStream(next func() (rune, bool), emit func(Match) 
 	if dat.size <= datRootPos+1 {
 		return
 	}
-	band := e.banded.dfaBand
+	bd := e.banded
 
 	state := datRootPos
 	runeIndex := 0
@@ -161,7 +358,6 @@ func (e *balancedEngine) matchStream(next func() (rune, bool), emit func(Match) 
 		if !ok {
 			return
 		}
-
 		code, ok := dat.code(ch)
 		if !ok {
 			state = datRootPos
@@ -169,26 +365,20 @@ func (e *balancedEngine) matchStream(next func() (rune, bool), emit func(Match) 
 			continue
 		}
 
-		if band[state] != nil {
-			state = band[state][code]
-		} else {
-			if nx := dat.gotoStateByCode(state, code); nx != 0 {
-				state = nx
-			} else {
-				state = dat.followFailByCode(state, code)
-			}
-		}
-		if state == 0 {
-			state = datRootPos
-		}
-
+		nx, hasOut := bd.step(state, code)
+		state = nx
 		runeIndex++
-		if state < len(dat.output) {
-			for _, out := range dat.output[state] {
-				start := runeIndex - utf8.RuneCountInString(out)
-				if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
-					return
-				}
+		if !hasOut {
+			continue
+		}
+		for s := state; s != outNone; s = int(dat.outLink[s]) {
+			out := dat.own[s]
+			if out == "" {
+				continue
+			}
+			start := runeIndex - runeLen(out, dat.asciiOnly)
+			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
+				return
 			}
 		}
 	}
@@ -200,11 +390,8 @@ func (e *balancedEngine) info() *InMemoryInfo {
 		return &InMemoryInfo{Preset: e.preset}
 	}
 	mem := dat.memoryBytes()
-	for _, row := range e.banded.dfaBand {
-		if row != nil {
-			mem += int64(len(row)) * 8
-		}
-	}
+	mem += int64(len(e.banded.band)) * 4
+	mem += int64(len(e.banded.bandOff)) * 4
 	return &InMemoryInfo{
 		Keywords:    dat.keywordCount(),
 		Nodes:       dat.size - datRootPos,

--- a/internal/engine/engine_banded_dfa.go
+++ b/internal/engine/engine_banded_dfa.go
@@ -27,10 +27,6 @@ type bandedDFA struct {
 }
 
 const (
-	// hasOutputBit is packed into a band entry alongside the target state. States
-	// are double-array positions, which stay far below 1<<30 for any realistic
-	// dictionary.
-	hasOutputBit int32 = 1 << 30
 	// bandNotBanded marks a state with no precomputed DFA row.
 	bandNotBanded int32 = -1
 )
@@ -97,11 +93,7 @@ func (bd *bandedDFA) buildDFABand() {
 		bd.bandOff[s] = off
 		for ai := range dat.runes {
 			next := dat.followFailByCode(s, ai)
-			entry := int32(next) //nolint:gosec // G115: dat.size < hasOutputBit per the guard.
-			if next < len(dat.hasOutput) && dat.hasOutput[next] {
-				entry |= hasOutputBit
-			}
-			bd.band[off+int32(ai)] = entry //nolint:gosec // G115: ai < alphaSize, bounded above.
+			bd.band[off+int32(ai)] = packState(next, next < len(dat.hasOutput) && dat.hasOutput[next]) //nolint:gosec // G115: ai < alphaSize, bounded above.
 		}
 		off += int32(alphaSize) //nolint:gosec // G115: rows*alphaSize fits int32 per the guard.
 	}
@@ -162,17 +154,7 @@ func (e *balancedEngine) find(text string) []string {
 	// for a filter, and preallocating made that path allocate for nothing.
 	var matched []string
 	collect := func(state int) bool {
-		if matched == nil {
-			// Take the whole starting capacity at the first hit instead of letting
-			// append regrow 1,2,4,8. Lazy allocation is for the no-match path and
-			// should not cost the matching one.
-			matched = make([]string, 0, findResultHint)
-		}
-		for s := state; s != outNone; s = int(dat.outLink[s]) {
-			if kw := dat.own[s]; kw != "" {
-				matched = append(matched, kw)
-			}
-		}
+		matched = appendOutputChain(matched, state, dat.own, dat.outLink)
 		return true
 	}
 
@@ -200,13 +182,7 @@ func (e *balancedEngine) findSet(text string) []string {
 
 	var c setCollector
 	e.scan(text, func(state int) bool {
-		if c.addState(state) {
-			for s := state; s != outNone; s = int(dat.outLink[s]) {
-				if kw := dat.own[s]; kw != "" {
-					c.addKeyword(kw)
-				}
-			}
-		}
+		collectOutputChain(&c, state, dat.own, dat.outLink)
 		return true
 	})
 	return c.result()
@@ -292,14 +268,7 @@ func (e *balancedEngine) findIndex(text string) map[string][]int {
 		if !out {
 			continue
 		}
-		for s := state; s != outNone; s = int(dat.outLink[s]) {
-			kw := dat.own[s]
-			if kw == "" {
-				continue
-			}
-			startIdx := runeIndex - runeLen(kw, dat.asciiOnly)
-			matched[kw] = append(matched[kw], startIdx)
-		}
+		indexOutputChain(matched, state, runeIndex, dat.own, dat.outLink, dat.asciiOnly)
 	}
 
 	return matched
@@ -328,17 +297,8 @@ func (e *balancedEngine) matchString(text string, emit func(Match) bool) {
 		next, hasOut := bd.step(state, code)
 		state = next
 		runeIndex++
-		if hasOut {
-			for s := state; s != outNone; s = int(dat.outLink[s]) {
-				out := dat.own[s]
-				if out == "" {
-					continue
-				}
-				start := runeIndex - runeLen(out, dat.asciiOnly)
-				if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
-					return
-				}
-			}
+		if hasOut && !emitOutputChain(state, runeIndex, dat.own, dat.outLink, dat.asciiOnly, emit) {
+			return
 		}
 	}
 }
@@ -371,15 +331,8 @@ func (e *balancedEngine) matchStream(next func() (rune, bool), emit func(Match) 
 		if !hasOut {
 			continue
 		}
-		for s := state; s != outNone; s = int(dat.outLink[s]) {
-			out := dat.own[s]
-			if out == "" {
-				continue
-			}
-			start := runeIndex - runeLen(out, dat.asciiOnly)
-			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
-				return
-			}
+		if !emitOutputChain(state, runeIndex, dat.own, dat.outLink, dat.asciiOnly, emit) {
+			return
 		}
 	}
 }

--- a/internal/engine/engine_dat.go
+++ b/internal/engine/engine_dat.go
@@ -274,7 +274,7 @@ func (dat *doubleArrayTrie) computeFailLinks() {
 			// of copying its outputs in. The fail target is strictly shallower and
 			// this BFS visits by depth, so its outLink is already final.
 			if f := int(dat.fail[next]); dat.own[f] != "" {
-				dat.outLink[next] = int32(f) //nolint:gosec // G115: dat.size is bounded by hasOutputBit at band build.
+				dat.outLink[next] = int32(f) //nolint:gosec // G115: DAT state ids use int32 throughout.
 			} else {
 				dat.outLink[next] = dat.outLink[f]
 			}

--- a/internal/engine/engine_dat.go
+++ b/internal/engine/engine_dat.go
@@ -11,14 +11,33 @@ import "slices"
 // Position 0 is unused (sentinel); root is at position 1. This avoids the
 // ambiguity where check[pos]=0 could mean either "empty" or "parent is state 0".
 type doubleArrayTrie struct {
-	base   []int
-	check  []int
-	fail   []int
-	output [][]string
-	depth  []int
-	size   int
-	cap    int
-	runes  []rune
+	// base, check and fail are int32 rather than int: three arrays cost 12 bytes per
+	// state instead of 24. Overflowing int32 would need over 8 GiB of double-array,
+	// so the allocation fails first.
+	base  []int32
+	check []int32
+	fail  []int32
+	// own[s] is the keyword ending at s, or "" for none, and outLink[s] chains to
+	// the next keyword-carrying state along the failure path (outNone at the end).
+	// They replace an eagerly merged [][]string, which copied each state's whole
+	// suffix output list into every state failing to it: O(n^2) on a suffix-nested
+	// dictionary, where 500 keywords produced 125,250 entries against the chain's
+	// 500.
+	own     []string
+	outLink []int32
+	// hasOutput[s] reports whether s or its output chain carries a keyword. Banded
+	// states pack the same fact into their transition entry, so this array serves
+	// the states below the band — the majority once keywords run longer than
+	// bandDepth (3) — where one []bool load replaces walking the chain.
+	hasOutput []bool
+	// depth drives band selection at build time and nothing after it, so
+	// balancedEngine.buildFromKeywords releases it once the band is chosen.
+	// trieDepth keeps the one value Info still needs.
+	depth     []int32
+	trieDepth int
+	size      int
+	cap       int
+	runes     []rune
 	alphabetCoder
 }
 
@@ -29,10 +48,10 @@ const (
 
 func newDoubleArrayTrie() *doubleArrayTrie {
 	return &doubleArrayTrie{
-		base:  make([]int, datInitialCap),
-		check: make([]int, datInitialCap),
-		fail:  make([]int, datInitialCap),
-		depth: make([]int, datInitialCap),
+		base:  make([]int32, datInitialCap),
+		check: make([]int32, datInitialCap),
+		fail:  make([]int32, datInitialCap),
+		depth: make([]int32, datInitialCap),
 		cap:   datInitialCap,
 		size:  datRootPos + 1,
 	}
@@ -40,10 +59,10 @@ func newDoubleArrayTrie() *doubleArrayTrie {
 
 func (dat *doubleArrayTrie) expand() {
 	newCap := dat.cap * 2
-	newBase := make([]int, newCap)
-	newCheck := make([]int, newCap)
-	newFail := make([]int, newCap)
-	newDepth := make([]int, newCap)
+	newBase := make([]int32, newCap)
+	newCheck := make([]int32, newCap)
+	newFail := make([]int32, newCap)
+	newDepth := make([]int32, newCap)
 	copy(newBase, dat.base)
 	copy(newCheck, dat.check)
 	copy(newFail, dat.fail)
@@ -62,13 +81,16 @@ func (dat *doubleArrayTrie) ensureCapacity(needed int) {
 }
 
 func (dat *doubleArrayTrie) buildFromKeywords(keywords map[string]struct{}) { //nolint:gocyclo,funlen
-	dat.base = make([]int, datInitialCap)
-	dat.check = make([]int, datInitialCap)
-	dat.fail = make([]int, datInitialCap)
-	dat.depth = make([]int, datInitialCap)
+	dat.base = make([]int32, datInitialCap)
+	dat.check = make([]int32, datInitialCap)
+	dat.fail = make([]int32, datInitialCap)
+	dat.depth = make([]int32, datInitialCap)
 	dat.cap = datInitialCap
 	dat.size = datRootPos + 1
-	dat.output = nil
+	dat.own, dat.outLink = nil, nil
+	// Reset with the arrays: Build reconstructs the automaton, so a rebuild from
+	// shorter keywords must not keep the old maximum.
+	dat.trieDepth = 0
 
 	runeSet := make(map[rune]struct{})
 	for kw := range keywords {
@@ -84,11 +106,17 @@ func (dat *doubleArrayTrie) buildFromKeywords(keywords map[string]struct{}) { //
 	dat.build(dat.runes)
 
 	tmpChildren := make(map[int]map[rune]int)
-	tmpOutput := make(map[int][]string)
+	tmpOwn := make(map[int]string)
 	nextID := 1
 	tmpChildren[0] = make(map[rune]int)
 
 	for kw := range keywords {
+		// An empty keyword would end at the root, where own == "" already means "no
+		// keyword". The public API rejects empty keywords; skipping keeps this trie
+		// correct on its own.
+		if kw == "" {
+			continue
+		}
 		cur := 0
 		for _, ch := range kw {
 			if _, ok := tmpChildren[cur][ch]; !ok {
@@ -101,7 +129,7 @@ func (dat *doubleArrayTrie) buildFromKeywords(keywords map[string]struct{}) { //
 			}
 			cur = tmpChildren[cur][ch]
 		}
-		tmpOutput[cur] = append(tmpOutput[cur], kw)
+		tmpOwn[cur] = kw
 	}
 
 	dat.ensureCapacity(nextID + 2)
@@ -131,22 +159,25 @@ func (dat *doubleArrayTrie) buildFromKeywords(keywords map[string]struct{}) { //
 		}
 
 		base := dat.findBase(codes)
-		dat.base[datPos[parent]] = base
+		dat.base[datPos[parent]] = int32(base) //nolint:gosec // G115: see the int32 note on the fields.
 
 		for ch, childID := range children {
 			code := dat.index[ch]
 			pos := base + code
 			dat.ensureCapacity(pos + 1)
 
-			dat.check[pos] = datPos[parent]
+			dat.check[pos] = int32(datPos[parent]) //nolint:gosec // G115: as above.
 			dat.depth[pos] = dat.depth[datPos[parent]] + 1
+			if d := int(dat.depth[pos]); d > dat.trieDepth {
+				dat.trieDepth = d
+			}
 			datPos[childID] = pos
 
-			if outs, ok := tmpOutput[childID]; ok && len(outs) > 0 {
-				for pos >= len(dat.output) {
-					dat.output = append(dat.output, nil)
+			if kw, ok := tmpOwn[childID]; ok && kw != "" {
+				for pos >= len(dat.own) {
+					dat.own = append(dat.own, "")
 				}
-				dat.output[pos] = outs
+				dat.own[pos] = kw
 			}
 
 			if pos >= dat.size {
@@ -162,13 +193,23 @@ func (dat *doubleArrayTrie) buildFromKeywords(keywords map[string]struct{}) { //
 	dat.fail = dat.fail[:dat.size]
 	dat.depth = dat.depth[:dat.size]
 
-	if len(dat.output) < dat.size {
-		newOut := make([][]string, dat.size)
-		copy(newOut, dat.output)
-		dat.output = newOut
+	if len(dat.own) < dat.size {
+		newOwn := make([]string, dat.size)
+		copy(newOwn, dat.own)
+		dat.own = newOwn
 	}
 
+	dat.outLink = make([]int32, dat.size)
+	for s := range dat.outLink {
+		dat.outLink[s] = outNone
+	}
 	dat.computeFailLinks()
+
+	// Derived after the fail links, which fill the output chain.
+	dat.hasOutput = make([]bool, dat.size)
+	for s := 0; s < dat.size; s++ {
+		dat.hasOutput[s] = dat.own[s] != "" || dat.outLink[s] != outNone
+	}
 }
 
 func (dat *doubleArrayTrie) findBase(codes []int) int {
@@ -228,33 +269,38 @@ func (dat *doubleArrayTrie) computeFailLinks() {
 			}
 			queue = append(queue, next)
 
-			dat.fail[next] = dat.followFailByCode(dat.fail[state], code)
-			if len(dat.output[dat.fail[next]]) > 0 {
-				dat.output[next] = append(dat.output[next], dat.output[dat.fail[next]]...)
+			dat.fail[next] = int32(dat.followFailByCode(int(dat.fail[state]), code)) //nolint:gosec // G115: as above.
+			// Link to the nearest keyword-carrying state on the failure path instead
+			// of copying its outputs in. The fail target is strictly shallower and
+			// this BFS visits by depth, so its outLink is already final.
+			if f := int(dat.fail[next]); dat.own[f] != "" {
+				dat.outLink[next] = int32(f) //nolint:gosec // G115: dat.size is bounded by hasOutputBit at band build.
+			} else {
+				dat.outLink[next] = dat.outLink[f]
 			}
 		}
 	}
 }
 
 // gotoStateByCode resolves a goto transition with the rune already mapped to its
-// alphabet index, so callers in the hot loop avoid re-resolving the rune on every fail hop.
+// alphabet index, so the hot loop does not re-resolve the rune on every fail hop.
 func (dat *doubleArrayTrie) gotoStateByCode(state, code int) int {
-	pos := dat.base[state] + code
+	pos := int(dat.base[state]) + code
 	if pos < 0 || pos >= dat.size {
 		return 0
 	}
-	if dat.check[pos] != state {
+	if int(dat.check[pos]) != state {
 		return 0
 	}
 	return pos
 }
 
 func (dat *doubleArrayTrie) followFailByCode(state, code int) int {
-	// Compute the transition once per visited state (loop condition + post-loop
-	// value share it) instead of twice, since this runs on the fail-walk hot path.
+	// Compute the transition once per visited state, shared by the loop condition
+	// and the post-loop value, since this runs on the fail-walk hot path.
 	next := dat.gotoStateByCode(state, code)
 	for state != datRootPos && next == 0 {
-		state = dat.fail[state]
+		state = int(dat.fail[state])
 		next = dat.gotoStateByCode(state, code)
 	}
 	if next == 0 {
@@ -264,25 +310,26 @@ func (dat *doubleArrayTrie) followFailByCode(state, code int) int {
 }
 
 func (dat *doubleArrayTrie) memoryBytes() int64 {
-	return int64(len(dat.base)+len(dat.check)+len(dat.fail)+len(dat.depth)) * 8
+	mem := int64(len(dat.base)+len(dat.check)+len(dat.fail)+len(dat.depth)) * 4
+	mem += int64(len(dat.own)) * 16 // string header per state
+	mem += int64(len(dat.outLink)) * 4
+	mem += int64(len(dat.hasOutput)) // one bool per state
+	return mem
 }
 
-func (dat *doubleArrayTrie) maxDepth() int {
-	d := 0
-	for _, v := range dat.depth {
-		if v > d {
-			d = v
-		}
-	}
-	return d
-}
+// maxDepth reports the deepest trie level from the value recorded during the
+// build, since depth itself is released once the band is chosen.
+func (dat *doubleArrayTrie) maxDepth() int { return dat.trieDepth }
 
+// keywordCount counts the states that terminate a keyword. Each keyword is
+// reached by exactly one path and so fills exactly one own slot, and the build
+// input is a set, so nothing needs deduplication.
 func (dat *doubleArrayTrie) keywordCount() int {
-	seen := make(map[string]struct{})
-	for _, outs := range dat.output {
-		for _, o := range outs {
-			seen[o] = struct{}{}
+	n := 0
+	for _, kw := range dat.own {
+		if kw != "" {
+			n++
 		}
 	}
-	return len(seen)
+	return n
 }

--- a/internal/engine/engine_flat.go
+++ b/internal/engine/engine_flat.go
@@ -5,14 +5,17 @@ package engine
 import (
 	"cmp"
 	"slices"
-	"unicode/utf8"
 )
 
 // flatNode is a trie node using a map for goto transitions (flat array pool).
+//
+// own is the single keyword ending at this node, or "" for none: a trie node is
+// reached by exactly one string, so at most one keyword can end there.
 type flatNode struct {
 	gotoMap map[rune]int
-	output  []string
+	own     string
 	fail    int
+	outLink int32
 	depth   int
 }
 
@@ -22,11 +25,27 @@ var _ matchEngine = (*speedEngine)(nil)
 // speedEngine implements matchEngine using a flat array trie with Full DFA
 // transitions and compact alphabet mapping. Used by PresetSpeed.
 type speedEngine struct {
-	dfa       [][]int    // [state][alphabetIndex] -> nextState
-	outputMap [][]string // [state] -> matched keywords
-	alphabet  []rune     // sorted unique runes from all keywords
+	// dfa is the transition table flattened to state*alphaSize+alphabetIndex. A
+	// [][]int cost the scan a slice-header load and two bounds checks per
+	// character, where one flat []int32 costs a single indexed load. Each entry
+	// carries hasOutputBit so the scan skips the output lookup on a miss.
+	dfa       []int32
+	alphaSize int
+	// own[state] is the keyword ending at state, or "" for none, and outLink[state]
+	// chains to the next state with a keyword along the failure path (outNone at the
+	// end). They replace an eagerly merged [][]string, which copied each state's
+	// whole suffix output list into every state failing to it: O(n^2) on a
+	// suffix-nested dictionary, where 500 keywords built 125,250 entries (2 MB of
+	// string headers) against the chain's 500.
+	own      []string
+	outLink  []int32
+	alphabet []rune // sorted unique runes from all keywords
 	alphabetCoder
 	numStates int
+	// trieDepth is the deepest trie level, recorded during the build. Info reported
+	// zero for this preset before, because the depths lived on flatNode and were
+	// dropped with it.
+	trieDepth int
 	preset    Preset
 }
 
@@ -37,8 +56,8 @@ func newSpeedEngine() *speedEngine {
 func (e *speedEngine) buildFromKeywords(keywords map[string]struct{}) { //nolint:gocyclo,funlen
 	if len(keywords) == 0 {
 		e.dfa = nil
-		e.outputMap = nil
-		e.numStates = 0
+		e.own, e.outLink = nil, nil
+		e.numStates, e.trieDepth = 0, 0
 		return
 	}
 
@@ -56,7 +75,7 @@ func (e *speedEngine) buildFromKeywords(keywords map[string]struct{}) { //nolint
 	e.build(e.alphabet)
 
 	nodes := []flatNode{
-		{gotoMap: make(map[rune]int), depth: 0},
+		{gotoMap: make(map[rune]int), depth: 0, outLink: outNone},
 	}
 	sortedKw := make([]string, 0, len(keywords))
 	for kw := range keywords {
@@ -64,17 +83,27 @@ func (e *speedEngine) buildFromKeywords(keywords map[string]struct{}) { //nolint
 	}
 	slices.Sort(sortedKw)
 	for _, kw := range sortedKw {
+		// An empty keyword would end at the root, where own == "" already means "no
+		// keyword". The public API rejects empty keywords; skipping keeps this engine
+		// correct on its own.
+		if kw == "" {
+			continue
+		}
 		state := 0
 		for _, ch := range kw {
 			child, ok := nodes[state].gotoMap[ch]
 			if !ok {
 				child = len(nodes)
 				nodes[state].gotoMap[ch] = child
-				nodes = append(nodes, flatNode{gotoMap: make(map[rune]int), depth: nodes[state].depth + 1})
+				nodes = append(nodes, flatNode{
+					gotoMap: make(map[rune]int),
+					depth:   nodes[state].depth + 1,
+					outLink: outNone,
+				})
 			}
 			state = child
 		}
-		nodes[state].output = append(nodes[state].output, kw)
+		nodes[state].own = kw
 	}
 
 	numStates := len(nodes)
@@ -137,52 +166,131 @@ func (e *speedEngine) buildFromKeywords(keywords map[string]struct{}) { //nolint
 				fail = next
 			}
 			nodes[child].fail = fail
-			if len(nodes[fail].output) > 0 {
-				nodes[child].output = append(nodes[child].output, nodes[fail].output...)
+			// Link to the nearest keyword-carrying state on the failure path instead
+			// of copying its outputs in. fail is strictly shallower and BFS visits by
+			// depth, so nodes[fail].outLink is already final here.
+			if nodes[fail].own != "" {
+				nodes[child].outLink = int32(fail) //nolint:gosec // G115: state ids are bounded by the DFA allocation below.
+			} else {
+				nodes[child].outLink = nodes[fail].outLink
 			}
 		}
 	}
 
-	e.dfa = make([][]int, numStates)
-	e.outputMap = make([][]string, numStates)
-	for i := range e.dfa {
-		e.dfa[i] = make([]int, alphaSize)
-		e.outputMap[i] = nodes[i].output
+	e.alphaSize = alphaSize
+	e.dfa = make([]int32, numStates*alphaSize)
+	e.own = make([]string, numStates)
+	e.outLink = make([]int32, numStates)
+	for i := range nodes {
+		e.own[i] = nodes[i].own
+		e.outLink[i] = nodes[i].outLink
+	}
+
+	// enc packs a target state with the flag saying whether it carries outputs, so
+	// the scan loop learns both from one load. Copying a fail row copies the flag
+	// with it, which is correct: the flag describes the target state. A state
+	// carries keywords when it terminates one or its output chain reaches one.
+	//
+	// State ids share an int32 with hasOutputBit and so must stay below 1<<30.
+	// There is no guard, unlike bandedDFA.buildDFABand: a full DFA needs the
+	// packing and has nothing to degrade to. Reaching the bound takes a billion
+	// trie states, which the three allocations above already size at 24 GiB or more,
+	// so no dictionary this library accepts comes close. Past it a state id would
+	// alias the bit, read back as the root, and drop matches silently.
+	enc := func(state int) int32 {
+		v := int32(state) //nolint:gosec // G115: see the bound above.
+		if e.own[state] != "" || e.outLink[state] != outNone {
+			v |= hasOutputBit
+		}
+		return v
 	}
 
 	for ai, r := range e.alphabet {
 		if child, ok := nodes[0].gotoMap[r]; ok {
-			e.dfa[0][ai] = child
+			e.dfa[ai] = enc(child)
 		} else {
-			e.dfa[0][ai] = 0
+			e.dfa[ai] = enc(0)
 		}
 	}
 
-	// Fill non-root rows in BFS (non-decreasing depth) order. A fail link always
-	// points to a strictly shallower state, so e.dfa[fail] is already filled when
-	// we copy from it. Iterating by state id is wrong: ids come from trie-insertion
-	// order, so a fail link can point to a higher-id (not-yet-filled) state, leaving
-	// the copied row all zeros and silently dropping matches.
+	// Fill non-root rows in BFS (non-decreasing depth) order. A fail link points to
+	// a strictly shallower state, so the fail row is already filled when we copy
+	// from it. Iterating by state id is wrong: ids come from trie-insertion order,
+	// so a fail link can point to a higher-id row that is still all zeros, which
+	// silently drops matches.
 	for _, s := range bfsOrder {
+		row := s * alphaSize
+		failRow := nodes[s].fail * alphaSize
 		for ai, r := range e.alphabet {
 			if child, ok := nodes[s].gotoMap[r]; ok {
-				e.dfa[s][ai] = child
+				e.dfa[row+ai] = enc(child)
 			} else {
-				e.dfa[s][ai] = e.dfa[nodes[s].fail][ai]
+				e.dfa[row+ai] = e.dfa[failRow+ai]
 			}
 		}
 	}
 
 	e.numStates = numStates
+	// Reset-and-recompute, not max-with-previous: Build reconstructs the automaton,
+	// so a rebuild from shorter keywords must report the shorter depth.
+	e.trieDepth = 0
+	for i := range nodes {
+		if nodes[i].depth > e.trieDepth {
+			e.trieDepth = nodes[i].depth
+		}
+	}
 }
 
-func (e *speedEngine) find(text string) []string {
+// find and findSet write out both the ASCII and rune loops instead of sharing a
+// scan(text, onOutput) helper the way balancedEngine does. That refactor was
+// measured: capturing the result slice in a closure boxes it on the heap, so every
+// match writes through a pointer, and PresetSpeed's ASCII match path lost 12-17%
+// (2,979 -> 3,483 ns at 1000 keywords). It won on multibyte and no-match text,
+// but not by enough to pay for the primary case.
+
+// The two loops make this function look branch-heavy to gocyclo; see the note
+// above for why they are not shared.
+func (e *speedEngine) find(text string) []string { //nolint:gocyclo
 	if e.dfa == nil {
 		return []string{}
 	}
 
-	matched := make([]string, 0)
+	// Left nil until something matches: text matching nothing is the common case
+	// for a filter and should not allocate for a hit that never happened.
+	var matched []string
 	state := 0
+	alpha := e.alphaSize
+
+	// Byte scan when the dictionary is pure ASCII. Every byte of a multibyte rune
+	// is >= utf8.RuneSelf and so cannot be in the alphabet, so it resets to root
+	// just as the rune scan does. Find reports no offsets, so the rune/byte index
+	// distinction never surfaces.
+	if e.asciiOnly {
+		for i := 0; i < len(text); i++ {
+			ai, ok := e.codeByte(text[i])
+			if !ok {
+				state = 0
+				continue
+			}
+			v := e.dfa[state*alpha+ai]
+			state = int(v &^ hasOutputBit)
+			if v&hasOutputBit == 0 {
+				continue
+			}
+			if matched == nil {
+				matched = make([]string, 0, findResultHint)
+			}
+			for s := state; s != outNone; s = int(e.outLink[s]) {
+				if kw := e.own[s]; kw != "" {
+					matched = append(matched, kw)
+				}
+			}
+		}
+		if matched == nil {
+			return []string{}
+		}
+		return matched
+	}
 
 	for _, ch := range text {
 		ai, ok := e.code(ch)
@@ -190,13 +298,123 @@ func (e *speedEngine) find(text string) []string {
 			state = 0
 			continue
 		}
-		state = e.dfa[state][ai]
-		if len(e.outputMap[state]) > 0 {
-			matched = append(matched, e.outputMap[state]...)
+		v := e.dfa[state*alpha+ai]
+		state = int(v &^ hasOutputBit)
+		if v&hasOutputBit == 0 {
+			continue
+		}
+		if matched == nil {
+			matched = make([]string, 0, findResultHint)
+		}
+		for s := state; s != outNone; s = int(e.outLink[s]) {
+			if kw := e.own[s]; kw != "" {
+				matched = append(matched, kw)
+			}
 		}
 	}
 
+	if matched == nil {
+		return []string{}
+	}
 	return matched
+}
+
+// findSet reports which keywords appear, without one entry per occurrence. The
+// dedup bookkeeping lives in setCollector, shared with balancedEngine; see it for
+// why the small case scans instead of hashing.
+func (e *speedEngine) findSet(text string) []string {
+	if e.dfa == nil {
+		return []string{}
+	}
+
+	var c setCollector
+	state := 0
+	alpha := e.alphaSize
+
+	if e.asciiOnly {
+		for i := 0; i < len(text); i++ {
+			ai, ok := e.codeByte(text[i])
+			if !ok {
+				state = 0
+				continue
+			}
+			v := e.dfa[state*alpha+ai]
+			state = int(v &^ hasOutputBit)
+			if v&hasOutputBit != 0 {
+				if c.addState(state) {
+					for s := state; s != outNone; s = int(e.outLink[s]) {
+						if kw := e.own[s]; kw != "" {
+							c.addKeyword(kw)
+						}
+					}
+				}
+			}
+		}
+	} else {
+		for _, ch := range text {
+			ai, ok := e.code(ch)
+			if !ok {
+				state = 0
+				continue
+			}
+			v := e.dfa[state*alpha+ai]
+			state = int(v &^ hasOutputBit)
+			if v&hasOutputBit != 0 {
+				if c.addState(state) {
+					for s := state; s != outNone; s = int(e.outLink[s]) {
+						if kw := e.own[s]; kw != "" {
+							c.addKeyword(kw)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return c.result()
+}
+
+// contains reports presence and stops at the first hit. It is the byte/rune scan
+// with the output lookup dropped, since hasOutputBit already says whether the
+// state carries keywords.
+func (e *speedEngine) contains(text string) bool {
+	if e.dfa == nil {
+		return false
+	}
+
+	state := 0
+	alpha := e.alphaSize
+
+	if e.asciiOnly {
+		for i := 0; i < len(text); i++ {
+			ai, ok := e.codeByte(text[i])
+			if !ok {
+				state = 0
+				continue
+			}
+			v := e.dfa[state*alpha+ai]
+			if v&hasOutputBit != 0 {
+				return true
+			}
+			// Reached only when the bit is clear, so v needs no masking.
+			state = int(v)
+		}
+		return false
+	}
+
+	for _, ch := range text {
+		ai, ok := e.code(ch)
+		if !ok {
+			state = 0
+			continue
+		}
+		v := e.dfa[state*alpha+ai]
+		if v&hasOutputBit != 0 {
+			return true
+		}
+		state = int(v)
+	}
+	return false
 }
 
 func (e *speedEngine) findIndex(text string) map[string][]int {
@@ -207,6 +425,7 @@ func (e *speedEngine) findIndex(text string) map[string][]int {
 	matched := make(map[string][]int)
 	state := 0
 	runeIndex := 0
+	alpha := e.alphaSize
 
 	for _, ch := range text {
 		ai, ok := e.code(ch)
@@ -215,15 +434,60 @@ func (e *speedEngine) findIndex(text string) map[string][]int {
 			runeIndex++
 			continue
 		}
-		state = e.dfa[state][ai]
+		v := e.dfa[state*alpha+ai]
+		state = int(v &^ hasOutputBit)
 		runeIndex++
-		for _, out := range e.outputMap[state] {
-			startIdx := runeIndex - utf8.RuneCountInString(out)
+		if v&hasOutputBit == 0 {
+			continue
+		}
+		for s := state; s != outNone; s = int(e.outLink[s]) {
+			out := e.own[s]
+			if out == "" {
+				continue
+			}
+			startIdx := runeIndex - runeLen(out, e.asciiOnly)
 			matched[out] = append(matched[out], startIdx)
 		}
 	}
 
 	return matched
+}
+
+// matchString is matchStream over an in-memory string; see the matchEngine
+// interface for why the loop is duplicated rather than shared through a closure.
+func (e *speedEngine) matchString(text string, emit func(Match) bool) {
+	if e.dfa == nil {
+		return
+	}
+
+	state := 0
+	runeIndex := 0
+	alpha := e.alphaSize
+
+	for _, ch := range text {
+		ai, ok := e.code(ch)
+		if !ok {
+			state = 0
+			runeIndex++
+			continue
+		}
+		v := e.dfa[state*alpha+ai]
+		state = int(v &^ hasOutputBit)
+		runeIndex++
+		if v&hasOutputBit == 0 {
+			continue
+		}
+		for s := state; s != outNone; s = int(e.outLink[s]) {
+			out := e.own[s]
+			if out == "" {
+				continue
+			}
+			start := runeIndex - runeLen(out, e.asciiOnly)
+			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
+				return
+			}
+		}
+	}
 }
 
 func (e *speedEngine) matchStream(next func() (rune, bool), emit func(Match) bool) {
@@ -233,6 +497,7 @@ func (e *speedEngine) matchStream(next func() (rune, bool), emit func(Match) boo
 
 	state := 0
 	runeIndex := 0
+	alpha := e.alphaSize
 
 	for {
 		ch, ok := next()
@@ -245,10 +510,18 @@ func (e *speedEngine) matchStream(next func() (rune, bool), emit func(Match) boo
 			runeIndex++
 			continue
 		}
-		state = e.dfa[state][ai]
+		v := e.dfa[state*alpha+ai]
+		state = int(v &^ hasOutputBit)
 		runeIndex++
-		for _, out := range e.outputMap[state] {
-			start := runeIndex - utf8.RuneCountInString(out)
+		if v&hasOutputBit == 0 {
+			continue
+		}
+		for s := state; s != outNone; s = int(e.outLink[s]) {
+			out := e.own[s]
+			if out == "" {
+				continue
+			}
+			start := runeIndex - runeLen(out, e.asciiOnly)
 			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
 				return
 			}
@@ -260,13 +533,9 @@ func (e *speedEngine) info() *InMemoryInfo {
 	if e.dfa == nil {
 		return &InMemoryInfo{Preset: e.preset}
 	}
-	var mem int64
-	for _, row := range e.dfa {
-		mem += int64(len(row)) * 8
-	}
-	for _, outs := range e.outputMap {
-		mem += int64(16 + len(outs)*16)
-	}
+	mem := int64(len(e.dfa)) * 4
+	mem += int64(len(e.own)) * 16    // string header per state
+	mem += int64(len(e.outLink)) * 4 // output-chain link per state
 	mem += int64(len(e.alphabet)) * 16
 	mem += int64(len(e.index)) * 24
 
@@ -275,15 +544,19 @@ func (e *speedEngine) info() *InMemoryInfo {
 		Nodes:       e.numStates,
 		Preset:      e.preset,
 		MemoryBytes: mem,
+		TrieDepth:   e.trieDepth,
 	}
 }
 
+// countKeywords counts the states that terminate a keyword. Each keyword is
+// reached by exactly one path and so fills exactly one own slot, and the build
+// input is a set, so nothing needs deduplication.
 func (e *speedEngine) countKeywords() int {
-	seen := make(map[string]struct{})
-	for _, outs := range e.outputMap {
-		for _, out := range outs {
-			seen[out] = struct{}{}
+	n := 0
+	for _, kw := range e.own {
+		if kw != "" {
+			n++
 		}
 	}
-	return len(seen)
+	return n
 }

--- a/internal/engine/engine_flat.go
+++ b/internal/engine/engine_flat.go
@@ -107,6 +107,7 @@ func (e *speedEngine) buildFromKeywords(keywords map[string]struct{}) { //nolint
 	}
 
 	numStates := len(nodes)
+	requirePackableStateCount(numStates)
 	alphaSize := len(e.alphabet)
 
 	queue := make([]int, 0)
@@ -170,7 +171,7 @@ func (e *speedEngine) buildFromKeywords(keywords map[string]struct{}) { //nolint
 			// of copying its outputs in. fail is strictly shallower and BFS visits by
 			// depth, so nodes[fail].outLink is already final here.
 			if nodes[fail].own != "" {
-				nodes[child].outLink = int32(fail) //nolint:gosec // G115: state ids are bounded by the DFA allocation below.
+				nodes[child].outLink = int32(fail) //nolint:gosec // G115: state ids pass requirePackableStateCount above.
 			} else {
 				nodes[child].outLink = nodes[fail].outLink
 			}
@@ -191,18 +192,8 @@ func (e *speedEngine) buildFromKeywords(keywords map[string]struct{}) { //nolint
 	// with it, which is correct: the flag describes the target state. A state
 	// carries keywords when it terminates one or its output chain reaches one.
 	//
-	// State ids share an int32 with hasOutputBit and so must stay below 1<<30.
-	// There is no guard, unlike bandedDFA.buildDFABand: a full DFA needs the
-	// packing and has nothing to degrade to. Reaching the bound takes a billion
-	// trie states, which the three allocations above already size at 24 GiB or more,
-	// so no dictionary this library accepts comes close. Past it a state id would
-	// alias the bit, read back as the root, and drop matches silently.
 	enc := func(state int) int32 {
-		v := int32(state) //nolint:gosec // G115: see the bound above.
-		if e.own[state] != "" || e.outLink[state] != outNone {
-			v |= hasOutputBit
-		}
-		return v
+		return packState(state, e.own[state] != "" || e.outLink[state] != outNone)
 	}
 
 	for ai, r := range e.alphabet {
@@ -277,14 +268,7 @@ func (e *speedEngine) find(text string) []string { //nolint:gocyclo
 			if v&hasOutputBit == 0 {
 				continue
 			}
-			if matched == nil {
-				matched = make([]string, 0, findResultHint)
-			}
-			for s := state; s != outNone; s = int(e.outLink[s]) {
-				if kw := e.own[s]; kw != "" {
-					matched = append(matched, kw)
-				}
-			}
+			matched = appendOutputChain(matched, state, e.own, e.outLink)
 		}
 		if matched == nil {
 			return []string{}
@@ -303,14 +287,7 @@ func (e *speedEngine) find(text string) []string { //nolint:gocyclo
 		if v&hasOutputBit == 0 {
 			continue
 		}
-		if matched == nil {
-			matched = make([]string, 0, findResultHint)
-		}
-		for s := state; s != outNone; s = int(e.outLink[s]) {
-			if kw := e.own[s]; kw != "" {
-				matched = append(matched, kw)
-			}
-		}
+		matched = appendOutputChain(matched, state, e.own, e.outLink)
 	}
 
 	if matched == nil {
@@ -341,13 +318,7 @@ func (e *speedEngine) findSet(text string) []string {
 			v := e.dfa[state*alpha+ai]
 			state = int(v &^ hasOutputBit)
 			if v&hasOutputBit != 0 {
-				if c.addState(state) {
-					for s := state; s != outNone; s = int(e.outLink[s]) {
-						if kw := e.own[s]; kw != "" {
-							c.addKeyword(kw)
-						}
-					}
-				}
+				collectOutputChain(&c, state, e.own, e.outLink)
 			}
 		}
 	} else {
@@ -360,13 +331,7 @@ func (e *speedEngine) findSet(text string) []string {
 			v := e.dfa[state*alpha+ai]
 			state = int(v &^ hasOutputBit)
 			if v&hasOutputBit != 0 {
-				if c.addState(state) {
-					for s := state; s != outNone; s = int(e.outLink[s]) {
-						if kw := e.own[s]; kw != "" {
-							c.addKeyword(kw)
-						}
-					}
-				}
+				collectOutputChain(&c, state, e.own, e.outLink)
 			}
 		}
 	}
@@ -440,14 +405,7 @@ func (e *speedEngine) findIndex(text string) map[string][]int {
 		if v&hasOutputBit == 0 {
 			continue
 		}
-		for s := state; s != outNone; s = int(e.outLink[s]) {
-			out := e.own[s]
-			if out == "" {
-				continue
-			}
-			startIdx := runeIndex - runeLen(out, e.asciiOnly)
-			matched[out] = append(matched[out], startIdx)
-		}
+		indexOutputChain(matched, state, runeIndex, e.own, e.outLink, e.asciiOnly)
 	}
 
 	return matched
@@ -477,15 +435,8 @@ func (e *speedEngine) matchString(text string, emit func(Match) bool) {
 		if v&hasOutputBit == 0 {
 			continue
 		}
-		for s := state; s != outNone; s = int(e.outLink[s]) {
-			out := e.own[s]
-			if out == "" {
-				continue
-			}
-			start := runeIndex - runeLen(out, e.asciiOnly)
-			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
-				return
-			}
+		if !emitOutputChain(state, runeIndex, e.own, e.outLink, e.asciiOnly, emit) {
+			return
 		}
 	}
 }
@@ -516,15 +467,8 @@ func (e *speedEngine) matchStream(next func() (rune, bool), emit func(Match) boo
 		if v&hasOutputBit == 0 {
 			continue
 		}
-		for s := state; s != outNone; s = int(e.outLink[s]) {
-			out := e.own[s]
-			if out == "" {
-				continue
-			}
-			start := runeIndex - runeLen(out, e.asciiOnly)
-			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
-				return
-			}
+		if !emitOutputChain(state, runeIndex, e.own, e.outLink, e.asciiOnly, emit) {
+			return
 		}
 	}
 }

--- a/internal/engine/engine_handle.go
+++ b/internal/engine/engine_handle.go
@@ -41,22 +41,6 @@ const findResultHint = 8
 // outputs would remove the trade-off by making dedup an integer index test.
 const dedupLinearMax = 32
 
-// outNone marks the end of an output-link chain.
-//
-// A state's output chain is its failure chain restricted to states carrying a
-// keyword, so walking it enumerates the keywords ending at the current position,
-// longest first:
-//
-//	for s := state; s != outNone; s = int(outLink[s]) {
-//		if kw := own[s]; kw != "" { ... }
-//	}
-//
-// The cursor is an int and widens on read, so no narrowing conversion is needed.
-// Each scan writes the loop out rather than sharing a callback helper: find and
-// findSet run it per match, where an indirect call costs what engine_flat.go's
-// header note measured.
-const outNone = -1
-
 // setCollector folds matched states into the unique keyword set behind FindSet,
 // preserving first-match order.
 //
@@ -79,7 +63,7 @@ type setCollector struct {
 // skip walking its output chain.
 func (c *setCollector) addState(state int) bool {
 	if c.seenState != nil {
-		if _, done := c.seenState[int32(state)]; done { //nolint:gosec // G115: state ids are bounded by hasOutputBit.
+		if _, done := c.seenState[int32(state)]; done { //nolint:gosec // G115: speed is packing-bounded; DAT state ids are int32.
 			return false
 		}
 		c.seenState[int32(state)] = struct{}{} //nolint:gosec // G115: as above.

--- a/internal/engine/engine_handle.go
+++ b/internal/engine/engine_handle.go
@@ -2,7 +2,151 @@
 
 package engine
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
+
+// setFinder is the optional specialization behind Engine.FindSet. It is separate
+// from matchEngine so an engine with no cheaper way to answer a set query is not
+// forced to reimplement the generic one.
+type setFinder interface {
+	findSet(text string) []string
+}
+
+// container is the optional specialization behind Engine.Contains. Routing a
+// presence check through matchString was the most expensive of the cheap
+// operations: it missed the byte-scan fast path on ASCII text and built a Match
+// (including a RuneCountInString) per hit only to discard it. On 1000 keywords
+// over a 640 B text it went from 1,147 to 666 ns with no match, 77 to 25 ns with
+// one, and two allocations to zero.
+type container interface {
+	contains(text string) bool
+}
+
+// findResultHint is the starting capacity for a match-result slice. Text that
+// matches nothing is the common case, so it only has to absorb the first few
+// appends on text that does match; sizing it to the dictionary would allocate far
+// more than a single scan needs.
+const findResultHint = 8
+
+// dedupLinearMax is the match-set size at which setCollector stops deduping by
+// linear scan and switches to hash maps. Below it the scan wins: two maps cost two
+// allocations up front and a string hash per hit, and a content filter typically
+// finds a handful of keywords per document. On 1000 keywords over a 640 B text,
+// linear scanning took findSet from 1,295 to 700 ns and 5 allocations to 3.
+//
+// ponytail: linear dedup is O(k^2) in the unique-match count k. Past the threshold
+// the maps take over, so match-dense text does not pay the quadratic. Pattern-id
+// outputs would remove the trade-off by making dedup an integer index test.
+const dedupLinearMax = 32
+
+// outNone marks the end of an output-link chain.
+//
+// A state's output chain is its failure chain restricted to states carrying a
+// keyword, so walking it enumerates the keywords ending at the current position,
+// longest first:
+//
+//	for s := state; s != outNone; s = int(outLink[s]) {
+//		if kw := own[s]; kw != "" { ... }
+//	}
+//
+// The cursor is an int and widens on read, so no narrowing conversion is needed.
+// Each scan writes the loop out rather than sharing a callback helper: find and
+// findSet run it per match, where an indirect call costs what engine_flat.go's
+// header note measured.
+const outNone = -1
+
+// setCollector folds matched states into the unique keyword set behind FindSet,
+// preserving first-match order.
+//
+// State dedup comes first because a state's keyword set is fixed: landing on it
+// again can add nothing new. Keyword dedup is still needed on top because distinct
+// states' output chains overlap, since every state whose failure path reaches a
+// keyword reports it.
+//
+// It is a struct with methods rather than closures over local variables so it
+// stays on the stack; a closure capturing the slice would be boxed on the heap.
+type setCollector struct {
+	out        []string
+	seenStates []int32
+	seen       map[string]struct{}
+	seenState  map[int32]struct{}
+}
+
+// addState records a matching state and reports whether it is new. A state's
+// keyword set is fixed, so landing there again adds nothing and the caller can
+// skip walking its output chain.
+func (c *setCollector) addState(state int) bool {
+	if c.seenState != nil {
+		if _, done := c.seenState[int32(state)]; done { //nolint:gosec // G115: state ids are bounded by hasOutputBit.
+			return false
+		}
+		c.seenState[int32(state)] = struct{}{} //nolint:gosec // G115: as above.
+		return true
+	}
+
+	if slices.Contains(c.seenStates, int32(state)) { //nolint:gosec // G115: as above.
+		return false
+	}
+	c.seenStates = append(c.seenStates, int32(state)) //nolint:gosec // G115: as above.
+	if len(c.seenStates) > dedupLinearMax {
+		c.promote()
+	}
+	return true
+}
+
+// addKeyword records a single keyword. It is the entry point for engines that
+// report keywords without a state id (the generic matchString path).
+func (c *setCollector) addKeyword(kw string) {
+	if c.seen != nil {
+		if _, dup := c.seen[kw]; dup {
+			return
+		}
+		c.seen[kw] = struct{}{}
+		c.out = append(c.out, kw)
+		return
+	}
+	if slices.Contains(c.out, kw) {
+		return
+	}
+	if c.out == nil {
+		// Take the whole starting capacity at the first hit instead of letting
+		// append regrow 1,2,4,8, exactly as find does.
+		c.out = make([]string, 0, findResultHint)
+	}
+	c.out = append(c.out, kw)
+	if len(c.out) > dedupLinearMax {
+		c.promote()
+	}
+}
+
+// promote moves the linear state into hash maps once the match set is large enough
+// that rescanning it per hit costs more than hashing. out keeps its order.
+func (c *setCollector) promote() {
+	if c.seen != nil {
+		return
+	}
+	c.seen = make(map[string]struct{}, len(c.out)*2)
+	for _, kw := range c.out {
+		c.seen[kw] = struct{}{}
+	}
+	c.seenState = make(map[int32]struct{}, len(c.seenStates)*2)
+	for _, s := range c.seenStates {
+		c.seenState[s] = struct{}{}
+	}
+	c.seenStates = nil
+}
+
+// result returns the unique keywords in first-match order. Like Find it is never
+// nil, and a zero-length literal costs no allocation, so text that matched
+// nothing stays allocation-free.
+func (c *setCollector) result() []string {
+	if c.out == nil {
+		return []string{}
+	}
+	return c.out
+}
 
 // Engine is the exported handle to an in-memory Aho-Corasick match engine.
 // It wraps the preset-selected internal implementation so callers outside this
@@ -22,8 +166,8 @@ func (e *Engine) Build(keywords map[string]struct{}) {
 	e.impl.buildFromKeywords(keywords)
 }
 
-// Find returns the keywords found in text. Like FindMatches it is never nil — an
-// automaton with no keywords yields an empty slice — so callers can hand it
+// Find returns the keywords found in text. Like FindMatches it is never nil (an
+// automaton with no keywords yields an empty slice), so callers can hand it
 // straight to a JSON encoder or compare it without a nil special case.
 func (e *Engine) Find(text string) []string {
 	return e.impl.find(text)
@@ -38,22 +182,66 @@ func (e *Engine) FindIndex(text string) map[string][]int {
 // FindMatches returns every match (overlaps included) in text, in scan order,
 // each carrying its keyword and rune-offset span.
 func (e *Engine) FindMatches(text string) []Match {
-	out := make([]Match, 0)
-	e.impl.matchStream(stringRuneSource(text), func(m Match) bool {
+	return e.FindMatchesAppend(nil, text)
+}
+
+// FindMatchesAppend appends matches to dst and returns the extended slice, so a
+// caller scanning many texts can reuse one buffer instead of allocating a result
+// slice per call. dst may be nil.
+func (e *Engine) FindMatchesAppend(dst []Match, text string) []Match {
+	out := dst
+	e.impl.matchString(text, func(m Match) bool {
+		if out == nil {
+			out = make([]Match, 0, findResultHint)
+		}
 		out = append(out, m)
 		return true
 	})
+	if out == nil {
+		return []Match{}
+	}
 	return out
 }
 
 // Contains reports whether text contains any keyword, stopping at the first hit.
 func (e *Engine) Contains(text string) bool {
+	// An engine that can answer presence without positions does so directly; the
+	// generic path below pays UTF-8 decoding, a Match struct, and a heap-boxed
+	// capture for a bool.
+	if c, ok := e.impl.(container); ok {
+		return c.contains(text)
+	}
+
 	found := false
-	e.impl.matchStream(stringRuneSource(text), func(Match) bool {
+	e.impl.matchString(text, func(Match) bool {
 		found = true
 		return false
 	})
 	return found
+}
+
+// FindSet returns each matched keyword once, in first-match order.
+//
+// Find reports one entry per occurrence, so callers asking "which of my patterns
+// appear" have to fold that into a set themselves. Doing it during the scan skips
+// the per-occurrence slice, which on match-dense text is most of the work.
+func (e *Engine) FindSet(text string) []string {
+	// An engine that can answer this without positions does so directly; the
+	// generic path below pays for a Match struct and a closure call per occurrence,
+	// all of which a set query throws away.
+	if sf, ok := e.impl.(setFinder); ok {
+		return sf.findSet(text)
+	}
+
+	// The collector stays unallocated until something matches: text matching nothing
+	// is the common case for a filter, and it should not pay for the bookkeeping of
+	// a hit that never happened.
+	var c setCollector
+	e.impl.matchString(text, func(m Match) bool {
+		c.addKeyword(m.Keyword)
+		return true
+	})
+	return c.result()
 }
 
 // Stream pulls runes from next (rune-global offsets accumulate across calls) and
@@ -64,8 +252,10 @@ func (e *Engine) Stream(next func() (rune, bool), emit func(Match) bool) {
 }
 
 // stringRuneSource adapts a string to the rune-pull source matchStream expects.
-// strings.Reader.ReadRune decodes exactly like a range loop (invalid UTF-8
-// yields RuneError).
+// strings.Reader.ReadRune decodes exactly like a range loop (invalid UTF-8 yields
+// RuneError), which makes it useful for testing Stream against a string. The match
+// entry points no longer route through it: that indirect call per rune is what
+// matchString exists to avoid.
 func stringRuneSource(s string) func() (rune, bool) {
 	rd := strings.NewReader(s)
 	return func() (rune, bool) {

--- a/internal/engine/engine_map.go
+++ b/internal/engine/engine_map.go
@@ -5,21 +5,19 @@ package engine
 import "unicode/utf8"
 
 // mapNode is a trie node using Go maps for children (sparse representation).
-// own is the single keyword ending at this node, or "" for none, and outLink
-// chains to the next keyword-carrying node along the failure path (outNone at the
-// end). See doubleArrayTrie.own for the O(n^2) that eagerly merging output lists
-// cost on a suffix-nested dictionary.
 type mapNode struct {
 	children map[rune]int
 	fail     int
-	own      string
-	outLink  int32
 	depth    int
 }
 
 // mapTrie is a trie backed by a slice of mapNodes.
 type mapTrie struct {
 	nodes []mapNode
+	// own and outLink use the same output-chain representation as the flat and
+	// double-array tries, so all engines share the matching helpers.
+	own     []string
+	outLink []int32
 }
 
 // Compile-time check that memEfficientEngine satisfies matchEngine.
@@ -43,8 +41,10 @@ func newMemEfficientEngine() *memEfficientEngine {
 func (e *memEfficientEngine) buildFromKeywords(keywords map[string]struct{}) {
 	trie := mapTrie{
 		nodes: []mapNode{
-			{children: make(map[rune]int), depth: 0, outLink: outNone},
+			{children: make(map[rune]int), depth: 0},
 		},
+		own:     []string{""},
+		outLink: []int32{outNone},
 	}
 
 	for kw := range keywords {
@@ -63,12 +63,13 @@ func (e *memEfficientEngine) buildFromKeywords(keywords map[string]struct{}) {
 				trie.nodes = append(trie.nodes, mapNode{
 					children: make(map[rune]int),
 					depth:    trie.nodes[state].depth + 1,
-					outLink:  outNone,
 				})
+				trie.own = append(trie.own, "")
+				trie.outLink = append(trie.outLink, outNone)
 			}
 			state = child
 		}
-		trie.nodes[state].own = kw
+		trie.own[state] = kw
 	}
 
 	type queueEntry struct {
@@ -108,10 +109,10 @@ func (e *memEfficientEngine) buildFromKeywords(keywords map[string]struct{}) {
 			// Link to the nearest keyword-carrying state on the failure path instead
 			// of copying its outputs in. fail is strictly shallower and this BFS
 			// visits by depth, so its outLink is already final.
-			if trie.nodes[fail].own != "" {
-				trie.nodes[child].outLink = int32(fail) //nolint:gosec // G115: node ids index a slice built above.
+			if trie.own[fail] != "" {
+				trie.outLink[child] = int32(fail) //nolint:gosec // G115: node ids index a slice built above.
 			} else {
-				trie.nodes[child].outLink = trie.nodes[fail].outLink
+				trie.outLink[child] = trie.outLink[fail]
 			}
 		}
 	}
@@ -153,11 +154,7 @@ func (e *memEfficientEngine) find(text string) []string {
 			state = e.trie.nodes[state].fail
 		}
 
-		for s := state; s != outNone; s = int(e.trie.nodes[s].outLink) {
-			if kw := e.trie.nodes[s].own; kw != "" {
-				matched = append(matched, kw)
-			}
-		}
+		matched = appendOutputChain(matched, state, e.trie.own, e.trie.outLink)
 	}
 
 	return matched
@@ -190,14 +187,7 @@ func (e *memEfficientEngine) findIndex(text string) map[string][]int {
 		}
 
 		runeIndex++
-		for s := state; s != outNone; s = int(e.trie.nodes[s].outLink) {
-			out := e.trie.nodes[s].own
-			if out == "" {
-				continue
-			}
-			startIdx := runeIndex - runeLen(out, e.asciiOnly)
-			matched[out] = append(matched[out], startIdx)
-		}
+		indexOutputChain(matched, state, runeIndex, e.trie.own, e.trie.outLink, e.asciiOnly)
 	}
 
 	return matched
@@ -231,15 +221,8 @@ func (e *memEfficientEngine) matchString(text string, emit func(Match) bool) {
 		}
 
 		runeIndex++
-		for s := state; s != outNone; s = int(e.trie.nodes[s].outLink) {
-			out := e.trie.nodes[s].own
-			if out == "" {
-				continue
-			}
-			start := runeIndex - runeLen(out, e.asciiOnly)
-			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
-				return
-			}
+		if !emitOutputChain(state, runeIndex, e.trie.own, e.trie.outLink, e.asciiOnly, emit) {
+			return
 		}
 	}
 }
@@ -274,22 +257,15 @@ func (e *memEfficientEngine) matchStream(next func() (rune, bool), emit func(Mat
 		}
 
 		runeIndex++
-		for s := state; s != outNone; s = int(e.trie.nodes[s].outLink) {
-			out := e.trie.nodes[s].own
-			if out == "" {
-				continue
-			}
-			start := runeIndex - runeLen(out, e.asciiOnly)
-			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
-				return
-			}
+		if !emitOutputChain(state, runeIndex, e.trie.own, e.trie.outLink, e.asciiOnly, emit) {
+			return
 		}
 	}
 }
 
 func (e *memEfficientEngine) info() *InMemoryInfo {
 	return &InMemoryInfo{
-		Keywords:    countUniqueOutputs(e.trie.nodes),
+		Keywords:    countUniqueOutputs(e.trie.own),
 		Nodes:       len(e.trie.nodes),
 		Preset:      PresetMemoryEfficient,
 		MemoryBytes: e.estimateMemory(),
@@ -300,10 +276,10 @@ func (e *memEfficientEngine) info() *InMemoryInfo {
 // countUniqueOutputs counts the nodes that terminate a keyword. Each keyword is
 // reached by exactly one path and so fills exactly one own slot, and the build
 // input is a set, so nothing needs deduplication.
-func countUniqueOutputs(nodes []mapNode) int {
+func countUniqueOutputs(own []string) int {
 	n := 0
-	for _, node := range nodes {
-		if node.own != "" {
+	for _, kw := range own {
+		if kw != "" {
 			n++
 		}
 	}
@@ -323,11 +299,12 @@ func trieMaxDepth(nodes []mapNode) int {
 func (e *memEfficientEngine) estimateMemory() int64 {
 	var size int64
 	for _, n := range e.trie.nodes {
-		size += int64(24 + 16 + 16 + 16 + 4) // children hdr, fail, depth, own, outLink
+		size += int64(24 + 16 + 16) // children hdr, fail, depth
 		for range n.children {
 			size += 24
 		}
 	}
+	size += int64(len(e.trie.own))*16 + int64(len(e.trie.outLink))*4
 	if e.bloom != nil {
 		size += e.bloom.memoryBytes()
 	}

--- a/internal/engine/engine_map.go
+++ b/internal/engine/engine_map.go
@@ -5,10 +5,15 @@ package engine
 import "unicode/utf8"
 
 // mapNode is a trie node using Go maps for children (sparse representation).
+// own is the single keyword ending at this node, or "" for none, and outLink
+// chains to the next keyword-carrying node along the failure path (outNone at the
+// end). See doubleArrayTrie.own for the O(n^2) that eagerly merging output lists
+// cost on a suffix-nested dictionary.
 type mapNode struct {
 	children map[rune]int
 	fail     int
-	output   []string
+	own      string
+	outLink  int32
 	depth    int
 }
 
@@ -25,6 +30,10 @@ var _ matchEngine = (*memEfficientEngine)(nil)
 type memEfficientEngine struct {
 	trie  mapTrie
 	bloom *bloomFilter
+	// asciiOnly reports whether every keyword is pure ASCII, which lets runeLen take
+	// a keyword's byte length instead of rescanning it. This engine has no
+	// alphabetCoder to carry the flag, so it derives it at build time.
+	asciiOnly bool
 }
 
 func newMemEfficientEngine() *memEfficientEngine {
@@ -34,11 +43,17 @@ func newMemEfficientEngine() *memEfficientEngine {
 func (e *memEfficientEngine) buildFromKeywords(keywords map[string]struct{}) {
 	trie := mapTrie{
 		nodes: []mapNode{
-			{children: make(map[rune]int), depth: 0},
+			{children: make(map[rune]int), depth: 0, outLink: outNone},
 		},
 	}
 
 	for kw := range keywords {
+		// An empty keyword would end at the root, where own == "" already means "no
+		// keyword". The public API rejects empty keywords; skipping keeps this engine
+		// correct on its own.
+		if kw == "" {
+			continue
+		}
 		state := 0
 		for _, ch := range kw {
 			child, ok := trie.nodes[state].children[ch]
@@ -48,11 +63,12 @@ func (e *memEfficientEngine) buildFromKeywords(keywords map[string]struct{}) {
 				trie.nodes = append(trie.nodes, mapNode{
 					children: make(map[rune]int),
 					depth:    trie.nodes[state].depth + 1,
+					outLink:  outNone,
 				})
 			}
 			state = child
 		}
-		trie.nodes[state].output = append(trie.nodes[state].output, kw)
+		trie.nodes[state].own = kw
 	}
 
 	type queueEntry struct {
@@ -89,14 +105,28 @@ func (e *memEfficientEngine) buildFromKeywords(keywords map[string]struct{}) {
 			}
 
 			trie.nodes[child].fail = fail
-			if len(trie.nodes[fail].output) > 0 {
-				trie.nodes[child].output = append(trie.nodes[child].output, trie.nodes[fail].output...)
+			// Link to the nearest keyword-carrying state on the failure path instead
+			// of copying its outputs in. fail is strictly shallower and this BFS
+			// visits by depth, so its outLink is already final.
+			if trie.nodes[fail].own != "" {
+				trie.nodes[child].outLink = int32(fail) //nolint:gosec // G115: node ids index a slice built above.
+			} else {
+				trie.nodes[child].outLink = trie.nodes[fail].outLink
 			}
 		}
 	}
 
 	e.trie = trie
 	e.bloom = buildFirstRuneBloom(keywords)
+
+	e.asciiOnly = true
+	for kw := range keywords {
+		// A keyword is pure ASCII exactly when its byte length equals its rune count.
+		if len(kw) != utf8.RuneCountInString(kw) {
+			e.asciiOnly = false
+			break
+		}
+	}
 }
 
 func (e *memEfficientEngine) find(text string) []string {
@@ -123,8 +153,10 @@ func (e *memEfficientEngine) find(text string) []string {
 			state = e.trie.nodes[state].fail
 		}
 
-		if len(e.trie.nodes[state].output) > 0 {
-			matched = append(matched, e.trie.nodes[state].output...)
+		for s := state; s != outNone; s = int(e.trie.nodes[s].outLink) {
+			if kw := e.trie.nodes[s].own; kw != "" {
+				matched = append(matched, kw)
+			}
 		}
 	}
 
@@ -158,13 +190,58 @@ func (e *memEfficientEngine) findIndex(text string) map[string][]int {
 		}
 
 		runeIndex++
-		for _, out := range e.trie.nodes[state].output {
-			startIdx := runeIndex - utf8.RuneCountInString(out)
+		for s := state; s != outNone; s = int(e.trie.nodes[s].outLink) {
+			out := e.trie.nodes[s].own
+			if out == "" {
+				continue
+			}
+			startIdx := runeIndex - runeLen(out, e.asciiOnly)
 			matched[out] = append(matched[out], startIdx)
 		}
 	}
 
 	return matched
+}
+
+// matchString is matchStream over an in-memory string; see the matchEngine
+// interface for why the loop is duplicated rather than shared through a closure.
+func (e *memEfficientEngine) matchString(text string, emit func(Match) bool) {
+	if len(e.trie.nodes) <= 1 {
+		return
+	}
+
+	state := 0
+	runeIndex := 0
+
+	for _, ch := range text {
+		if e.bloom.skipAtRoot(state == 0, ch) {
+			runeIndex++
+			continue
+		}
+
+		for {
+			if nx, ok := e.trie.nodes[state].children[ch]; ok {
+				state = nx
+				break
+			}
+			if state == 0 {
+				break
+			}
+			state = e.trie.nodes[state].fail
+		}
+
+		runeIndex++
+		for s := state; s != outNone; s = int(e.trie.nodes[s].outLink) {
+			out := e.trie.nodes[s].own
+			if out == "" {
+				continue
+			}
+			start := runeIndex - runeLen(out, e.asciiOnly)
+			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
+				return
+			}
+		}
+	}
 }
 
 func (e *memEfficientEngine) matchStream(next func() (rune, bool), emit func(Match) bool) {
@@ -197,8 +274,12 @@ func (e *memEfficientEngine) matchStream(next func() (rune, bool), emit func(Mat
 		}
 
 		runeIndex++
-		for _, out := range e.trie.nodes[state].output {
-			start := runeIndex - utf8.RuneCountInString(out)
+		for s := state; s != outNone; s = int(e.trie.nodes[s].outLink) {
+			out := e.trie.nodes[s].own
+			if out == "" {
+				continue
+			}
+			start := runeIndex - runeLen(out, e.asciiOnly)
 			if !emit(Match{Keyword: out, Start: start, End: runeIndex}) {
 				return
 			}
@@ -216,14 +297,17 @@ func (e *memEfficientEngine) info() *InMemoryInfo {
 	}
 }
 
+// countUniqueOutputs counts the nodes that terminate a keyword. Each keyword is
+// reached by exactly one path and so fills exactly one own slot, and the build
+// input is a set, so nothing needs deduplication.
 func countUniqueOutputs(nodes []mapNode) int {
-	seen := make(map[string]struct{})
-	for _, n := range nodes {
-		for _, out := range n.output {
-			seen[out] = struct{}{}
+	n := 0
+	for _, node := range nodes {
+		if node.own != "" {
+			n++
 		}
 	}
-	return len(seen)
+	return n
 }
 
 func trieMaxDepth(nodes []mapNode) int {
@@ -239,7 +323,7 @@ func trieMaxDepth(nodes []mapNode) int {
 func (e *memEfficientEngine) estimateMemory() int64 {
 	var size int64
 	for _, n := range e.trie.nodes {
-		size += int64(24 + 16 + 16 + len(n.output)*16)
+		size += int64(24 + 16 + 16 + 16 + 4) // children hdr, fail, depth, own, outLink
 		for range n.children {
 			size += 24
 		}

--- a/internal/engine/engine_matches_test.go
+++ b/internal/engine/engine_matches_test.go
@@ -3,6 +3,7 @@
 package engine
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -70,6 +71,110 @@ func TestContains(t *testing.T) {
 		if e.Contains("") {
 			t.Errorf("preset %v: Contains(\"\") should be false", p)
 		}
+	}
+}
+
+// uniqueInOrder is FindSet's contract stated independently of it: Find's
+// occurrences with later duplicates dropped.
+func uniqueInOrder(all []string) []string {
+	seen := make(map[string]struct{}, len(all))
+	out := make([]string, 0, len(all))
+	for _, s := range all {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// TestFindSetAcrossDedupThreshold pins FindSet against Find on both sides of
+// dedupLinearMax, so the handoff from linear scanning to hash maps cannot change
+// the answer or its order. A text matching well over the threshold is the case
+// the linear path is not meant to serve.
+func TestFindSetAcrossDedupThreshold(t *testing.T) {
+	for _, n := range []int{1, dedupLinearMax - 1, dedupLinearMax, dedupLinearMax + 1, 4 * dedupLinearMax} {
+		kws := make(map[string]struct{}, n)
+		var text string
+		for i := 0; i < n; i++ {
+			kw := fmt.Sprintf("kw%d", i)
+			kws[kw] = struct{}{}
+			// Each keyword appears twice, so dedup has something to do.
+			text += kw + " " + kw + " "
+		}
+		for _, p := range allPresets {
+			t.Run(fmt.Sprintf("%dkw/%v", n, p), func(t *testing.T) {
+				e := New(p)
+				e.Build(kws)
+				want := uniqueInOrder(e.Find(text))
+				got := e.FindSet(text)
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("FindSet = %v, want %v (unique Find order)", got, want)
+				}
+				if len(got) != n {
+					t.Errorf("FindSet returned %d keywords, want %d", len(got), n)
+				}
+			})
+		}
+	}
+}
+
+// TestContainsAgreesWithFind pins the Contains specialization against Find on the
+// paths that differ between them: the ASCII byte scan, the multibyte rune scan,
+// and runes outside the alphabet.
+func TestContainsAgreesWithFind(t *testing.T) {
+	cases := []struct {
+		keywords []string
+		texts    []string
+	}{
+		{[]string{"he", "she", "his"}, []string{"this is here", "no match at all", "", "h", "☃ she ☃"}},
+		{[]string{"한국", "안녕"}, []string{"안녕 한국", "hello", "", "한 국", "🦊안녕🦊"}},
+		{[]string{"a", "aa", "aaa"}, []string{"aaaa", "bbbb", ""}},
+		{[]string{"café"}, []string{"un café", "un cafe", ""}},
+	}
+	for _, tc := range cases {
+		kws := keywordSet(tc.keywords...)
+		for _, p := range allPresets {
+			e := New(p)
+			e.Build(kws)
+			for _, txt := range tc.texts {
+				want := len(e.Find(txt)) > 0
+				if got := e.Contains(txt); got != want {
+					t.Errorf("preset %v: Contains(%q) = %v, want %v", p, txt, got, want)
+				}
+			}
+		}
+	}
+}
+
+// TestRebuildResetsInfo guards the state that survives a rebuild. Build is
+// documented as reconstructing the automaton, and TrieDepth is now recorded during
+// the build rather than derived from a retained array — so a rebuild from shorter
+// keywords must report the shorter depth, not the old maximum.
+func TestRebuildResetsInfo(t *testing.T) {
+	for _, p := range allPresets {
+		t.Run(p.String(), func(t *testing.T) {
+			e := New(p)
+
+			e.Build(keywordSet("abcdefgh"))
+			if got := e.Info().Keywords; got != 1 {
+				t.Errorf("after first build: Keywords = %d, want 1", got)
+			}
+			deep := e.Info().TrieDepth
+
+			e.Build(keywordSet("ab"))
+			info := e.Info()
+			if info.Keywords != 1 {
+				t.Errorf("after rebuild: Keywords = %d, want 1", info.Keywords)
+			}
+			if info.TrieDepth >= deep {
+				t.Errorf("after rebuild on shorter keywords: TrieDepth = %d, want < %d", info.TrieDepth, deep)
+			}
+			if got := e.Find("abcdefgh"); len(got) != 1 || got[0] != "ab" {
+				t.Errorf("after rebuild: Find = %v, want [ab] only", got)
+			}
+		})
 	}
 }
 

--- a/internal/engine/engine_matches_test.go
+++ b/internal/engine/engine_matches_test.go
@@ -89,6 +89,30 @@ func uniqueInOrder(all []string) []string {
 	return out
 }
 
+func TestFindSetNoMatches(t *testing.T) {
+	cases := []struct {
+		name     string
+		keywords map[string]struct{}
+		text     string
+	}{
+		{"empty_keywords", map[string]struct{}{}, "non-empty text"},
+		{"no_matching_text", keywordSet("keyword1", "keyword2", "another-keyword"), "nothing here matches"},
+	}
+
+	for _, p := range allPresets {
+		for _, tc := range cases {
+			t.Run(fmt.Sprintf("%s/%v", tc.name, p), func(t *testing.T) {
+				e := New(p)
+				e.Build(tc.keywords)
+				got := e.FindSet(tc.text)
+				if got == nil || len(got) != 0 {
+					t.Fatalf("FindSet = %#v, want non-nil empty slice", got)
+				}
+			})
+		}
+	}
+}
+
 // TestFindSetAcrossDedupThreshold pins FindSet against Find on both sides of
 // dedupLinearMax, so the handoff from linear scanning to hash maps cannot change
 // the answer or its order. A text matching well over the threshold is the case

--- a/internal/engine/engine_output.go
+++ b/internal/engine/engine_output.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package engine
+
+const (
+	// hasOutputBit shares an int32 transition entry with its target state. Valid
+	// packed state IDs are [0, hasOutputBit), leaving the sign bit clear.
+	hasOutputBit int32 = 1 << 30
+	// outNone marks the end of an output-link chain.
+	outNone = -1
+)
+
+func requirePackableStateCount(count int) {
+	if count >= int(hasOutputBit) {
+		panic("engine: too many states for packed transitions")
+	}
+}
+
+func packState(state int, hasOutput bool) int32 {
+	if state < 0 || state >= int(hasOutputBit) {
+		panic("engine: state does not fit in packed transition")
+	}
+	entry := int32(state) //nolint:gosec // G115: guarded above.
+	if hasOutput {
+		entry |= hasOutputBit
+	}
+	return entry
+}
+
+func appendOutputChain(dst []string, state int, own []string, outLink []int32) []string {
+	for s := state; s != outNone; s = int(outLink[s]) {
+		if kw := own[s]; kw != "" {
+			if dst == nil {
+				dst = make([]string, 0, findResultHint)
+			}
+			dst = append(dst, kw)
+		}
+	}
+	return dst
+}
+
+func collectOutputChain(c *setCollector, state int, own []string, outLink []int32) {
+	if !c.addState(state) {
+		return
+	}
+	for s := state; s != outNone; s = int(outLink[s]) {
+		if kw := own[s]; kw != "" {
+			c.addKeyword(kw)
+		}
+	}
+}
+
+func indexOutputChain(dst map[string][]int, state, end int, own []string, outLink []int32, asciiOnly bool) {
+	for s := state; s != outNone; s = int(outLink[s]) {
+		if kw := own[s]; kw != "" {
+			dst[kw] = append(dst[kw], end-runeLen(kw, asciiOnly))
+		}
+	}
+}
+
+func emitOutputChain(state, end int, own []string, outLink []int32, asciiOnly bool, emit func(Match) bool) bool {
+	for s := state; s != outNone; s = int(outLink[s]) {
+		if kw := own[s]; kw != "" && !emit(Match{
+			Keyword: kw,
+			Start:   end - runeLen(kw, asciiOnly),
+			End:     end,
+		}) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/engine/engine_output_test.go
+++ b/internal/engine/engine_output_test.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package engine
+
+import "testing"
+
+func TestPackedStateCountGuard(t *testing.T) {
+	requirePackableStateCount(int(hasOutputBit) - 1)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("requirePackableStateCount did not panic at the packing limit")
+		}
+	}()
+	requirePackableStateCount(int(hasOutputBit))
+}

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -3,6 +3,7 @@
 package engine
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"testing"
@@ -77,6 +78,10 @@ func TestEngineResultInvariance(t *testing.T) {
 		{"mixed-alphabet", []string{"café", "안녕", "ab"}, "un café 안녕 abc"},
 		{"out-of-alphabet", []string{"cat"}, "a cat zzz ☃ cat"},
 		{"prefix-chain", []string{"a", "aa", "aaa"}, "aaaa"},
+		// A suffix chain (each keyword a suffix of the next) is what walks the
+		// output-link chain to full depth: landing on "aaaw" must report "aaw",
+		// "aw" and "w" too. A prefix chain never exercises more than one link.
+		{"suffix-chain", []string{"w", "aw", "aaw", "aaaw"}, "aaaw aw baaaw"},
 	}
 
 	for _, tc := range cases {
@@ -105,6 +110,63 @@ func TestEngineResultInvariance(t *testing.T) {
 			})
 		}
 	}
+}
+
+// TestOutputStorageStaysLinear pins the bound that output links exist for. Eager
+// suffix merging copied each state's whole output list into every state that
+// failed to it, so a suffix-nested dictionary stored O(n^2) keyword entries —
+// 500 keywords produced 125,250. Each keyword now occupies exactly one state's
+// own slot, so the total is n regardless of nesting.
+//
+// The assertion is on storage rather than time because that is what regressed:
+// a reintroduced merge would still return the right matches.
+func TestOutputStorageStaysLinear(t *testing.T) {
+	for _, n := range []int{10, 100, 500} {
+		// w, aw, aaw, aaaw, ...: every keyword is a suffix of the next.
+		kws := make(map[string]struct{}, n)
+		kw := "w"
+		for i := 0; i < n; i++ {
+			kws[kw] = struct{}{}
+			kw = "a" + kw
+		}
+
+		t.Run(fmt.Sprintf("%dkw", n), func(t *testing.T) {
+			se := newSpeedEngine()
+			se.buildFromKeywords(kws)
+			if got := countNonEmpty(se.own); got != n {
+				t.Errorf("speedEngine stored %d keyword entries, want %d", got, n)
+			}
+
+			be := newBalancedEngine(defaultBandDepth)
+			be.buildFromKeywords(kws)
+			if got := countNonEmpty(be.banded.dat.own); got != n {
+				t.Errorf("balancedEngine stored %d keyword entries, want %d", got, n)
+			}
+
+			// Deepest keyword present means the whole chain must be reported.
+			deepest := kw[1:]
+			for _, p := range allPresets {
+				e := New(p)
+				e.Build(kws)
+				if got := len(e.Find(deepest)); got != n {
+					t.Errorf("preset %v: Find(deepest) reported %d matches, want %d", p, got, n)
+				}
+				if got := e.Info().Keywords; got != n {
+					t.Errorf("preset %v: Info().Keywords = %d, want %d", p, got, n)
+				}
+			}
+		})
+	}
+}
+
+func countNonEmpty(own []string) int {
+	n := 0
+	for _, kw := range own {
+		if kw != "" {
+			n++
+		}
+	}
+	return n
 }
 
 // TestEngineEmptyKeywords guards the degenerate build (no keywords): every


### PR DESCRIPTION
# Pull Request

## Description

Two structural problems in the match engines, both paid per character or per keyword
rather than once.

**Transition tables were slices of slices.** `PresetSpeed`'s full DFA and
`PresetBalanced`'s banded DFA each cost the scan a slice-header load plus two bounds
checks per character. They are now one flat `[]int32` indexed by state and alphabet
code, with a bit per entry (`hasOutputBit`) recording whether the target state
carries keywords, so the scan skips the output lookup on the common miss. A
dictionary too large for the `int32` packing keeps working on the unpacked NFA path —
the guard covers every conversion. Scans over a pure-ASCII dictionary now walk raw
bytes instead of decoding UTF-8 for the queries that report no offsets.

**Output storage merged suffixes eagerly.** The build copied a state's whole output
list into every state that failed to it, which is O(n²) on a suffix-nested
dictionary: 500 keywords where each is a suffix of the next produced 125,250 stored
entries — about 2 MB of string headers — where 500 suffice. Each state now holds only
the keyword ending there (`own[s]`) plus a link to the next keyword-carrying state on
its failure path (`outLink[s]`), so storage is linear in the dictionary regardless of
nesting. `PresetBalanced`'s documented "output link compression" now describes what
the code does.

Match results are unchanged, including the order overlapping matches are reported in.

At 1000 keywords over a 640 B text:

| Measurement | Before | After |
|---|---|---|
| `PresetSpeed` findSet | 1,681 ns/op | 1,030 ns/op |
| `PresetBalanced` findSet | 2,225 ns/op | 1,083 ns/op |
| `PresetSpeed` `FindMatches` (positioned) | 2,663 ns/op | 1,852 ns/op |
| `FindMatches` (Speed) | 2,184 ns/op | 1,678 ns/op |
| `FindMatches` (Balanced) | 2,580 ns/op | 2,126 ns/op |

Positioned `FindMatches` on `PresetSpeed` is now faster than
`petar-dambovaliev/aho-corasick`.

Also fixes `Info().TrieDepth` reporting 0 on `PresetSpeed`. That engine computed each
node's depth while building the trie and then dropped it instead of recording the
maximum, so the field was silently zero for the whole preset while the other two
reported it correctly. It is now populated, and recomputed from scratch on every
rebuild so a smaller dictionary reports a smaller depth rather than keeping the
previous maximum.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed — engine internals are unexported; the published figures land in the docs PR at the top of this stack
- [x] Changelog fragment added (`changie new`) — `Changed-20260802-000005`, `Changed-20260804-000001`, `Fixed-20260804-000003`
- [x] Commit messages follow guidelines

## Additional Notes

**Largest PR in the stack (~1,200 lines) and the one worth the most review time.**
Flattening and output-links are bundled because they were developed against each
other inside the same scan loops in `engine_flat.go` and `engine_banded_dfa.go`;
separating them would mean authoring an intermediate state that never existed and
never ran.

Suggested reading order: `engine_dat.go` (the `own`/`outLink`/`hasOutput` field
comments explain the new storage model), then `engine_banded_dfa.go` `step()` and
`scan()`, then `engine_flat.go`.

`TestOutputStorageStaysLinear` asserts on **storage** rather than a timing, because
storage is what regressed — a reintroduced merge would still return the right
matches, so a correctness test would not catch it.

This PR adds `findSet`/`contains`/`matchString` specializations to the engines; the
next PR is what exposes them through `pkg/acor`.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).
