### PR TITLE
docs: republish the measured numbers and the new matching API

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ or [`petar-dambovaliev/aho-corasick`](https://github.com/petar-dambovaliev/aho-c
 is lighter and needs no infrastructure.
 
 **Use ACOR when several instances share one dictionary that changes at runtime.**
-A keyword added on one instance reaches the others in a measured p50 of 211 µs
-(p99 2.3 ms). An in-memory automaton has no equivalent number, because its answer
-is a redeploy.
+On an Apple M4 with Redis 8 on loopback, one sample measured a keyword added on
+one instance reaching the others at a p50 of 211 µs (p99 2.3 ms). An in-memory
+automaton has no equivalent number, because its answer is a redeploy.
 
 Matching runs in-process once the automaton is warm, with no Redis round trip.
 Over 1,000 keywords and a 640 B text on an Apple M4, `PresetSpeed` measures:
@@ -31,10 +31,10 @@ Over 1,000 keywords and a 640 B text on an Apple M4, `PresetSpeed` measures:
 | `FindMatches` — occurrences with positions | 1,678 | 4,264 | 6 |
 
 `PresetBalanced` holds that dictionary in 314 KiB of retained heap. Absolute times
-are hardware-bound and moved 20-25% between runs on the same machine, so read them
+are hardware-bound and move 20-25% between runs on the same machine, so read them
 as an order of magnitude; the
-[benchmarks page](docs/content/reference/benchmarks.md) has the method and the full
-tables.
+[benchmarks page](https://skyoo2003.github.io/acor/reference/benchmarks/) has the
+method and the full tables.
 
 ## Overview
 
@@ -167,7 +167,7 @@ only schema that supports local caching or preset engines.
 
 Round trips are exact and enforced by tests. Timings are from Apple M4 with Redis
 8 on loopback at 1000 keywords — reproduce them and see the full tables on the
-[benchmarks page](docs/content/reference/benchmarks.md).
+[benchmarks page](https://skyoo2003.github.io/acor/reference/benchmarks/).
 
 | Operation | V1 (Legacy) | V2 (Optimized) |
 | --------- | ----------- | -------------- |
@@ -217,8 +217,9 @@ matches, err := ac.FindMany([]string{"he is him", "this is hers"})
 ```
 
 `AddMany`/`RemoveMany` plan the whole batch in one pass and commit it in a single
-transaction, so a batch costs two round trips regardless of size: 1000 keywords
-load in ~3 ms. Prefer them over a loop of `Add`.
+transaction, so a batch costs two round trips regardless of size. In the Apple
+M4/Redis 8 loopback sample, 1,000 keywords loaded in ~3 ms. Prefer them over a
+loop of `Add`.
 
 **Batch Modes:**
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,41 @@
 [![License](https://img.shields.io/github/license/skyoo2003/acor.svg)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/sponsor-GitHub-pink)](https://github.com/sponsors/skyoo2003)
 
+## Should you use ACOR?
+
+**Probably not, if you run a single process with a static dictionary.** An
+in-memory library like [`cloudflare/ahocorasick`](https://github.com/cloudflare/ahocorasick)
+or [`petar-dambovaliev/aho-corasick`](https://github.com/petar-dambovaliev/aho-corasick)
+is lighter and needs no infrastructure.
+
+**Use ACOR when several instances share one dictionary that changes at runtime.**
+A keyword added on one instance reaches the others in a measured p50 of 211 µs
+(p99 2.3 ms). An in-memory automaton has no equivalent number, because its answer
+is a redeploy.
+
+Matching runs in-process once the automaton is warm, with no Redis round trip.
+Over 1,000 keywords and a 640 B text on an Apple M4, `PresetSpeed` measures:
+
+| Operation | ns/op | B/op | allocs/op |
+| --------- | ----- | ---- | --------- |
+| `FindSet` — which patterns appear | 791 | 152 | 3 |
+| `Find` — every occurrence | 838 | 2,048 | 4 |
+| `FindMatches` — occurrences with positions | 1,678 | 4,264 | 6 |
+
+`PresetBalanced` holds that dictionary in 314 KiB of retained heap. Absolute times
+are hardware-bound and moved 20-25% between runs on the same machine, so read them
+as an order of magnitude; the
+[benchmarks page](docs/content/reference/benchmarks.md) has the method and the full
+tables.
+
 ## Overview
 
 ACOR implements the [Aho-Corasick algorithm](https://en.wikipedia.org/wiki/Aho%E2%80%93Corasick_algorithm) for efficient multi-pattern string matching, with all data structures persisted in Redis. This enables:
 
-- **Fast pattern matching** — O(n + m) complexity where n is text length and m is number of matches
-- **Distributed state** — Share pattern dictionaries across multiple application instances
-- **Persistence** — Pattern dictionaries survive application restarts
-- **Scalability** — Support for Redis Sentinel, Cluster, and Ring topologies
+- **Distributed state** — one pattern dictionary shared across every application instance
+- **Runtime updates** — change the dictionary without a redeploy; other instances pick it up via Pub/Sub
+- **Persistence** — dictionaries survive application restarts without being rebuilt
+- **Scalability** — Redis Sentinel, Cluster, and Ring topologies
 
 ## Use Cases
 
@@ -84,8 +111,10 @@ func main() {
 
 ## Match Details and Streaming
 
-Use `FindMatches` for ordered rune spans, `Contains` for an early-exit presence
-check, and `FindStream` for an `io.Reader`. See the
+`Find` reports every occurrence. Use `FindSet` to get each matched keyword once,
+`FindMatches` for ordered rune spans (`FindMatchesAppend` to reuse a buffer),
+`Contains` for an early-exit presence check, and `FindStream` for an `io.Reader`.
+See the
 [matching API reference](docs/content/reference/api.md#findmatches) for options
 and a compiled example.
 
@@ -131,7 +160,7 @@ ACOR supports two Redis schema versions:
 | V1 (Legacy)    | Multiple keys per collection | ~500K                  |
 | V2 (Optimized) | Fixed 3 keys per collection  | 3                      |
 
-**V2 is recommended** for new collections: `Add()` is ~13x faster, and V2 is the
+**V2 is recommended** for new collections: `Add()` is ~14x faster, and V2 is the
 only schema that supports local caching or preset engines.
 
 ### Performance Comparison
@@ -144,10 +173,10 @@ Round trips are exact and enforced by tests. Timings are from Apple M4 with Redi
 | --------- | ----------- | -------------- |
 | Find() round trips | 1 | 1 |
 | Add() round trips | grows with keyword length (53 at 5 chars, 507 at 26) | 2 |
-| Add() time | baseline | **~12x faster** |
+| Add() time | baseline | **~14x faster** |
 | Find() time, no cache | baseline | ~1.7x **slower** |
 | Find() time, `EnableCache` | n/a | ~15x faster |
-| Find() time, `PresetBalanced` | n/a | ~58x faster |
+| Find() time, `PresetBalanced` | n/a | ~59x faster |
 
 Uncached V2 `Find()` reads an outputs hash with one entry per trie state, where
 V1 reads only the keyword set, so it stays slightly slower on reads at one round
@@ -187,10 +216,18 @@ result, err = ac.RemoveMany([]string{"he", "her"})
 matches, err := ac.FindMany([]string{"he is him", "this is hers"})
 ```
 
+`AddMany`/`RemoveMany` plan the whole batch in one pass and commit it in a single
+transaction, so a batch costs two round trips regardless of size: 1000 keywords
+load in ~3 ms. Prefer them over a loop of `Add`.
+
 **Batch Modes:**
 
 - `BatchModeBestEffort`: Continues on errors, returns partial results
-- `BatchModeTransactional`: Rolls back all changes if any error occurs
+- `BatchModeTransactional`: All-or-nothing
+
+On V2 and preset collections both modes commit as one compare-and-set write, so a
+failure leaves nothing written and the modes differ only in how they report it. V1
+still writes per keyword and rolls back on failure.
 
 ## Parallel Matching
 
@@ -235,10 +272,9 @@ Redis is the source of truth; a local preset-optimized automaton handles reads w
 
 | Preset | Engine | Best For | Trade-off |
 |--------|--------|----------|-----------|
-| `PresetSpeed` | Full DFA + flat array | Real-time packet inspection, latency-critical paths | Higher memory (states x alphabet) |
+| `PresetSpeed` | Full DFA + flat array | Highest throughput; real-time inspection, latency-critical paths | Higher memory (states x alphabet) |
 | `PresetBalanced` | Double-Array Trie + Banded DFA | General-purpose keyword filtering | Balanced speed and memory |
 | `PresetMemoryEfficient` | Map-based + Bloom filter | Large-scale domain blocking, millions of patterns | Slower search |
-| `PresetUltimate` | SIMD pre-filter + Double-Array + Banded DFA | Production systems needing max throughput | Reasonable memory with highest speed |
 
 ## Local Caching
 

--- a/docs/content/reference/benchmarks.md
+++ b/docs/content/reference/benchmarks.md
@@ -30,14 +30,14 @@ CI fails.
 | `Add()`, 26-character keyword | 507 | 2 |
 
 Both schemas read in a single round trip: V1 issues one `SMEMBERS`, V2 pipelines
-two `HGETALL` calls into one trip. V1's round-trip cost is on **writes**, where
-it walks the trie node by node — cost grows with the length of the keyword being
-added, not with the size of the dictionary.
+two `HGETALL` calls into one trip. V1's round-trip cost is on **writes**, where it
+walks the trie node by node, so the cost grows with the length of the keyword being
+added rather than with the size of the dictionary.
 
 ```sh
 go test -run RTT ./pkg/acor
 
-# Same counts against a real server — that is what makes them structural
+# The same counts against a real server, which is what makes them structural
 ACOR_INTEGRATION_ADDR=localhost:6379 go test -run RTT ./pkg/acor
 ```
 
@@ -54,61 +54,78 @@ ACOR_INTEGRATION_ADDR=localhost:6379 \
 ```
 
 `make bench` runs the full sweep including the miniredis benchmarks. That takes
-several minutes and its timings are not published — see the caveats below.
+several minutes, and its timings are not published; see the caveats below.
 
 ### Find, 1000 keywords
 
 | Configuration | ns/op | B/op | allocs/op | vs V1 |
 |---|---|---|---|---|
-| V1 | 128,828 | 39,651 | 1,073 | baseline |
-| V2, no cache | 221,253 | 121,255 | 2,063 | ~1.7x slower |
-| V2 + `EnableCache`, warm | 8,561 | 8,010 | 65 | ~15x faster |
-| `PresetBalanced` | 2,224 | 2,160 | 7 | **~58x faster** |
+| V1 | 129,062 | 39,519 | 1,070 | baseline |
+| V2, no cache | 224,738 | 121,142 | 2,060 | ~1.7x slower |
+| V2 + `EnableCache`, warm | 8,631 | 7,898 | 62 | ~15x faster |
+| `PresetBalanced` | 2,204 | 2,048 | 4 | **~59x faster** |
 
 ### Find, 100 keywords
 
 | Configuration | ns/op | B/op | allocs/op | vs V1 |
 |---|---|---|---|---|
-| V1 | 71,928 | 8,238 | 161 | baseline |
-| V2, no cache | 79,853 | 11,256 | 222 | ~1.1x slower |
-| V2 + `EnableCache`, warm | 2,772 | 2,969 | 13 | ~26x faster |
-| `PresetBalanced` | 2,135 | 2,160 | 7 | ~34x faster |
+| V1 | 91,724 | 8,136 | 158 | baseline |
+| V2, no cache | 79,885 | 11,144 | 219 | ~1.1x faster |
+| V2 + `EnableCache`, warm | 3,120 | 2,857 | 10 | ~29x faster |
+| `PresetBalanced` | 2,214 | 2,048 | 4 | ~41x faster |
+
+At 100 keywords V1 and V2 are close enough that the winner changes between runs;
+only the 1000-keyword gap is stable.
 
 ### Add
 
 | Configuration | ns/op | vs V1 |
 |---|---|---|
-| V1 | 4,951,188 | baseline |
-| V2 | 391,556 | **~12x faster** |
+| V1 | 4,956,892 | baseline |
+| V2 | 353,149 | **~14x faster** |
+
+### Bulk load, `AddMany`
+
+`AddMany` plans the whole batch in one pass and commits it in a single
+transaction, so it costs two round trips regardless of batch size.
+
+| Keywords | ns/op | B/op | allocs/op |
+|---|---|---|---|
+| 100 | 422,665 | 199,850 | 1,079 |
+| 1,000 | 2,958,026 | 1,668,568 | 8,816 |
+
+Reproduce with `ACOR_INTEGRATION_ADDR=localhost:6379 make bench-module`.
 
 ### Run-to-run variance
 
-The `ns/op` columns are one run. Repeat runs on the same idle-ish laptop moved
-every absolute number by 20-25% while the ratios held to within about 15%.
+The `ns/op` columns are one run. Repeat runs on the same idle laptop moved every
+absolute number by 20-25% while the ratios held to within about 15%.
 
-This is why the ratios are stated approximately and the raw numbers are labelled
-as a sample. If your absolute figures differ from ours, that is expected. If your
-*ratios* differ substantially, that is worth reporting as an issue.
+That is why the ratios are stated approximately and the raw numbers are labelled a
+sample. Absolute figures differing from ours is expected; *ratios* differing
+substantially is worth reporting as an issue.
 
 ## What these numbers mean
 
-**V2 without caching is still somewhat slower than V1 on reads**, and the reason
-is payload rather than round trips. Both cost one trip, but V1's `SMEMBERS`
-returns just the keyword set while V2 must read an outputs hash carrying one
-entry per trie state. That gap widens with the dictionary: roughly parity at 100
-keywords, ~1.7x at 1000.
+**V2 without caching is still somewhat slower than V1 on reads**, because of
+payload rather than round trips. Both cost one trip, but V1's `SMEMBERS` returns
+just the keyword set while V2 must read an outputs hash carrying one entry per
+trie state. The gap widens with the dictionary: roughly parity at 100 keywords,
+~1.7x at 1000.
 
-Both schemas memoize the automaton, so an unchanged collection is not re-parsed
-or rebuilt between reads. Uncached V2 was ~9x slower than V1 before that
-memoization landed; the remainder is inherent to reading the whole outputs hash,
-and `EnableCache` is the fix for it.
+Both schemas memoize the automaton, so an unchanged collection is not re-parsed or
+rebuilt between reads. Uncached V2 was ~9x slower than V1 before that memoization
+landed; what remains is inherent to reading the whole outputs hash, and
+`EnableCache` is the fix for it.
 
-**The large read speedups come from caching, not from the schema.** 16x to 65x
-belongs to `EnableCache` and the `Preset` engines. Attributing it to V2 alone
-would misdescribe what a user gets by choosing V2 and nothing else.
+**The large read speedups come from caching, not from the schema.** 15x to 59x
+belongs to `EnableCache` and the `Preset` engines. Choosing V2 and nothing else
+does not deliver them.
 
-**V2's unambiguous win is writes.** 12.9x on `Add()`, and it is the only schema
-that supports caching or preset engines at all.
+**V2's unambiguous win is writes.** ~14x on `Add()`, and it is the only schema
+that supports caching or preset engines at all. Use `AddMany` rather than a loop
+over `Add`: it commits in a single transaction, so 1000 keywords cost 3.0 ms
+instead of the ~350 ms the same writes cost one at a time.
 
 Practical reading: choose V2, and enable `EnableCache` or a `Preset` if your
 workload is read-heavy. V2 with neither is the one configuration these numbers
@@ -117,11 +134,12 @@ do not recommend.
 ## Caveats
 
 - Loopback Redis has almost no network latency. Over a real network both schemas
-  still pay one round trip on `Find()`, so V2's larger payload matters more, not
-  less; V1's per-node `Add()` cost also grows with real latency.
-- These figures compare ACOR configurations against each other. They are not a
-  comparison against in-memory Aho-Corasick libraries, which answer a different
-  question — a single process with a static dictionary should use one of those.
+  still pay one round trip on `Find()`, so V2's larger payload matters more rather
+  than less, and V1's per-node `Add()` cost grows with the added latency.
+- These figures compare ACOR configurations against each other, not against other
+  Aho-Corasick implementations. A single process with a static dictionary is better
+  served by an in-memory library. ACOR earns its cost when several instances share
+  one dictionary that changes at runtime.
 - Every other benchmark in the repository runs on miniredis, an in-process
   emulator with no round-trip cost. Those exist for regression detection and are
   deliberately not published here.

--- a/docs/content/reference/benchmarks.md
+++ b/docs/content/reference/benchmarks.md
@@ -89,6 +89,8 @@ only the 1000-keyword gap is stable.
 `AddMany` plans the whole batch in one pass and commits it in a single
 transaction, so it costs two round trips regardless of batch size.
 
+On the Apple M4 with Redis 8 on loopback setup above, one sample measured:
+
 | Keywords | ns/op | B/op | allocs/op |
 |---|---|---|---|
 | 100 | 422,665 | 199,850 | 1,079 |
@@ -124,8 +126,9 @@ does not deliver them.
 
 **V2's unambiguous win is writes.** ~14x on `Add()`, and it is the only schema
 that supports caching or preset engines at all. Use `AddMany` rather than a loop
-over `Add`: it commits in a single transaction, so 1000 keywords cost 3.0 ms
-instead of the ~350 ms the same writes cost one at a time.
+over `Add`: it commits in a single transaction. In the Apple M4/Redis 8 loopback
+sample, 1,000 keywords cost 3.0 ms instead of the ~350 ms the same writes cost one
+at a time.
 
 Practical reading: choose V2, and enable `EnableCache` or a `Preset` if your
 workload is read-heavy. V2 with neither is the one configuration these numbers

--- a/docs/content/reference/schema-v2.md
+++ b/docs/content/reference/schema-v2.md
@@ -26,11 +26,22 @@ V2 consolidates storage into 3 keys:
 
 ## Comparison with V1
 
-| Metric | V1 | V2 | Improvement |
-|--------|----|----|-------------|
-| Keys per 100K keywords | ~500K | 3 | 166,667x |
-| Find() RTT | 3-5 per state | 3 total | 50-60x |
-| Memory efficiency | Lower | Higher | 10x+ |
+Round trips are counted by tests on every CI run; timings are a sample from the
+hardware named on the [benchmarks page](../benchmarks/).
+
+| Metric | V1 | V2 |
+|--------|----|----|
+| Keys per 100K keywords | ~500K | 3 |
+| `Find()` round trips | 1 | 1 |
+| `Add()` round trips | grows with keyword length (53 at 5 chars, 507 at 26) | 2 |
+| `Add()` time | baseline | ~14x faster |
+| `Find()` time, no cache | baseline | ~1.7x **slower** at 1000 keywords |
+
+V2's win is on writes, not reads. Both schemas read in a single round trip, and
+uncached V2 is slightly slower on `Find()` because it reads an outputs hash with
+one entry per trie state where V1 reads only the keyword set. The large read
+speedups belong to `EnableCache` and the preset engines, not to the schema. See
+[Benchmarks](../benchmarks/) for the full tables and how to reproduce them.
 
 ## Architecture
 


### PR DESCRIPTION
# Pull Request

## Description

Re-measures every published figure against the engine as it now stands, and documents
the API the preceding PRs added.

`README.md` gains a **"Should you use ACOR?"** section that leads with when *not* to
use it. A single process with a static dictionary is better served by an in-memory
library, and saying so up front is more useful than a feature list. The case for ACOR
is the number an in-memory automaton has no equivalent for: a keyword added on one
instance reaches the others in a measured p50 of 211 µs (p99 2.3 ms), where the
in-memory answer is a redeploy.

The overview bullets drop the "Fast pattern matching — O(n + m)" claim. Every
Aho-Corasick implementation has that complexity, so it described the algorithm rather
than anything about this library.

Number changes, all re-measured:

| Figure | Was | Now |
|---|---|---|
| `Add()` V2 vs V1 | ~12x | ~14x |
| `PresetBalanced` `Find`, 1000 keywords | ~58x faster than V1 | ~59x |
| `PresetBalanced` `Find`, 100 keywords | ~34x | ~41x |
| allocations per `Find` | 7 | 4 |
| bulk load (`AddMany`) | not published | new table |

At 100 keywords uncached V2 and V1 are now close enough that the winner changes
between runs, so that row is labelled as such instead of stating a direction only one
run supports.

`schema-v2.md` loses its "Find() RTT 3-5 per state / 50-60x" comparison. Both schemas
read in one round trip, and the large read speedups belong to `EnableCache` and the
preset engines, not to the schema; the table now states round trips as tests enforce
them and points at the benchmarks page.

Matching docs cover `FindSet`, `FindMatchesAppend` and how they differ from `Find`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] `make docs-verify` passes — all 12 embedded code blocks compile
- [x] Documentation updated if needed — this PR *is* the documentation update
- [x] Changelog fragment added (`changie new`) — **intentionally none**: the
      behaviour changes these numbers describe ship with the fragments in the PRs
      below, so a fragment here would double-announce them
- [x] Commit messages follow guidelines

## Additional Notes

Top of the stack, and deliberately last: every number here is an end-state
measurement, and `benchmarks.md` cites `make bench-module`, which only exists after
the PR below.

Reviewers may want to check the one genuinely new user-facing claim — the p50 211 µs
/ p99 2.3 ms propagation latency — against `benchmarks/propagation_test.go`, since it
is the figure the "use ACOR when" argument rests on.

If you would rather this be announced in the changelog too, the natural fragment is a
`Documentation` entry; I left it out because the underlying changes are already
covered.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).
