### PR TITLE
ci: stop auto-labeling breaking changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,11 +19,3 @@
 "enhancement":
   - changed-files:
       - any-glob-to-any-file: ["pkg/**/*.go"]
-
-# Public API surface: any change to the core package. Broad on purpose so new
-# files can't silently escape the label; a maintainer removes it when a change
-# in here isn't actually breaking (e.g. a test-only or comment change).
-"breaking_changes":
-  - changed-files:
-      - any-glob-to-any-file:
-          - "pkg/acor/*.go"


### PR DESCRIPTION
## Description

Remove the path-based `breaking_changes` labeler rule. Changes under `pkg/acor` are not necessarily public API breaks, so maintainers should apply this label manually when a PR actually introduces a breaking change.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — skipped because this is an internal CI change
- [x] Commit messages follow guidelines

## Additional Notes

The existing stale-workflow exemption for manually applied `breaking_changes` labels is unchanged.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).