### PR TITLE
feat: expose advanced operations in CLI

### DIFF
--- a/changes/unreleased/Added-20260804-235140.yaml
+++ b/changes/unreleased/Added-20260804-235140.yaml
@@ -1,0 +1,7 @@
+kind: Added
+body: >-
+  Expose batch operations, parallel matching, Redis-backed engine presets, and
+  local caching through the `acor` CLI
+time: 2026-08-04T23:51:40.000000+09:00
+custom:
+    Issue: "195"

--- a/cmd/acor/main.go
+++ b/cmd/acor/main.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/skyoo2003/acor/pkg/acor"
 )
@@ -24,9 +25,13 @@ const (
 
 Commands:
   add <keyword>
+  add-many <keyword>... | -
   remove <keyword>
+  remove-many <keyword>... | -
   find <input>
   find-index <input>
+  find-parallel <input> | -
+  find-index-parallel <input> | -
   suggest <input>
   suggest-index <input>
   info
@@ -49,17 +54,21 @@ func writeUsage(w io.Writer) {
 }
 
 const (
-	commandAdd             = "add"
-	commandRemove          = "remove"
-	commandFind            = "find"
-	commandFindIndex       = "find-index"
-	commandSuggest         = "suggest"
-	commandSuggestIndex    = "suggest-index"
-	commandInfo            = "info"
-	commandFlush           = "flush"
-	commandMigrate         = "migrate"
-	commandMigrateRollback = "migrate-rollback"
-	commandSchemaVersion   = "schema-version"
+	commandAdd               = "add"
+	commandAddMany           = "add-many"
+	commandRemove            = "remove"
+	commandRemoveMany        = "remove-many"
+	commandFind              = "find"
+	commandFindIndex         = "find-index"
+	commandFindParallel      = "find-parallel"
+	commandFindIndexParallel = "find-index-parallel"
+	commandSuggest           = "suggest"
+	commandSuggestIndex      = "suggest-index"
+	commandInfo              = "info"
+	commandFlush             = "flush"
+	commandMigrate           = "migrate"
+	commandMigrateRollback   = "migrate-rollback"
+	commandSchemaVersion     = "schema-version"
 
 	defaultCollectionName = "default"
 
@@ -70,9 +79,13 @@ const (
 
 type service interface {
 	Add(string) (int, error)
+	AddMany([]string, *acor.BatchOptions) (*acor.BatchResult, error)
 	Remove(string) (int, error)
+	RemoveManyWithOptions([]string, *acor.BatchOptions) (*acor.BatchResult, error)
 	Find(string) ([]string, error)
 	FindIndex(string) (map[string][]int, error)
+	FindParallel(string, *acor.ParallelOptions) ([]string, error)
+	FindIndexParallel(string, *acor.ParallelOptions) (map[string][]int, error)
 	Suggest(string) ([]string, error)
 	SuggestIndex(string) (map[string][]int, error)
 	Info() (*acor.AhoCorasickInfo, error)
@@ -84,31 +97,80 @@ type service interface {
 }
 
 type commandConfig struct {
-	addr        string
-	addrs       string
-	masterName  string
-	ringAddrs   string
-	password    string
-	db          int
-	name        string
-	debug       bool
-	dryRun      bool
-	keepOldKeys bool
+	addr         string
+	addrs        string
+	masterName   string
+	ringAddrs    string
+	password     string
+	db           int
+	name         string
+	debug        bool
+	cache        bool
+	preset       string
+	pollInterval time.Duration
+	batchMode    string
+	workers      int
+	chunkSize    int
+	boundary     string
+	overlap      int
+	dryRun       bool
+	keepOldKeys  bool
 }
 
-type commandRunner func(io.Writer, service, string, *migrateOptions) error
+type argumentMode int
+
+const (
+	argumentsNone argumentMode = iota
+	argumentsOne
+	argumentsOneOrMore
+)
+
+type commandRunner func(io.Reader, io.Writer, service, []string, *commandOptions) error
+
+type commandSpec struct {
+	runner commandRunner
+	mode   argumentMode
+}
+
+var commandSpecs = map[string]commandSpec{
+	commandAdd:               {runAdd, argumentsOne},
+	commandAddMany:           {runAddMany, argumentsOneOrMore},
+	commandRemove:            {runRemove, argumentsOne},
+	commandRemoveMany:        {runRemoveMany, argumentsOneOrMore},
+	commandFind:              {runFind, argumentsOne},
+	commandFindIndex:         {runFindIndex, argumentsOne},
+	commandFindParallel:      {runFindParallel, argumentsOne},
+	commandFindIndexParallel: {runFindIndexParallel, argumentsOne},
+	commandSuggest:           {runSuggest, argumentsOne},
+	commandSuggestIndex:      {runSuggestIndex, argumentsOne},
+	commandInfo:              {runInfo, argumentsNone},
+	commandFlush:             {runFlush, argumentsNone},
+	commandMigrate:           {runMigrate, argumentsNone},
+	commandMigrateRollback:   {runMigrateRollback, argumentsNone},
+	commandSchemaVersion:     {runSchemaVersion, argumentsNone},
+}
 
 func main() {
-	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, createService))
+	os.Exit(runWithInput(os.Args[1:], os.Stdin, os.Stdout, os.Stderr, createService))
 }
 
-type migrateOptions struct {
-	dryRun      bool
-	keepOldKeys bool
+type commandOptions struct {
+	dryRun           bool
+	keepOldKeys      bool
+	batchMode        acor.BatchMode
+	parallel         acor.ParallelOptions
+	batchFlagsSet    bool
+	parallelFlagsSet bool
+	pollFlagSet      bool
 }
 
 func run(args []string, stdout, stderr io.Writer, create func(*acor.AhoCorasickArgs) (service, error)) int {
-	config, migrateOpts, remaining, err := parseArgs(args)
+	return runWithInput(args, strings.NewReader(""), stdout, stderr, create)
+}
+
+func runWithInput(args []string, stdin io.Reader, stdout, stderr io.Writer,
+	create func(*acor.AhoCorasickArgs) (service, error)) int {
+	config, commandOpts, remaining, err := parseArgs(args)
 	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			writeUsage(stderr)
@@ -124,7 +186,7 @@ func run(args []string, stdout, stderr io.Writer, create func(*acor.AhoCorasickA
 	}
 
 	command := remaining[0]
-	runner, needsArg, err := commandHandler(command)
+	runner, argMode, err := commandHandler(command)
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, err.Error())
 		writeUsage(stderr)
@@ -133,14 +195,18 @@ func run(args []string, stdout, stderr io.Writer, create func(*acor.AhoCorasickA
 
 	// Both flags live on the single global flag set, so reject them rather than
 	// ignore them: a silently dropped -dry-run turns a preview into a real run.
-	if command != commandMigrate && (migrateOpts.dryRun || migrateOpts.keepOldKeys) {
+	if command != commandMigrate && (commandOpts.dryRun || commandOpts.keepOldKeys) {
 		_, _ = fmt.Fprintf(stderr, "-dry-run and -keep-old-keys only apply to the %q command\n", commandMigrate)
 		return exitCodeUsage
 	}
 
-	commandArg, err := commandArgument(command, remaining[1:], needsArg)
+	commandArgs, err := commandArguments(command, remaining[1:], argMode)
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, err.Error())
+		return exitCodeUsage
+	}
+	if validationErr := validateCommandOptions(command, config, commandOpts); validationErr != nil {
+		_, _ = fmt.Fprintln(stderr, validationErr.Error())
 		return exitCodeUsage
 	}
 
@@ -151,7 +217,7 @@ func run(args []string, stdout, stderr io.Writer, create func(*acor.AhoCorasickA
 	}
 	defer func() { _ = ac.Close() }()
 
-	if err := runner(stdout, ac, commandArg, migrateOpts); err != nil {
+	if err := runner(stdin, stdout, ac, commandArgs, commandOpts); err != nil {
 		_, _ = fmt.Fprintln(stderr, err.Error())
 		return 1
 	}
@@ -162,7 +228,13 @@ func run(args []string, stdout, stderr io.Writer, create func(*acor.AhoCorasickA
 // newFlagSet registers the global and migrate flags. It is also what writeUsage
 // renders, so the flag list cannot drift from the help text.
 func newFlagSet() (*flag.FlagSet, *commandConfig) {
-	config := &commandConfig{}
+	config := &commandConfig{
+		preset:    "none",
+		batchMode: "best-effort",
+		chunkSize: acor.DefaultChunkSize,
+		boundary:  "word",
+		overlap:   acor.DefaultOverlap,
+	}
 	fs := flag.NewFlagSet("acor", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
 	fs.StringVar(&config.addr, "addr", "", "Redis server address for standalone mode")
@@ -173,13 +245,21 @@ func newFlagSet() (*flag.FlagSet, *commandConfig) {
 	fs.IntVar(&config.db, "db", 0, "Redis DB number")
 	fs.StringVar(&config.name, "name", defaultCollectionName, "Pattern collection name")
 	fs.BoolVar(&config.debug, "debug", false, "Enable debug logging")
+	fs.BoolVar(&config.cache, "cache", false, "Enable the local V2 matching cache")
+	fs.StringVar(&config.preset, "preset", config.preset, "Local engine preset: none, speed, balanced, or memory-efficient")
+	fs.DurationVar(&config.pollInterval, "invalidation-poll-interval", 0, "Preset mode: poll interval for missed invalidations (for example 30s)")
+	fs.StringVar(&config.batchMode, "batch-mode", config.batchMode, "Batch mode: best-effort or transactional")
+	fs.IntVar(&config.workers, "workers", 0, "Parallel matching workers (0 uses the CPU count)")
+	fs.IntVar(&config.chunkSize, "chunk-size", config.chunkSize, "Parallel matching chunk size in runes")
+	fs.StringVar(&config.boundary, "boundary", config.boundary, "Parallel chunk boundary: word, sentence, or line")
+	fs.IntVar(&config.overlap, "overlap", config.overlap, "Parallel chunk overlap in runes")
 	fs.BoolVar(&config.dryRun, "dry-run", false, "migrate: preview migration without making changes")
 	fs.BoolVar(&config.keepOldKeys, "keep-old-keys", false, "migrate: keep V1 keys after migration (for rollback)")
 	fs.Usage = func() {}
 	return fs, config
 }
 
-func parseArgs(args []string) (*acor.AhoCorasickArgs, *migrateOptions, []string, error) {
+func parseArgs(args []string) (*acor.AhoCorasickArgs, *commandOptions, []string, error) {
 	fs, config := newFlagSet()
 
 	if err := fs.Parse(args); err != nil {
@@ -204,21 +284,106 @@ func parseArgs(args []string) (*acor.AhoCorasickArgs, *migrateOptions, []string,
 		return nil, nil, nil, errors.New("addrs must contain at least one address")
 	}
 
-	migrateOpts := &migrateOptions{
+	preset, err := parsePreset(config.preset)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	batchMode, err := parseBatchMode(config.batchMode)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	boundary, err := parseBoundary(config.boundary)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if validationErr := validateNumericOptions(config); validationErr != nil {
+		return nil, nil, nil, validationErr
+	}
+
+	seen := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) { seen[f.Name] = true })
+	commandOpts := &commandOptions{
 		dryRun:      config.dryRun,
 		keepOldKeys: config.keepOldKeys,
+		batchMode:   batchMode,
+		parallel: acor.ParallelOptions{
+			Workers:   config.workers,
+			ChunkSize: config.chunkSize,
+			Boundary:  boundary,
+			Overlap:   config.overlap,
+		},
+		batchFlagsSet:    seen["batch-mode"],
+		parallelFlagsSet: seen["workers"] || seen["chunk-size"] || seen["boundary"] || seen["overlap"],
+		pollFlagSet:      seen["invalidation-poll-interval"],
 	}
 
 	return &acor.AhoCorasickArgs{
-		Addr:       strings.TrimSpace(config.addr),
-		Addrs:      addrs,
-		MasterName: strings.TrimSpace(config.masterName),
-		RingAddrs:  ringAddrs,
-		Password:   config.password,
-		DB:         config.db,
-		Name:       config.name,
-		Debug:      config.debug,
-	}, migrateOpts, fs.Args(), nil
+		Addr:                     strings.TrimSpace(config.addr),
+		Addrs:                    addrs,
+		MasterName:               strings.TrimSpace(config.masterName),
+		RingAddrs:                ringAddrs,
+		Password:                 config.password,
+		DB:                       config.db,
+		Name:                     config.name,
+		Debug:                    config.debug,
+		EnableCache:              config.cache,
+		Preset:                   preset,
+		InvalidationPollInterval: config.pollInterval,
+	}, commandOpts, fs.Args(), nil
+}
+
+func parsePreset(raw string) (acor.Preset, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "none":
+		return acor.PresetNone, nil
+	case "speed":
+		return acor.PresetSpeed, nil
+	case "balanced":
+		return acor.PresetBalanced, nil
+	case "memory-efficient":
+		return acor.PresetMemoryEfficient, nil
+	default:
+		return acor.PresetNone, fmt.Errorf("unknown preset %q", raw)
+	}
+}
+
+func parseBatchMode(raw string) (acor.BatchMode, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "best-effort":
+		return acor.BatchModeBestEffort, nil
+	case "transactional":
+		return acor.BatchModeTransactional, nil
+	default:
+		return acor.BatchModeBestEffort, fmt.Errorf("unknown batch mode %q", raw)
+	}
+}
+
+func parseBoundary(raw string) (acor.ChunkBoundary, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "word":
+		return acor.ChunkBoundaryWord, nil
+	case "sentence":
+		return acor.ChunkBoundarySentence, nil
+	case "line":
+		return acor.ChunkBoundaryLine, nil
+	default:
+		return acor.ChunkBoundaryWord, fmt.Errorf("unknown boundary %q", raw)
+	}
+}
+
+func validateNumericOptions(config *commandConfig) error {
+	switch {
+	case config.workers < 0:
+		return errors.New("workers must be non-negative")
+	case config.chunkSize <= 0:
+		return errors.New("chunk-size must be positive")
+	case config.overlap < 0 || config.overlap >= config.chunkSize:
+		return errors.New("overlap must be non-negative and smaller than chunk-size")
+	case config.pollInterval < 0:
+		return errors.New("invalidation-poll-interval must be non-negative")
+	default:
+		return nil
+	}
 }
 
 func parseCSV(raw string) []string {
@@ -264,102 +429,157 @@ func parseRingAddrs(raw string) (map[string]string, error) {
 	return values, nil
 }
 
-func commandHandler(command string) (commandRunner, bool, error) {
-	switch command {
-	case commandAdd:
-		return runAdd, true, nil
-	case commandRemove:
-		return runRemove, true, nil
-	case commandFind:
-		return runFind, true, nil
-	case commandFindIndex:
-		return runFindIndex, true, nil
-	case commandSuggest:
-		return runSuggest, true, nil
-	case commandSuggestIndex:
-		return runSuggestIndex, true, nil
-	case commandInfo:
-		return runInfo, false, nil
-	case commandFlush:
-		return runFlush, false, nil
-	case commandMigrate:
-		return runMigrate, false, nil
-	case commandMigrateRollback:
-		return runMigrateRollback, false, nil
-	case commandSchemaVersion:
-		return runSchemaVersion, false, nil
-	default:
-		return nil, false, fmt.Errorf("unknown command %q", command)
+func commandHandler(command string) (commandRunner, argumentMode, error) {
+	spec, ok := commandSpecs[command]
+	if !ok {
+		return nil, argumentsNone, fmt.Errorf("unknown command %q", command)
 	}
+	return spec.runner, spec.mode, nil
 }
 
-func commandArgument(command string, args []string, needsArg bool) (string, error) {
-	if needsArg {
+func commandArguments(command string, args []string, mode argumentMode) ([]string, error) {
+	switch mode {
+	case argumentsOne:
 		if len(args) != 1 {
-			return "", fmt.Errorf("command %q requires exactly one argument", command)
+			return nil, fmt.Errorf("command %q requires exactly one argument", command)
 		}
-		return args[0], nil
+	case argumentsOneOrMore:
+		if len(args) == 0 {
+			return nil, fmt.Errorf("command %q requires at least one argument", command)
+		}
+	case argumentsNone:
+		if len(args) != 0 {
+			return nil, fmt.Errorf("command %q does not accept arguments", command)
+		}
+	}
+	return args, nil
+}
+
+func validateCommandOptions(command string, config *acor.AhoCorasickArgs, opts *commandOptions) error {
+	isBatch := command == commandAddMany || command == commandRemoveMany
+	if opts.batchFlagsSet && !isBatch {
+		return fmt.Errorf("-batch-mode only applies to %q and %q", commandAddMany, commandRemoveMany)
 	}
 
-	if len(args) != 0 {
-		return "", fmt.Errorf("command %q does not accept arguments", command)
+	isParallel := command == commandFindParallel || command == commandFindIndexParallel
+	if opts.parallelFlagsSet && !isParallel {
+		return fmt.Errorf("parallel matching options only apply to %q and %q", commandFindParallel, commandFindIndexParallel)
 	}
-	return "", nil
+
+	if config.EnableCache && config.Preset != acor.PresetNone {
+		return errors.New("-cache and -preset cannot be used together; preset mode already uses a local engine")
+	}
+	if opts.pollFlagSet && config.Preset == acor.PresetNone {
+		return errors.New("-invalidation-poll-interval requires -preset")
+	}
+	if config.Preset != acor.PresetNone &&
+		(command == commandMigrate || command == commandMigrateRollback) {
+		return fmt.Errorf("%q is unavailable in preset mode", command)
+	}
+	return nil
 }
 
 func createService(args *acor.AhoCorasickArgs) (service, error) {
 	return acor.Create(args)
 }
 
-func runAdd(stdout io.Writer, ac service, input string, _ *migrateOptions) error {
-	count, err := ac.Add(input)
+func runAdd(_ io.Reader, stdout io.Writer, ac service, args []string, _ *commandOptions) error {
+	count, err := ac.Add(args[0])
 	if err != nil {
 		return err
 	}
 	return writeJSON(stdout, map[string]int{jsonKeyCount: count})
 }
 
-func runRemove(stdout io.Writer, ac service, input string, _ *migrateOptions) error {
-	count, err := ac.Remove(input)
+func runAddMany(stdin io.Reader, stdout io.Writer, ac service, args []string, opts *commandOptions) error {
+	keywords, err := batchKeywords(stdin, args)
+	if err != nil {
+		return err
+	}
+	result, err := ac.AddMany(keywords, &acor.BatchOptions{Mode: opts.batchMode})
+	if err != nil {
+		return err
+	}
+	return writeBatchResult(stdout, "added", result.Added, result)
+}
+
+func runRemove(_ io.Reader, stdout io.Writer, ac service, args []string, _ *commandOptions) error {
+	count, err := ac.Remove(args[0])
 	if err != nil {
 		return err
 	}
 	return writeJSON(stdout, map[string]int{jsonKeyCount: count})
 }
 
-func runFind(stdout io.Writer, ac service, input string, _ *migrateOptions) error {
-	matches, err := ac.Find(input)
+func runRemoveMany(stdin io.Reader, stdout io.Writer, ac service, args []string, opts *commandOptions) error {
+	keywords, err := batchKeywords(stdin, args)
+	if err != nil {
+		return err
+	}
+	result, err := ac.RemoveManyWithOptions(keywords, &acor.BatchOptions{Mode: opts.batchMode})
+	if err != nil {
+		return err
+	}
+	return writeBatchResult(stdout, "removed", result.Removed, result)
+}
+
+func runFind(_ io.Reader, stdout io.Writer, ac service, args []string, _ *commandOptions) error {
+	matches, err := ac.Find(args[0])
 	if err != nil {
 		return err
 	}
 	return writeJSON(stdout, map[string][]string{jsonKeyMatches: matches})
 }
 
-func runFindIndex(stdout io.Writer, ac service, input string, _ *migrateOptions) error {
-	matches, err := ac.FindIndex(input)
+func runFindIndex(_ io.Reader, stdout io.Writer, ac service, args []string, _ *commandOptions) error {
+	matches, err := ac.FindIndex(args[0])
 	if err != nil {
 		return err
 	}
 	return writeJSON(stdout, map[string]map[string][]int{jsonKeyMatches: matches})
 }
 
-func runSuggest(stdout io.Writer, ac service, input string, _ *migrateOptions) error {
-	matches, err := ac.Suggest(input)
+func runFindParallel(stdin io.Reader, stdout io.Writer, ac service, args []string, opts *commandOptions) error {
+	input, err := textInput(stdin, args[0])
+	if err != nil {
+		return err
+	}
+	matches, err := ac.FindParallel(input, &opts.parallel)
 	if err != nil {
 		return err
 	}
 	return writeJSON(stdout, map[string][]string{jsonKeyMatches: matches})
 }
 
-func runSuggestIndex(stdout io.Writer, ac service, input string, _ *migrateOptions) error {
-	matches, err := ac.SuggestIndex(input)
+func runFindIndexParallel(stdin io.Reader, stdout io.Writer, ac service, args []string, opts *commandOptions) error {
+	input, err := textInput(stdin, args[0])
+	if err != nil {
+		return err
+	}
+	matches, err := ac.FindIndexParallel(input, &opts.parallel)
 	if err != nil {
 		return err
 	}
 	return writeJSON(stdout, map[string]map[string][]int{jsonKeyMatches: matches})
 }
 
-func runInfo(stdout io.Writer, ac service, _ string, _ *migrateOptions) error {
+func runSuggest(_ io.Reader, stdout io.Writer, ac service, args []string, _ *commandOptions) error {
+	matches, err := ac.Suggest(args[0])
+	if err != nil {
+		return err
+	}
+	return writeJSON(stdout, map[string][]string{jsonKeyMatches: matches})
+}
+
+func runSuggestIndex(_ io.Reader, stdout io.Writer, ac service, args []string, _ *commandOptions) error {
+	matches, err := ac.SuggestIndex(args[0])
+	if err != nil {
+		return err
+	}
+	return writeJSON(stdout, map[string]map[string][]int{jsonKeyMatches: matches})
+}
+
+func runInfo(_ io.Reader, stdout io.Writer, ac service, _ []string, _ *commandOptions) error {
 	info, err := ac.Info()
 	if err != nil {
 		return err
@@ -370,14 +590,14 @@ func runInfo(stdout io.Writer, ac service, _ string, _ *migrateOptions) error {
 	})
 }
 
-func runFlush(stdout io.Writer, ac service, _ string, _ *migrateOptions) error {
+func runFlush(_ io.Reader, stdout io.Writer, ac service, _ []string, _ *commandOptions) error {
 	if err := ac.Flush(); err != nil {
 		return err
 	}
 	return writeJSON(stdout, map[string]string{jsonKeyStatus: "ok"})
 }
 
-func runMigrate(stdout io.Writer, ac service, _ string, opts *migrateOptions) error {
+func runMigrate(_ io.Reader, stdout io.Writer, ac service, _ []string, opts *commandOptions) error {
 	result, err := ac.MigrateV1ToV2(&acor.MigrationOptions{
 		DryRun:      opts.dryRun,
 		KeepOldKeys: opts.keepOldKeys,
@@ -388,16 +608,62 @@ func runMigrate(stdout io.Writer, ac service, _ string, opts *migrateOptions) er
 	return writeJSON(stdout, result)
 }
 
-func runMigrateRollback(stdout io.Writer, ac service, _ string, _ *migrateOptions) error {
+func runMigrateRollback(_ io.Reader, stdout io.Writer, ac service, _ []string, _ *commandOptions) error {
 	if err := ac.RollbackToV1(); err != nil {
 		return err
 	}
 	return writeJSON(stdout, map[string]string{jsonKeyStatus: "rolled_back"})
 }
 
-func runSchemaVersion(stdout io.Writer, ac service, _ string, _ *migrateOptions) error {
+func runSchemaVersion(_ io.Reader, stdout io.Writer, ac service, _ []string, _ *commandOptions) error {
 	version := ac.SchemaVersion()
 	return writeJSON(stdout, map[string]int{"schema_version": version})
+}
+
+func batchKeywords(stdin io.Reader, args []string) ([]string, error) {
+	if len(args) != 1 || args[0] != "-" {
+		return args, nil
+	}
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return nil, fmt.Errorf("read batch input: %w", err)
+	}
+	if len(data) == 0 {
+		return []string{}, nil
+	}
+	lines := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	for i := range lines {
+		lines[i] = strings.TrimSuffix(lines[i], "\r")
+	}
+	return lines, nil
+}
+
+func textInput(stdin io.Reader, arg string) (string, error) {
+	if arg != "-" {
+		return arg, nil
+	}
+	data, err := io.ReadAll(stdin)
+	if err != nil {
+		return "", fmt.Errorf("read matching input: %w", err)
+	}
+	return string(data), nil
+}
+
+type batchFailure struct {
+	Keyword string `json:"keyword"`
+	Error   string `json:"error"`
+}
+
+func writeBatchResult(w io.Writer, changedKey string, changed []string, result *acor.BatchResult) error {
+	failed := make([]batchFailure, len(result.Failed))
+	for i, failure := range result.Failed {
+		failed[i] = batchFailure{Keyword: failure.Keyword, Error: fmt.Sprint(failure.Error)}
+	}
+	return writeJSON(w, map[string]interface{}{
+		changedKey: changed,
+		"failed":   failed,
+		"skipped":  result.Skipped,
+	})
 }
 
 func writeJSON(w io.Writer, value interface{}) error {

--- a/cmd/acor/main_test.go
+++ b/cmd/acor/main_test.go
@@ -18,18 +18,24 @@ const (
 )
 
 type fakeService struct {
-	addCount       int
-	removeCount    int
-	findMatches    []string
-	findIndexes    map[string][]int
-	suggestMatches []string
-	suggestIndexes map[string][]int
-	info           *acor.AhoCorasickInfo
-	err            error
-	flushCalls     int
-	closed         bool
-	lastInput      string
-	lastKeyword    string
+	addCount         int
+	batchResult      *acor.BatchResult
+	removeCount      int
+	findMatches      []string
+	findIndexes      map[string][]int
+	parallelMatches  []string
+	parallelIndexes  map[string][]int
+	suggestMatches   []string
+	suggestIndexes   map[string][]int
+	info             *acor.AhoCorasickInfo
+	err              error
+	flushCalls       int
+	closed           bool
+	lastInput        string
+	lastKeyword      string
+	lastKeywords     []string
+	lastBatchOpts    *acor.BatchOptions
+	lastParallelOpts *acor.ParallelOptions
 }
 
 func (f *fakeService) Add(keyword string) (int, error) {
@@ -40,12 +46,24 @@ func (f *fakeService) Add(keyword string) (int, error) {
 	return f.addCount, nil
 }
 
+func (f *fakeService) AddMany(keywords []string, opts *acor.BatchOptions) (*acor.BatchResult, error) {
+	f.lastKeywords = keywords
+	f.lastBatchOpts = opts
+	return f.batchResult, f.err
+}
+
 func (f *fakeService) Remove(keyword string) (int, error) {
 	f.lastKeyword = keyword
 	if f.err != nil {
 		return 0, f.err
 	}
 	return f.removeCount, nil
+}
+
+func (f *fakeService) RemoveManyWithOptions(keywords []string, opts *acor.BatchOptions) (*acor.BatchResult, error) {
+	f.lastKeywords = keywords
+	f.lastBatchOpts = opts
+	return f.batchResult, f.err
 }
 
 func (f *fakeService) Find(input string) ([]string, error) {
@@ -62,6 +80,18 @@ func (f *fakeService) FindIndex(input string) (map[string][]int, error) {
 		return nil, f.err
 	}
 	return f.findIndexes, nil
+}
+
+func (f *fakeService) FindParallel(input string, opts *acor.ParallelOptions) ([]string, error) {
+	f.lastInput = input
+	f.lastParallelOpts = opts
+	return f.parallelMatches, f.err
+}
+
+func (f *fakeService) FindIndexParallel(input string, opts *acor.ParallelOptions) (map[string][]int, error) {
+	f.lastInput = input
+	f.lastParallelOpts = opts
+	return f.parallelIndexes, f.err
 }
 
 func (f *fakeService) Suggest(input string) ([]string, error) {
@@ -128,6 +158,7 @@ func TestParseArgs(t *testing.T) {
 		"-db", "2",
 		"-name", collectionNameSample,
 		"-debug",
+		"-cache",
 		commandFind, testKeywordHello,
 	})
 	if err != nil {
@@ -146,14 +177,74 @@ func TestParseArgs(t *testing.T) {
 	if parsed.RingAddrs["shard-1"] != "127.0.0.1:7100" || parsed.RingAddrs["shard-2"] != "127.0.0.1:7101" {
 		t.Fatalf("unexpected ring addresses: %v", parsed.RingAddrs)
 	}
-	if len(parsed.RingAddrs) != 2 {
-		t.Fatalf("expected 2 ring addresses, got %v", parsed.RingAddrs)
-	}
-	if parsed.Password != "secret" || parsed.DB != 2 || parsed.Name != collectionNameSample || !parsed.Debug {
+	if parsed.Password != "secret" || parsed.DB != 2 || parsed.Name != collectionNameSample ||
+		!parsed.Debug || !parsed.EnableCache {
 		t.Fatalf("unexpected parsed args: %+v", parsed)
 	}
 	if len(remaining) != 2 || remaining[0] != commandFind || remaining[1] != testKeywordHello {
 		t.Fatalf("unexpected remaining args: %v", remaining)
+	}
+}
+
+func TestRunForwardsPresetConfiguration(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	exitCode := run([]string{
+		"-addr", "localhost:6379",
+		"-preset", "balanced",
+		"-invalidation-poll-interval", "30s",
+		"info",
+	}, stdout, stderr, func(args *acor.AhoCorasickArgs) (service, error) {
+		if args.Preset != acor.PresetBalanced || args.InvalidationPollInterval.String() != "30s" {
+			t.Fatalf("unexpected preset args %+v", args)
+		}
+		return &fakeService{info: &acor.AhoCorasickInfo{}}, nil
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", exitCode, stderr.String())
+	}
+}
+
+func TestRunRejectsInvalidFeatureOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "unknown preset", args: []string{"-preset", "fastest", "info"}, want: "unknown preset"},
+		{name: "unknown batch mode", args: []string{"-batch-mode", "atomic", "add-many", "foo"}, want: "unknown batch mode"},
+		{name: "unknown boundary", args: []string{"-boundary", "byte", "find-parallel", "text"}, want: "unknown boundary"},
+		{name: "negative workers", args: []string{"-workers", "-1", "find-parallel", "text"}, want: "workers must be non-negative"},
+		{name: "zero chunk size", args: []string{"-chunk-size", "0", "find-parallel", "text"}, want: "chunk-size must be positive"},
+		{name: "large overlap", args: []string{"-chunk-size", "10", "-overlap", "10", "find-parallel", "text"}, want: "overlap must be"},
+		{name: "batch option on find", args: []string{"-batch-mode", "best-effort", "find", "text"}, want: "only applies"},
+		{name: "parallel option on find", args: []string{"-workers", "2", "find", "text"}, want: "parallel matching options"},
+		{name: "cache with preset", args: []string{"-addr", "localhost:6379", "-cache", "-preset", "speed", "info"}, want: "cannot be used together"},
+		{name: "poll without preset", args: []string{"-invalidation-poll-interval", "30s", "info"}, want: "requires -preset"},
+		{name: "migrate in preset mode", args: []string{"-addr", "localhost:6379", "-preset", "balanced", "migrate"}, want: "unavailable in preset mode"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+			created := false
+			exitCode := run(tt.args, stdout, stderr, func(*acor.AhoCorasickArgs) (service, error) {
+				created = true
+				return &fakeService{}, nil
+			})
+			if exitCode != exitCodeUsage {
+				t.Fatalf("expected exit code %d, got %d", exitCodeUsage, exitCode)
+			}
+			if created {
+				t.Fatal("expected validation before service creation")
+			}
+			if !strings.Contains(stderr.String(), tt.want) {
+				t.Fatalf("expected stderr to contain %q, got %q", tt.want, stderr.String())
+			}
+		})
 	}
 }
 
@@ -204,6 +295,106 @@ func TestRunAddCommand(t *testing.T) {
 	}
 	if !fake.closed {
 		t.Fatal("expected service to be closed")
+	}
+}
+
+func TestRunAddManyCommand(t *testing.T) {
+	fake := &fakeService{batchResult: &acor.BatchResult{
+		Added:   []string{"foo"},
+		Failed:  []acor.KeywordError{{Keyword: "", Error: acor.ErrEmptyKeyword}},
+		Skipped: []string{"Foo"},
+	}}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	exitCode := run([]string{"-batch-mode", "transactional", "add-many", "foo", "Foo"}, stdout, stderr,
+		func(*acor.AhoCorasickArgs) (service, error) { return fake, nil })
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", exitCode, stderr.String())
+	}
+	if strings.Join(fake.lastKeywords, ",") != "foo,Foo" {
+		t.Fatalf("unexpected keywords %v", fake.lastKeywords)
+	}
+	if fake.lastBatchOpts == nil || fake.lastBatchOpts.Mode != acor.BatchModeTransactional {
+		t.Fatalf("unexpected batch options %+v", fake.lastBatchOpts)
+	}
+	want := "{\"added\":[\"foo\"],\"failed\":[{\"keyword\":\"\",\"error\":\"keyword cannot be empty\"}],\"skipped\":[\"Foo\"]}\n"
+	if stdout.String() != want {
+		t.Fatalf("unexpected stdout %q", stdout.String())
+	}
+}
+
+func TestRunRemoveManyReadsLinesFromStdin(t *testing.T) {
+	fake := &fakeService{batchResult: &acor.BatchResult{
+		Removed: []string{"foo", "hello world"},
+		Failed:  []acor.KeywordError{},
+		Skipped: []string{},
+	}}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	exitCode := runWithInput([]string{"remove-many", "-"}, strings.NewReader("foo\r\nhello world\n"), stdout, stderr,
+		func(*acor.AhoCorasickArgs) (service, error) { return fake, nil })
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", exitCode, stderr.String())
+	}
+	if strings.Join(fake.lastKeywords, ",") != "foo,hello world" {
+		t.Fatalf("unexpected stdin keywords %v", fake.lastKeywords)
+	}
+	if fake.lastBatchOpts == nil || fake.lastBatchOpts.Mode != acor.BatchModeBestEffort {
+		t.Fatalf("unexpected batch options %+v", fake.lastBatchOpts)
+	}
+	want := "{\"failed\":[],\"removed\":[\"foo\",\"hello world\"],\"skipped\":[]}\n"
+	if stdout.String() != want {
+		t.Fatalf("unexpected stdout %q", stdout.String())
+	}
+}
+
+func TestRunFindParallelReadsStdinAndForwardsOptions(t *testing.T) {
+	fake := &fakeService{parallelMatches: []string{"hello", "world"}}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	exitCode := runWithInput([]string{
+		"-workers", "3",
+		"-chunk-size", "100",
+		"-boundary", "line",
+		"-overlap", "10",
+		"find-parallel", "-",
+	}, strings.NewReader("hello\nworld\n"), stdout, stderr, func(*acor.AhoCorasickArgs) (service, error) {
+		return fake, nil
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", exitCode, stderr.String())
+	}
+	if fake.lastInput != "hello\nworld\n" {
+		t.Fatalf("unexpected input %q", fake.lastInput)
+	}
+	wantOpts := acor.ParallelOptions{Workers: 3, ChunkSize: 100, Boundary: acor.ChunkBoundaryLine, Overlap: 10}
+	if fake.lastParallelOpts == nil || *fake.lastParallelOpts != wantOpts {
+		t.Fatalf("unexpected parallel options %+v", fake.lastParallelOpts)
+	}
+	if stdout.String() != "{\"matches\":[\"hello\",\"world\"]}\n" {
+		t.Fatalf("unexpected stdout %q", stdout.String())
+	}
+}
+
+func TestRunFindIndexParallelCommand(t *testing.T) {
+	fake := &fakeService{parallelIndexes: map[string][]int{"he": {0, 6}}}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	exitCode := run([]string{"find-index-parallel", "hello hello"}, stdout, stderr,
+		func(*acor.AhoCorasickArgs) (service, error) { return fake, nil })
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", exitCode, stderr.String())
+	}
+	if stdout.String() != "{\"matches\":{\"he\":[0,6]}}\n" {
+		t.Fatalf("unexpected stdout %q", stdout.String())
 	}
 }
 
@@ -464,9 +655,13 @@ func TestRunCommandServiceErrors(t *testing.T) {
 		args []string
 	}{
 		{name: "add error", args: []string{"add", "kw"}},
+		{name: "add-many error", args: []string{"add-many", "kw"}},
 		{name: "remove error", args: []string{"remove", "kw"}},
+		{name: "remove-many error", args: []string{"remove-many", "kw"}},
 		{name: "find error", args: []string{"find", "input"}},
 		{name: "find-index error", args: []string{"find-index", "input"}},
+		{name: "find-parallel error", args: []string{"find-parallel", "input"}},
+		{name: "find-index-parallel error", args: []string{"find-index-parallel", "input"}},
 		{name: "suggest error", args: []string{"suggest", "input"}},
 		{name: "suggest-index error", args: []string{"suggest-index", "input"}},
 		{name: "info error", args: []string{"info"}},
@@ -524,6 +719,11 @@ func TestRunHelpFlag(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "Usage:") {
 		t.Fatalf("expected stderr to contain usage text, got %q", stderr.String())
+	}
+	for _, want := range []string{"add-many", "find-parallel", "-batch-mode", "-preset", "-cache"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("expected help to contain %q, got %q", want, stderr.String())
+		}
 	}
 }
 
@@ -618,28 +818,32 @@ func TestParseRingAddrs(t *testing.T) {
 
 func TestCommandHandler(t *testing.T) {
 	tests := []struct {
-		name     string
-		command  string
-		needsArg bool
-		wantErr  bool
+		name    string
+		command string
+		mode    argumentMode
+		wantErr bool
 	}{
-		{name: "add", command: "add", needsArg: true, wantErr: false},
-		{name: "remove", command: "remove", needsArg: true, wantErr: false},
-		{name: "find", command: "find", needsArg: true, wantErr: false},
-		{name: "find-index", command: "find-index", needsArg: true, wantErr: false},
-		{name: "suggest", command: "suggest", needsArg: true, wantErr: false},
-		{name: "suggest-index", command: "suggest-index", needsArg: true, wantErr: false},
-		{name: "info", command: "info", needsArg: false, wantErr: false},
-		{name: "flush", command: "flush", needsArg: false, wantErr: false},
-		{name: "migrate", command: "migrate", needsArg: false, wantErr: false},
-		{name: "migrate-rollback", command: "migrate-rollback", needsArg: false, wantErr: false},
-		{name: "schema-version", command: "schema-version", needsArg: false, wantErr: false},
-		{name: "unknown command", command: "bogus", needsArg: false, wantErr: true},
+		{name: "add", command: "add", mode: argumentsOne},
+		{name: "add-many", command: "add-many", mode: argumentsOneOrMore},
+		{name: "remove", command: "remove", mode: argumentsOne},
+		{name: "remove-many", command: "remove-many", mode: argumentsOneOrMore},
+		{name: "find", command: "find", mode: argumentsOne},
+		{name: "find-index", command: "find-index", mode: argumentsOne},
+		{name: "find-parallel", command: "find-parallel", mode: argumentsOne},
+		{name: "find-index-parallel", command: "find-index-parallel", mode: argumentsOne},
+		{name: "suggest", command: "suggest", mode: argumentsOne},
+		{name: "suggest-index", command: "suggest-index", mode: argumentsOne},
+		{name: "info", command: "info", mode: argumentsNone},
+		{name: "flush", command: "flush", mode: argumentsNone},
+		{name: "migrate", command: "migrate", mode: argumentsNone},
+		{name: "migrate-rollback", command: "migrate-rollback", mode: argumentsNone},
+		{name: "schema-version", command: "schema-version", mode: argumentsNone},
+		{name: "unknown command", command: "bogus", mode: argumentsNone, wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, needsArg, err := commandHandler(tt.command)
+			runner, mode, err := commandHandler(tt.command)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -655,32 +859,33 @@ func TestCommandHandler(t *testing.T) {
 			if runner == nil {
 				t.Fatal("expected runner, got nil")
 			}
-			if needsArg != tt.needsArg {
-				t.Fatalf("expected needsArg=%v, got %v", tt.needsArg, needsArg)
+			if mode != tt.mode {
+				t.Fatalf("expected mode=%v, got %v", tt.mode, mode)
 			}
 		})
 	}
 }
 
-func TestCommandArgument(t *testing.T) {
+func TestCommandArguments(t *testing.T) {
 	tests := []struct {
-		name     string
-		command  string
-		args     []string
-		needsArg bool
-		want     string
-		wantErr  bool
+		name    string
+		command string
+		args    []string
+		mode    argumentMode
+		wantErr bool
 	}{
-		{name: "needs arg with one arg", command: "find", args: []string{testKeywordHello}, needsArg: true, want: testKeywordHello, wantErr: false},
-		{name: "needs arg with no args", command: "find", args: []string{}, needsArg: true, want: "", wantErr: true},
-		{name: "needs arg with too many args", command: "find", args: []string{"a", "b"}, needsArg: true, want: "", wantErr: true},
-		{name: "no arg needed with no args", command: "info", args: []string{}, needsArg: false, want: "", wantErr: false},
-		{name: "no arg needed but gets args", command: "info", args: []string{"extra"}, needsArg: false, want: "", wantErr: true},
+		{name: "one arg", command: "find", args: []string{testKeywordHello}, mode: argumentsOne},
+		{name: "one arg missing", command: "find", mode: argumentsOne, wantErr: true},
+		{name: "one arg gets too many", command: "find", args: []string{"a", "b"}, mode: argumentsOne, wantErr: true},
+		{name: "many args", command: "add-many", args: []string{"a", "b"}, mode: argumentsOneOrMore},
+		{name: "many args missing", command: "add-many", mode: argumentsOneOrMore, wantErr: true},
+		{name: "no args", command: "info", mode: argumentsNone},
+		{name: "no args gets one", command: "info", args: []string{"extra"}, mode: argumentsNone, wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := commandArgument(tt.command, tt.args, tt.needsArg)
+			got, err := commandArguments(tt.command, tt.args, tt.mode)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -690,8 +895,8 @@ func TestCommandArgument(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if got != tt.want {
-				t.Fatalf("expected %q, got %q", tt.want, got)
+			if len(got) != len(tt.args) {
+				t.Fatalf("expected %v, got %v", tt.args, got)
 			}
 		})
 	}

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -60,6 +60,46 @@ Verify the CLI:
 acor --help
 ```
 
+CLI options must appear before the command. Batch commands accept keywords as
+arguments, or `-` as the only argument to read one keyword per line from stdin:
+
+```bash
+acor -addr localhost:6379 -batch-mode transactional add-many foo bar "hello world"
+printf 'foo\nbar\n' | acor -addr localhost:6379 remove-many -
+```
+
+`best-effort` is the default and reports per-keyword failures in JSON while
+returning success; `transactional` fails the command if the whole batch cannot
+be committed.
+
+Parallel matching accepts a text argument, or `-` to read the complete text
+from stdin. `word`, `sentence`, and `line` chunk boundaries are available:
+
+```bash
+acor -addr localhost:6379 -workers 8 -chunk-size 10000 \
+  -boundary line -overlap 100 find-parallel - < large.log
+
+acor -addr localhost:6379 -workers 8 \
+  find-index-parallel - < document.txt
+```
+
+Use `-cache` with the normal V2 engine, or select a Redis-backed local preset
+engine. Preset mode already keeps a local engine, so `-cache` and `-preset`
+cannot be combined:
+
+```bash
+acor -addr localhost:6379 -cache find-parallel - < document.txt
+
+acor -addr localhost:6379 -preset balanced \
+  -invalidation-poll-interval 30s find-parallel - < document.txt
+```
+
+Available presets are `speed`, `balanced`, and `memory-efficient`; `none` is
+the compatibility-preserving default. Preset mode requires an explicit Redis
+address and does not support `suggest`, `suggest-index`, or migration commands.
+The local cache is most useful for parallel matching, where every chunk shares
+one CLI process; a one-shot `find` invocation has no later lookup to reuse it.
+
 ## Next Steps
 
 - [Quick Start](../quick-start/) - Build your first application


### PR DESCRIPTION
# Pull Request

## Description

Expose the existing batch operations, parallel matching, Redis-backed preset engines, and local caching through the `acor` CLI.

- Add `add-many`, `remove-many`, `find-parallel`, and `find-index-parallel` commands.
- Accept newline-delimited batch input and complete matching text from stdin via `-`.
- Add batch, parallel, preset, cache, and invalidation polling options with CLI validation.
- Emit stable JSON for batch results, including readable per-keyword error strings.
- Document the new CLI workflows and constraints.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — uses PR #195 as the changie Issue value
- [x] Commit messages follow guidelines

## Additional Notes

- CLI options remain global and must appear before the command.
- `-cache` and `-preset` are intentionally mutually exclusive because preset mode already uses a local engine.
- Preset address and unsupported-operation errors remain owned by the public library API.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).