### PR TITLE
feat: prepare the public API for the v1 release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,13 @@ builds:
 - id: acor
   binary: acor
   main: cmd/acor/main.go
+  # Stamps `acor version`. Without this a release binary reports its "dev"
+  # default, so a bug report would not say which release it came from.
+  # .Version, not .Tag: it is the unprefixed number the brew formula, the OCI
+  # image.version label, and the archive names all carry, so `acor version` agrees
+  # with whatever the user downloaded.
+  ldflags:
+  - -s -w -X main.version={{ .Version }}
   goos:
   - darwin
   - linux
@@ -67,9 +74,10 @@ brews:
   license: "Apache-2.0"
   install: |
     bin.install "acor"
-  # acor has no version command, and every real command needs a Redis/Valkey
-  # server, so the usage text on exit code 2 is all that can be asserted here.
+  # Every real command needs a Redis/Valkey server, so the only things assertable
+  # here are the stamped version and the usage text on exit code 2.
   test: |
+    assert_match version.to_s, shell_output("#{bin}/acor version")
     assert_match "Usage:", shell_output("#{bin}/acor 2>&1", 2)
 
 dockers_v2:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thank you for your interest in contributing to ACOR! This document provides guid
 - [How Can I Contribute?](#how-can-i-contribute)
 - [Development Setup](#development-setup)
 - [Development Workflow](#development-workflow)
+- [Repository Layout](#repository-layout)
 - [Coding Standards](#coding-standards)
 - [Commit Messages](#commit-messages)
 - [Pull Requests](#pull-requests)
@@ -154,6 +155,28 @@ make clean
 ```
 
 Removes `dist/`, `coverage.out`, and `coverage.html`.
+
+## Repository Layout
+
+Three Go modules live in this repository:
+
+| Path          | Module                                 | Status                                        |
+| ------------- | -------------------------------------- | --------------------------------------------- |
+| `pkg/acor`    | `github.com/skyoo2003/acor`            | The library. Public API.                      |
+| `cmd/acor`    | same module                            | The CLI, released as a binary and image.      |
+| `server/`     | `github.com/skyoo2003/acor/server`     | Experimental. Separately versioned, untagged. |
+| `benchmarks/` | `github.com/skyoo2003/acor/benchmarks` | Test-only. Never published.                   |
+
+The library's import path is `github.com/skyoo2003/acor/pkg/acor` — the `pkg/`
+segment included. It stays that way deliberately: it is the path every released
+version has published, and moving the package to the module root would break every
+existing import to save eight characters. A proposal to flatten it needs to carry a
+migration plan for that, not just the shorter path.
+
+Both non-root modules keep a `replace` pointing at this checkout so local builds
+and CI compile against the core in the working tree. Go ignores a dependency's
+`replace`, so `server/go.mod`'s `require` for the core must name a released tag —
+that is the version an external consumer actually resolves.
 
 ## Coding Standards
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,16 +2,21 @@
 
 ## Supported Versions
 
-The following versions of ACOR are currently supported with security updates:
+ACOR is pre-1.0. Security patches go to the **latest released minor line only**,
+shipped as a new patch release. There is no long-term support branch, and earlier
+minor lines are not backported to.
 
-| Version | Supported |
-| ------- | --------- |
-| v2.x    | ✅        |
-| v1.8 - v1.x | ✅        |
-| < v1.8  | ❌        |
+| Version                | Supported |
+| ---------------------- | --------- |
+| Latest minor line      | ✅        |
+| Any earlier minor line | ❌        |
 
-"Supported" means the version receives security patches. Unsupported versions
-will not receive security fixes.
+See the [latest release](https://github.com/skyoo2003/acor/releases/latest) for
+which version that is, and upgrade to it before reporting a vulnerability so the
+report is against supported code.
+
+The experimental `acor/server` module publishes no tags of its own; fixes for it
+land on `main` and are consumed from there.
 
 ## Reporting a Vulnerability
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,7 +7,7 @@ If you need help with ACOR, here are the available channels:
 ### Documentation
 
 - **User Guide**: [GitHub Pages](https://skyoo2003.github.io/acor/)
-- **API Reference**: [pkg.go.dev](https://pkg.go.dev/github.com/skyoo2003/acor)
+- **API Reference**: [pkg.go.dev](https://pkg.go.dev/github.com/skyoo2003/acor/pkg/acor)
 
 ### Community
 

--- a/changes/unreleased/Added-20260805-000001.yaml
+++ b/changes/unreleased/Added-20260805-000001.yaml
@@ -1,0 +1,9 @@
+kind: Added
+body: >-
+  `CreateContext` constructs an instance with a context bounding the setup I/O
+  (schema check, initial keyword load, Pub/Sub subscribe). The context does not
+  bound the instance's lifetime, so canceling it cannot silently stop the
+  invalidation listener
+time: 2026-08-05T10:00:02.000000+09:00
+custom:
+    Issue: "196"

--- a/changes/unreleased/Added-20260805-000002.yaml
+++ b/changes/unreleased/Added-20260805-000002.yaml
@@ -1,0 +1,8 @@
+kind: Added
+body: >-
+  CLI commands `version`, `find-set`, `find-matches`, and `contains`, with
+  `-match-kind` and `-whole-word` for `find-matches`. `acor version` reports the
+  version stamped into release builds and needs no Redis
+time: 2026-08-05T10:00:03.000000+09:00
+custom:
+    Issue: "196"

--- a/changes/unreleased/Changed-20260805-000001.yaml
+++ b/changes/unreleased/Changed-20260805-000001.yaml
@@ -1,0 +1,8 @@
+kind: Changed
+body: >-
+  `RemoveMany` now takes `*BatchOptions` like `AddMany`, and `RemoveManyWithOptions`
+  is removed. Replace `RemoveMany(kw)` with `RemoveMany(kw, nil)` and
+  `RemoveManyWithOptions(kw, opts)` with `RemoveMany(kw, opts)`
+time: 2026-08-05T10:00:04.000000+09:00
+custom:
+    Issue: "196"

--- a/changes/unreleased/Deprecated-20260805-000001.yaml
+++ b/changes/unreleased/Deprecated-20260805-000001.yaml
@@ -1,0 +1,8 @@
+kind: Deprecated
+body: >-
+  `SchemaV1` is deprecated. V1 collections stay readable and writable and
+  `MigrateV1ToV2` converts them in place, but V1 gains no new features and support
+  for it may be removed in a future major version
+time: 2026-08-05T10:00:06.000000+09:00
+custom:
+    Issue: "196"

--- a/changes/unreleased/Documentation-20260805-000001.yaml
+++ b/changes/unreleased/Documentation-20260805-000001.yaml
@@ -1,0 +1,9 @@
+kind: Documentation
+body: >-
+  Corrected the security policy, which listed supported v1.x/v2.x lines that were
+  never released, and labeled the `acor/server` module experimental and separately
+  versioned. Documented the repository's module layout and why the library import
+  path keeps its `pkg/` segment
+time: 2026-08-05T10:00:07.000000+09:00
+custom:
+    Issue: "196"

--- a/changes/unreleased/Fixed-20260805-000001.yaml
+++ b/changes/unreleased/Fixed-20260805-000001.yaml
@@ -1,0 +1,8 @@
+kind: Fixed
+body: >-
+  `MigrateV1ToV2` and `RollbackToV1` no longer panic with a nil pointer dereference
+  when called on a Preset-mode instance. They return the new `ErrMigrationRequiresRedis`
+  instead, matching the check the CLI already performed
+time: 2026-08-05T10:00:00.000000+09:00
+custom:
+    Issue: "196"

--- a/changes/unreleased/Fixed-20260805-000002.yaml
+++ b/changes/unreleased/Fixed-20260805-000002.yaml
@@ -1,0 +1,8 @@
+kind: Fixed
+body: >-
+  `Create` now rejects `EnableCache` combined with a `Preset` (`ErrCacheWithPreset`)
+  instead of silently ignoring the cache setting. Preset mode already serves reads
+  from a local engine
+time: 2026-08-05T10:00:01.000000+09:00
+custom:
+    Issue: "196"

--- a/changes/unreleased/Fixed-20260805-000003.yaml
+++ b/changes/unreleased/Fixed-20260805-000003.yaml
@@ -1,0 +1,7 @@
+kind: Fixed
+body: >-
+  `Create(nil)` now returns the new `ErrNilArgs` instead of panicking with a nil
+  pointer dereference. `CreateContext` shares the guard
+time: 2026-08-05T10:00:08.000000+09:00
+custom:
+    Issue: "196"

--- a/changes/unreleased/Fixed-20260805-000004.yaml
+++ b/changes/unreleased/Fixed-20260805-000004.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: >-
+  The `acor` CLI now rejects `suggest` and `suggest-index` under `-preset` with the
+  usage exit code, instead of connecting, loading the whole dictionary, and then
+  failing with `ErrSuggestRequiresRedis`. `acor version` also no longer ignores
+  stray arguments and inapplicable flags
+time: 2026-08-05T10:00:09.000000+09:00
+custom:
+    Issue: "196"

--- a/changes/unreleased/Removed-20260805-000001.yaml
+++ b/changes/unreleased/Removed-20260805-000001.yaml
@@ -1,0 +1,8 @@
+kind: Removed
+body: >-
+  The exported V1 key-format constants `KeywordKey`, `PrefixKey`, `SuffixKey`,
+  `OutputKey`, and `NodeKey`. They never produced the keys ACOR writes (a real key
+  is hash-tagged, `{name}:keyword`) and nothing read them
+time: 2026-08-05T10:00:05.000000+09:00
+custom:
+    Issue: "196"

--- a/cmd/acor/main.go
+++ b/cmd/acor/main.go
@@ -30,6 +30,9 @@ Commands:
   remove-many <keyword>... | -
   find <input>
   find-index <input>
+  find-set <input>
+  find-matches <input>
+  contains <input>
   find-parallel <input> | -
   find-index-parallel <input> | -
   suggest <input>
@@ -39,10 +42,15 @@ Commands:
   migrate [options]
   migrate-rollback
   schema-version
+  version
 
 Options:
 `
 )
+
+// version is stamped at build time with -ldflags "-X main.version=vX.Y.Z". A
+// plain `go build` or `go install` leaves it "dev".
+var version = "dev"
 
 // writeUsage prints the command list followed by the flag set's own defaults,
 // so a flag's description lives only where the flag is registered.
@@ -60,6 +68,10 @@ const (
 	commandRemoveMany        = "remove-many"
 	commandFind              = "find"
 	commandFindIndex         = "find-index"
+	commandFindSet           = "find-set"
+	commandFindMatches       = "find-matches"
+	commandContains          = "contains"
+	commandVersion           = "version"
 	commandFindParallel      = "find-parallel"
 	commandFindIndexParallel = "find-index-parallel"
 	commandSuggest           = "suggest"
@@ -72,18 +84,31 @@ const (
 
 	defaultCollectionName = "default"
 
-	jsonKeyCount   = "count"
-	jsonKeyMatches = "matches"
-	jsonKeyStatus  = "status"
+	jsonKeyCount    = "count"
+	jsonKeyMatches  = "matches"
+	jsonKeyStatus   = "status"
+	jsonKeyContains = "contains"
 )
+
+// matchJSON is the wire shape for find-matches. acor.Match carries no JSON tags,
+// so marshaling it directly would emit Go field names among the CLI's snake_case
+// output — and adding tags upstream would change what library callers marshal.
+type matchJSON struct {
+	Keyword string `json:"keyword"`
+	Start   int    `json:"start"`
+	End     int    `json:"end"`
+}
 
 type service interface {
 	Add(string) (int, error)
 	AddMany([]string, *acor.BatchOptions) (*acor.BatchResult, error)
 	Remove(string) (int, error)
-	RemoveManyWithOptions([]string, *acor.BatchOptions) (*acor.BatchResult, error)
+	RemoveMany([]string, *acor.BatchOptions) (*acor.BatchResult, error)
 	Find(string) ([]string, error)
 	FindIndex(string) (map[string][]int, error)
+	FindSet(string) ([]string, error)
+	FindMatches(string, *acor.MatchOptions) ([]acor.Match, error)
+	Contains(string) (bool, error)
 	FindParallel(string, *acor.ParallelOptions) ([]string, error)
 	FindIndexParallel(string, *acor.ParallelOptions) (map[string][]int, error)
 	Suggest(string) ([]string, error)
@@ -113,6 +138,8 @@ type commandConfig struct {
 	chunkSize    int
 	boundary     string
 	overlap      int
+	matchKind    string
+	wholeWord    bool
 	dryRun       bool
 	keepOldKeys  bool
 }
@@ -139,6 +166,9 @@ var commandSpecs = map[string]commandSpec{
 	commandRemoveMany:        {runRemoveMany, argumentsOneOrMore},
 	commandFind:              {runFind, argumentsOne},
 	commandFindIndex:         {runFindIndex, argumentsOne},
+	commandFindSet:           {runFindSet, argumentsOne},
+	commandFindMatches:       {runFindMatches, argumentsOne},
+	commandContains:          {runContains, argumentsOne},
 	commandFindParallel:      {runFindParallel, argumentsOne},
 	commandFindIndexParallel: {runFindIndexParallel, argumentsOne},
 	commandSuggest:           {runSuggest, argumentsOne},
@@ -148,6 +178,7 @@ var commandSpecs = map[string]commandSpec{
 	commandMigrate:           {runMigrate, argumentsNone},
 	commandMigrateRollback:   {runMigrateRollback, argumentsNone},
 	commandSchemaVersion:     {runSchemaVersion, argumentsNone},
+	commandVersion:           {runVersion, argumentsNone},
 }
 
 func main() {
@@ -159,8 +190,10 @@ type commandOptions struct {
 	keepOldKeys      bool
 	batchMode        acor.BatchMode
 	parallel         acor.ParallelOptions
+	match            acor.MatchOptions
 	batchFlagsSet    bool
 	parallelFlagsSet bool
+	matchFlagsSet    bool
 	pollFlagSet      bool
 }
 
@@ -210,12 +243,20 @@ func runWithInput(args []string, stdin io.Reader, stdout, stderr io.Writer,
 		return exitCodeUsage
 	}
 
-	ac, err := create(config)
-	if err != nil {
-		_, _ = fmt.Fprintln(stderr, err.Error())
-		return 1
+	// version is the one command that must answer without a backend: it is what you
+	// run when the CLI misbehaves, which is exactly when Redis may be unreachable.
+	// It still passes through every check above, so stray arguments and misapplied
+	// flags are rejected for it like for any other command.
+	var ac service
+	if command != commandVersion {
+		created, createErr := create(config)
+		if createErr != nil {
+			_, _ = fmt.Fprintln(stderr, createErr.Error())
+			return 1
+		}
+		defer func() { _ = created.Close() }()
+		ac = created
 	}
-	defer func() { _ = ac.Close() }()
 
 	if err := runner(stdin, stdout, ac, commandArgs, commandOpts); err != nil {
 		_, _ = fmt.Fprintln(stderr, err.Error())
@@ -234,6 +275,7 @@ func newFlagSet() (*flag.FlagSet, *commandConfig) {
 		chunkSize: acor.DefaultChunkSize,
 		boundary:  "word",
 		overlap:   acor.DefaultOverlap,
+		matchKind: "overlapping",
 	}
 	fs := flag.NewFlagSet("acor", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -253,6 +295,11 @@ func newFlagSet() (*flag.FlagSet, *commandConfig) {
 	fs.IntVar(&config.chunkSize, "chunk-size", config.chunkSize, "Parallel matching chunk size in runes")
 	fs.StringVar(&config.boundary, "boundary", config.boundary, "Parallel chunk boundary: word, sentence, or line")
 	fs.IntVar(&config.overlap, "overlap", config.overlap, "Parallel chunk overlap in runes")
+	fs.StringVar(&config.matchKind, "match-kind", config.matchKind,
+		"find-matches: overlapping or leftmost-longest")
+	fs.BoolVar(&config.wholeWord, "whole-word", false,
+		"find-matches: drop matches whose neighboring runes are word characters "+
+			"(scripts without spaces between words, such as CJK, drop nearly every match)")
 	fs.BoolVar(&config.dryRun, "dry-run", false, "migrate: preview migration without making changes")
 	fs.BoolVar(&config.keepOldKeys, "keep-old-keys", false, "migrate: keep V1 keys after migration (for rollback)")
 	fs.Usage = func() {}
@@ -284,15 +331,7 @@ func parseArgs(args []string) (*acor.AhoCorasickArgs, *commandOptions, []string,
 		return nil, nil, nil, errors.New("addrs must contain at least one address")
 	}
 
-	preset, err := parsePreset(config.preset)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	batchMode, err := parseBatchMode(config.batchMode)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	boundary, err := parseBoundary(config.boundary)
+	enums, err := parseEnumOptions(config)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -305,15 +344,20 @@ func parseArgs(args []string) (*acor.AhoCorasickArgs, *commandOptions, []string,
 	commandOpts := &commandOptions{
 		dryRun:      config.dryRun,
 		keepOldKeys: config.keepOldKeys,
-		batchMode:   batchMode,
+		batchMode:   enums.batchMode,
 		parallel: acor.ParallelOptions{
 			Workers:   config.workers,
 			ChunkSize: config.chunkSize,
-			Boundary:  boundary,
+			Boundary:  enums.boundary,
 			Overlap:   config.overlap,
+		},
+		match: acor.MatchOptions{
+			Kind:      enums.matchKind,
+			WholeWord: config.wholeWord,
 		},
 		batchFlagsSet:    seen["batch-mode"],
 		parallelFlagsSet: seen["workers"] || seen["chunk-size"] || seen["boundary"] || seen["overlap"],
+		matchFlagsSet:    seen["match-kind"] || seen["whole-word"],
 		pollFlagSet:      seen["invalidation-poll-interval"],
 	}
 
@@ -327,7 +371,7 @@ func parseArgs(args []string) (*acor.AhoCorasickArgs, *commandOptions, []string,
 		Name:                     config.name,
 		Debug:                    config.debug,
 		EnableCache:              config.cache,
-		Preset:                   preset,
+		Preset:                   enums.preset,
 		InvalidationPollInterval: config.pollInterval,
 	}, commandOpts, fs.Args(), nil
 }
@@ -368,6 +412,51 @@ func parseBoundary(raw string) (acor.ChunkBoundary, error) {
 		return acor.ChunkBoundaryLine, nil
 	default:
 		return acor.ChunkBoundaryWord, fmt.Errorf("unknown boundary %q", raw)
+	}
+}
+
+// enumOptions holds the flags that map a string onto a library enum. They are
+// parsed together so parseArgs carries one error branch instead of four.
+type enumOptions struct {
+	preset    acor.Preset
+	batchMode acor.BatchMode
+	boundary  acor.ChunkBoundary
+	matchKind acor.MatchKind
+}
+
+func parseEnumOptions(config *commandConfig) (*enumOptions, error) {
+	preset, err := parsePreset(config.preset)
+	if err != nil {
+		return nil, err
+	}
+	batchMode, err := parseBatchMode(config.batchMode)
+	if err != nil {
+		return nil, err
+	}
+	boundary, err := parseBoundary(config.boundary)
+	if err != nil {
+		return nil, err
+	}
+	matchKind, err := parseMatchKind(config.matchKind)
+	if err != nil {
+		return nil, err
+	}
+	return &enumOptions{
+		preset:    preset,
+		batchMode: batchMode,
+		boundary:  boundary,
+		matchKind: matchKind,
+	}, nil
+}
+
+func parseMatchKind(raw string) (acor.MatchKind, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "overlapping":
+		return acor.MatchKindOverlapping, nil
+	case "leftmost-longest":
+		return acor.MatchKindLeftmostLongest, nil
+	default:
+		return acor.MatchKindOverlapping, fmt.Errorf("unknown match kind %q", raw)
 	}
 }
 
@@ -466,14 +555,36 @@ func validateCommandOptions(command string, config *acor.AhoCorasickArgs, opts *
 		return fmt.Errorf("parallel matching options only apply to %q and %q", commandFindParallel, commandFindIndexParallel)
 	}
 
+	if opts.matchFlagsSet && command != commandFindMatches {
+		return fmt.Errorf("-match-kind and -whole-word only apply to %q", commandFindMatches)
+	}
+
+	return validatePresetOptions(command, config, opts)
+}
+
+// presetUnsupported lists the commands the library refuses in preset mode:
+// ErrMigrationRequiresRedis for the migration pair, ErrSuggestRequiresRedis for
+// the prefix lookups the local engine holds no index for.
+var presetUnsupported = map[string]bool{
+	commandMigrate:         true,
+	commandMigrateRollback: true,
+	commandSuggest:         true,
+	commandSuggestIndex:    true,
+}
+
+// validatePresetOptions rejects flag and command combinations that preset mode
+// cannot honor. The library refuses the same combinations (ErrCacheWithPreset,
+// ErrMigrationRequiresRedis, ErrSuggestRequiresRedis); these checks name the
+// offending flag and fail with the usage exit code instead of after a connection
+// attempt and a full dictionary load.
+func validatePresetOptions(command string, config *acor.AhoCorasickArgs, opts *commandOptions) error {
 	if config.EnableCache && config.Preset != acor.PresetNone {
 		return errors.New("-cache and -preset cannot be used together; preset mode already uses a local engine")
 	}
 	if opts.pollFlagSet && config.Preset == acor.PresetNone {
 		return errors.New("-invalidation-poll-interval requires -preset")
 	}
-	if config.Preset != acor.PresetNone &&
-		(command == commandMigrate || command == commandMigrateRollback) {
+	if config.Preset != acor.PresetNone && presetUnsupported[command] {
 		return fmt.Errorf("%q is unavailable in preset mode", command)
 	}
 	return nil
@@ -516,7 +627,7 @@ func runRemoveMany(stdin io.Reader, stdout io.Writer, ac service, args []string,
 	if err != nil {
 		return err
 	}
-	result, err := ac.RemoveManyWithOptions(keywords, &acor.BatchOptions{Mode: opts.batchMode})
+	result, err := ac.RemoveMany(keywords, &acor.BatchOptions{Mode: opts.batchMode})
 	if err != nil {
 		return err
 	}
@@ -529,6 +640,34 @@ func runFind(_ io.Reader, stdout io.Writer, ac service, args []string, _ *comman
 		return err
 	}
 	return writeJSON(stdout, map[string][]string{jsonKeyMatches: matches})
+}
+
+func runFindSet(_ io.Reader, stdout io.Writer, ac service, args []string, _ *commandOptions) error {
+	matches, err := ac.FindSet(args[0])
+	if err != nil {
+		return err
+	}
+	return writeJSON(stdout, map[string][]string{jsonKeyMatches: matches})
+}
+
+func runFindMatches(_ io.Reader, stdout io.Writer, ac service, args []string, opts *commandOptions) error {
+	matches, err := ac.FindMatches(args[0], &opts.match)
+	if err != nil {
+		return err
+	}
+	out := make([]matchJSON, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, matchJSON{Keyword: m.Keyword, Start: m.Start, End: m.End})
+	}
+	return writeJSON(stdout, map[string][]matchJSON{jsonKeyMatches: out})
+}
+
+func runContains(_ io.Reader, stdout io.Writer, ac service, args []string, _ *commandOptions) error {
+	found, err := ac.Contains(args[0])
+	if err != nil {
+		return err
+	}
+	return writeJSON(stdout, map[string]bool{jsonKeyContains: found})
 }
 
 func runFindIndex(_ io.Reader, stdout io.Writer, ac service, args []string, _ *commandOptions) error {
@@ -616,8 +755,16 @@ func runMigrateRollback(_ io.Reader, stdout io.Writer, ac service, _ []string, _
 }
 
 func runSchemaVersion(_ io.Reader, stdout io.Writer, ac service, _ []string, _ *commandOptions) error {
-	version := ac.SchemaVersion()
-	return writeJSON(stdout, map[string]int{"schema_version": version})
+	// Not named `version`: that identifier is the build version at package scope.
+	schemaVersion := ac.SchemaVersion()
+	return writeJSON(stdout, map[string]int{"schema_version": schemaVersion})
+}
+
+// runVersion is the only runner that receives a nil service: runWithInput skips
+// create() for it so the build version is reportable without a reachable Redis.
+func runVersion(_ io.Reader, stdout io.Writer, _ service, _ []string, _ *commandOptions) error {
+	_, _ = fmt.Fprintln(stdout, version)
+	return nil
 }
 
 func batchKeywords(stdin io.Reader, args []string) ([]string, error) {

--- a/cmd/acor/main_test.go
+++ b/cmd/acor/main_test.go
@@ -36,6 +36,7 @@ type fakeService struct {
 	lastKeywords     []string
 	lastBatchOpts    *acor.BatchOptions
 	lastParallelOpts *acor.ParallelOptions
+	lastMatchOpts    *acor.MatchOptions
 }
 
 func (f *fakeService) Add(keyword string) (int, error) {
@@ -60,7 +61,7 @@ func (f *fakeService) Remove(keyword string) (int, error) {
 	return f.removeCount, nil
 }
 
-func (f *fakeService) RemoveManyWithOptions(keywords []string, opts *acor.BatchOptions) (*acor.BatchResult, error) {
+func (f *fakeService) RemoveMany(keywords []string, opts *acor.BatchOptions) (*acor.BatchResult, error) {
 	f.lastKeywords = keywords
 	f.lastBatchOpts = opts
 	return f.batchResult, f.err
@@ -72,6 +73,35 @@ func (f *fakeService) Find(input string) ([]string, error) {
 		return nil, f.err
 	}
 	return f.findMatches, nil
+}
+
+func (f *fakeService) FindSet(input string) ([]string, error) {
+	f.lastInput = input
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.findMatches, nil
+}
+
+func (f *fakeService) FindMatches(input string, opts *acor.MatchOptions) ([]acor.Match, error) {
+	f.lastInput = input
+	f.lastMatchOpts = opts
+	if f.err != nil {
+		return nil, f.err
+	}
+	out := make([]acor.Match, 0, len(f.findMatches))
+	for _, kw := range f.findMatches {
+		out = append(out, acor.Match{Keyword: kw, Start: 0, End: len([]rune(kw))})
+	}
+	return out, nil
+}
+
+func (f *fakeService) Contains(input string) (bool, error) {
+	f.lastInput = input
+	if f.err != nil {
+		return false, f.err
+	}
+	return len(f.findMatches) > 0, nil
 }
 
 func (f *fakeService) FindIndex(input string) (map[string][]int, error) {
@@ -588,6 +618,109 @@ func TestRunMigrateCommandWithDryRun(t *testing.T) {
 	}
 }
 
+// version must answer without a backend: it is what you run when the CLI is
+// misbehaving, which is exactly when Redis may be unreachable.
+func TestRunVersionCommandNeedsNoBackend(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	exitCode := run([]string{"version"}, stdout, stderr, func(*acor.AhoCorasickArgs) (service, error) {
+		t.Fatal("version must not construct a service")
+		return nil, nil
+	})
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", exitCode, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != version {
+		t.Fatalf("expected %q, got %q", version, stdout.String())
+	}
+}
+
+func TestRunMatchingCommands(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "find-set", args: []string{"find-set", "hehe"}, want: `"matches":["he"]`},
+		{name: "contains", args: []string{"contains", "hehe"}, want: `"contains":true`},
+		{
+			name: "find-matches",
+			args: []string{"find-matches", "hehe"},
+			want: `"matches":[{"keyword":"he","start":0,"end":2}]`,
+		},
+		{
+			name: "find-matches with options",
+			args: []string{"-match-kind", "leftmost-longest", "-whole-word", "find-matches", "hehe"},
+			want: `"keyword":"he"`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeService{findMatches: []string{testKeywordHE}}
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+
+			exitCode := run(tc.args, stdout, stderr, func(*acor.AhoCorasickArgs) (service, error) {
+				return fake, nil
+			})
+
+			if exitCode != 0 {
+				t.Fatalf("expected exit code 0, got %d with stderr %q", exitCode, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), tc.want) {
+				t.Fatalf("expected stdout to contain %q, got %q", tc.want, stdout.String())
+			}
+		})
+	}
+}
+
+func TestRunFindMatchesPassesOptions(t *testing.T) {
+	fake := &fakeService{findMatches: []string{testKeywordHE}}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	exitCode := run([]string{"-match-kind", "leftmost-longest", "-whole-word", "find-matches", "hehe"},
+		stdout, stderr, func(*acor.AhoCorasickArgs) (service, error) { return fake, nil })
+
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d with stderr %q", exitCode, stderr.String())
+	}
+	if fake.lastMatchOpts == nil {
+		t.Fatal("expected match options to reach FindMatches")
+	}
+	if fake.lastMatchOpts.Kind != acor.MatchKindLeftmostLongest {
+		t.Fatalf("expected leftmost-longest, got %v", fake.lastMatchOpts.Kind)
+	}
+	if !fake.lastMatchOpts.WholeWord {
+		t.Fatal("expected WholeWord to be set")
+	}
+}
+
+func TestRunRejectsMatchFlagsOnOtherCommands(t *testing.T) {
+	for _, args := range [][]string{
+		{"-match-kind", "leftmost-longest", "find", "text"},
+		{"-whole-word", "find-set", "text"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			fake := &fakeService{}
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+
+			exitCode := run(args, stdout, stderr, func(*acor.AhoCorasickArgs) (service, error) {
+				return fake, nil
+			})
+
+			if exitCode != exitCodeUsage {
+				t.Fatalf("expected exit code %d, got %d", exitCodeUsage, exitCode)
+			}
+			if !strings.Contains(stderr.String(), "only apply to") {
+				t.Fatalf("expected an explanatory error, got %q", stderr.String())
+			}
+		})
+	}
+}
+
 func TestRunRejectsMigrateFlagsOnOtherCommands(t *testing.T) {
 	for _, args := range [][]string{
 		{"-dry-run", "flush"},
@@ -979,6 +1112,84 @@ func TestParseArgsInvalidFlag(t *testing.T) {
 	_, _, _, err := parseArgs([]string{"-bogus", "info"})
 	if err == nil {
 		t.Fatal("expected error for invalid flag, got nil")
+	}
+}
+
+// commandSpecs is the dispatch table; commandsText is the hand-written help. A
+// command added to one and not the other is either invisible in `acor --help` or
+// advertised and unimplemented, and nothing else catches that.
+func TestUsageTextListsEveryCommand(t *testing.T) {
+	for command := range commandSpecs {
+		if !strings.Contains(commandsText, "\n  "+command) {
+			t.Errorf("command %q is dispatchable but missing from the usage text", command)
+		}
+	}
+
+	_, listed, ok := strings.Cut(commandsText, "Commands:\n")
+	if !ok {
+		t.Fatal(`usage text has no "Commands:" section`)
+	}
+	listed, _, _ = strings.Cut(listed, "\nOptions:")
+	for _, line := range strings.Split(listed, "\n") {
+		// The first field is the command name; the rest is argument syntax.
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if _, ok := commandSpecs[fields[0]]; !ok {
+			t.Errorf("usage text advertises %q, which has no commandSpecs entry", fields[0])
+		}
+	}
+}
+
+// version must reject what every other command rejects: the short-circuit that
+// keeps it from needing Redis must not also skip argument and flag validation.
+func TestRunVersionValidatesArguments(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{name: "stray argument", args: []string{"version", "extra"}},
+		{name: "migrate flag", args: []string{"-dry-run", "version"}},
+		{name: "match flag", args: []string{"-whole-word", "version"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+
+			exitCode := run(tc.args, stdout, stderr, func(*acor.AhoCorasickArgs) (service, error) {
+				t.Fatal("version must not construct a service")
+				return nil, nil
+			})
+
+			if exitCode != exitCodeUsage {
+				t.Fatalf("expected exit code %d, got %d with stdout %q", exitCodeUsage, exitCode, stdout.String())
+			}
+		})
+	}
+}
+
+// Preset mode has no prefix index, so the library answers ErrSuggestRequiresRedis.
+// The CLI must say so before connecting and loading the whole dictionary.
+func TestRunRejectsSuggestInPresetMode(t *testing.T) {
+	for _, command := range []string{"suggest", "suggest-index"} {
+		t.Run(command, func(t *testing.T) {
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+
+			exitCode := run([]string{"-addr", "localhost:6379", "-preset", "speed", command, "he"},
+				stdout, stderr, func(*acor.AhoCorasickArgs) (service, error) {
+					t.Fatal("preset-unsupported commands must fail before create()")
+					return nil, nil
+				})
+
+			if exitCode != exitCodeUsage {
+				t.Fatalf("expected exit code %d, got %d", exitCodeUsage, exitCode)
+			}
+			if !strings.Contains(stderr.String(), "unavailable in preset mode") {
+				t.Fatalf("expected an explanatory error, got %q", stderr.String())
+			}
+		})
 	}
 }
 

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -58,7 +58,11 @@ Verify the CLI:
 
 ```bash
 acor --help
+acor version
 ```
+
+`acor version` needs no Redis and prints the version stamped at release build
+time (`dev` for a locally built binary).
 
 CLI options must appear before the command. Batch commands accept keywords as
 arguments, or `-` as the only argument to read one keyword per line from stdin:
@@ -71,6 +75,26 @@ printf 'foo\nbar\n' | acor -addr localhost:6379 remove-many -
 `best-effort` is the default and reports per-keyword failures in JSON while
 returning success; `transactional` fails the command if the whole batch cannot
 be committed.
+
+Beyond `find` and `find-index`, the matching commands cover the set, span, and
+presence shapes of the same scan:
+
+```bash
+acor -addr localhost:6379 find-set "he is him"
+acor -addr localhost:6379 contains "he is him"
+acor -addr localhost:6379 -match-kind leftmost-longest -whole-word \
+  find-matches "he is him"
+```
+
+`find-set` reports each keyword once, `contains` stops at the first match, and
+`find-matches` reports each occurrence with its rune span in scan order.
+`-match-kind` and `-whole-word` apply only to `find-matches`.
+
+`-whole-word` assumes a script that separates words with spaces or punctuation.
+In scripts written without inter-word boundaries (CJK, Thai, …) every adjacent
+character counts as a word character, so nearly every match is treated as
+mid-word and dropped — scan such text without `-whole-word`, or use the library's
+`MatchOptions.WordRune` to supply your own boundary rule.
 
 Parallel matching accepts a text argument, or `-` to read the complete text
 from stdin. `word`, `sentence`, and `line` chunk boundaries are available:

--- a/docs/content/guides/batch-operations.md
+++ b/docs/content/guides/batch-operations.md
@@ -50,20 +50,25 @@ result, err := ac.AddMany(keywords, &acor.BatchOptions{
 
 ## Removing Multiple Keywords
 
+<!-- doccheck -->
 ```go
-result, err := ac.RemoveMany([]string{"he", "her"})
+result, err := ac.RemoveMany([]string{"he", "her"}, nil)
 if err != nil {
     panic(err)
 }
 fmt.Printf("Removed: %d\n", len(result.Removed))
 ```
 
-Use `RemoveManyWithOptions` to control the batch mode:
+`nil` options mean best-effort, the same default `AddMany` uses. Pass options to
+control the batch mode:
 
+<!-- doccheck -->
 ```go
-result, err := ac.RemoveManyWithOptions([]string{"he", "her"}, &acor.BatchOptions{
+result, err := ac.RemoveMany([]string{"he", "her"}, &acor.BatchOptions{
     Mode: acor.BatchModeTransactional,
 })
+_ = result
+_ = err
 ```
 
 ## Finding Matches in Multiple Texts

--- a/docs/content/operations/deployment.md
+++ b/docs/content/operations/deployment.md
@@ -140,6 +140,10 @@ services:
 
 ## Health Checks
 
+> `server/health` belongs to the experimental `acor/server` module, which is
+> versioned separately and not covered by the core compatibility promise. See
+> [Monitoring](../monitoring/) for what that means for your `go.mod`.
+
 The `server/health` package registers Kubernetes-compatible endpoints on an
 `http.ServeMux`:
 

--- a/docs/content/operations/monitoring.md
+++ b/docs/content/operations/monitoring.md
@@ -7,6 +7,17 @@ weight: 2
 
 Monitor ACOR performance with built-in observability support.
 
+> **The `server/*` packages on this page are experimental.** They live in the
+> separate `github.com/skyoo2003/acor/server` module, which publishes no version
+> tags of its own and is **not covered by the core module's compatibility
+> promise** — its API can change in any release. The core library (`pkg/acor`) is
+> unaffected.
+>
+> `go get github.com/skyoo2003/acor/server` resolves a pseudo-version from `main`.
+> Pin the core module explicitly in the same `go.mod`: Go ignores a dependency's
+> own `replace` directive, so without a pin you get whichever core version the
+> server module's `require` names.
+
 ## Overview
 
 ACOR provides three pillars of observability:

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -32,12 +32,12 @@ type AhoCorasickArgs struct {
     Name                            string            // Collection name (required)
     Debug                           bool              // Enable debug logging to stdout
     Logger                          Logger            // Custom logger (nil disables logging)
-    SchemaVersion                   int               // 0 or 2: V2 (default, optimized); 1: V1 (legacy)
-    EnableCache                     bool              // Enable local in-memory caching for Find/FindIndex
+    SchemaVersion                   int               // 0 or 2: V2 (default, optimized); 1: V1 (deprecated)
+    EnableCache                     bool              // Local caching for Find/FindIndex (V2 only, not with Preset)
     SelfInvalidationCleanupInterval uint64            // Cleanup frequency for self-invalidation map (default: 128)
     CaseSensitive                   bool              // Enable case-sensitive matching (default: false)
     RollbackTimeout                 time.Duration     // V1 rollback timeout (default: 10s)
-    Preset                           Preset            // Architecture preset (default: PresetNone)
+    Preset                          Preset            // Architecture preset (default: PresetNone)
     InvalidationPollInterval        time.Duration     // Preset version polling (zero: disabled)
 }
 ```
@@ -51,6 +51,26 @@ Main type for pattern matching operations.
 ac, err := acor.Create(&acor.AhoCorasickArgs{...})
 defer ac.Close()
 ```
+
+`CreateContext` is the same constructor with a context bounding the setup I/O
+(schema check and initialization write, initial keyword load):
+
+<!-- doccheck -->
+```go
+setupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+defer cancel()
+instance, err := acor.CreateContext(setupCtx, &acor.AhoCorasickArgs{
+    Addr: "localhost:6379",
+    Name: "default",
+})
+_ = instance
+_ = err
+```
+
+The context bounds construction only. Canceling it afterwards does not close the
+instance or stop its invalidation listener — use `Close` for that, and the
+`*Context` methods for per-operation cancellation. The Pub/Sub subscribe is part
+of that listener, so it runs on the instance's own context rather than this one.
 
 ## Core Methods
 
@@ -86,12 +106,15 @@ count, err := ac.Remove("keyword")
 
 Remove multiple keywords in a batch.
 
+<!-- doccheck -->
 ```go
-result, err := ac.RemoveMany([]string{"a", "b"})
-// Use RemoveManyWithOptions when transactional behavior is required.
-result, err = ac.RemoveManyWithOptions([]string{"c", "d"}, &acor.BatchOptions{
+result, err := ac.RemoveMany([]string{"a", "b"}, nil)
+// Pass options when transactional behavior is required.
+result, err = ac.RemoveMany([]string{"c", "d"}, &acor.BatchOptions{
     Mode: acor.BatchModeTransactional,
 })
+_ = result
+_ = err
 ```
 
 ### Find

--- a/docs/content/reference/schema-v1.md
+++ b/docs/content/reference/schema-v1.md
@@ -1,11 +1,16 @@
 ---
-title: "Schema V1 (Legacy)"
+title: "Schema V1 (Deprecated)"
 weight: 2
 ---
 
-# Schema V1 (Legacy)
+# Schema V1 (Deprecated)
 
 V1 is the original ACOR storage schema. It uses multiple Redis keys per collection.
+
+> **V1 is deprecated.** It stays readable and writable so existing collections keep
+> working, and `MigrateV1ToV2` converts them in place, but it gains no new features:
+> preset engines and `EnableCache` both require V2. New collections should use the
+> default V2 schema. Support for V1 may be removed in a future major version.
 
 ## Overview
 

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -10,7 +10,7 @@
 //
 //   - Redis-backed storage for distributed state and persistence
 //   - Support for multiple Redis topologies: Standalone, Sentinel, Cluster, and Ring
-//   - Two schema versions: V1 (legacy) and V2 (optimized with fewer keys)
+//   - Two schema versions: V2 (optimized, default) and V1 (deprecated, see SchemaV1)
 //   - Thread-safe operations with optimistic locking (V2)
 //   - Batch operations for bulk keyword management
 //   - Parallel text matching for improved performance on large texts
@@ -78,11 +78,12 @@
 //
 // # Schema Versions
 //
-// V1 (SchemaVersion: 1): Legacy schema using multiple Redis keys for each prefix/suffix/output.
-// Suitable for small collections but creates many keys.
-//
 // V2 (SchemaVersion: 2, default): Optimized schema consolidating data into 3 keys.
-// Recommended for most use cases. Uses Lua scripts for atomic operations.
+// Recommended for every use case. Uses Lua scripts for atomic operations.
+//
+// V1 (SchemaVersion: 1): Deprecated legacy schema using multiple Redis keys for each
+// prefix/suffix/output. Kept for existing collections only; migrate with
+// MigrateV1ToV2. New collections should not select it.
 //
 // # Batch Operations
 //
@@ -256,12 +257,15 @@ type AhoCorasickArgs struct {
 	Logger Logger
 	// SchemaVersion specifies the storage schema to use:
 	//   - 0 or 2: V2 schema (default, optimized, 3 keys)
-	//   - 1: V1 schema (legacy, multiple keys per prefix)
+	//   - 1: V1 schema (deprecated, multiple keys per prefix — see SchemaV1)
 	SchemaVersion int
 	// EnableCache enables local in-memory caching of trie data for Find/FindIndex operations.
 	// When enabled, prefixes and outputs are cached after the first read and invalidated
 	// via Redis Pub/Sub when any instance modifies the collection. Reduces Redis round-trips
 	// for read-heavy workloads at the cost of increased memory usage.
+	//
+	// Requires V2 (ErrCacheRequiresV2 otherwise) and cannot be combined with Preset,
+	// which already serves reads from a local engine (ErrCacheWithPreset).
 	EnableCache bool
 	// SelfInvalidationCleanupInterval controls how often the expired self-invalidation
 	// sweep runs relative to publishInvalidate calls. Every N publishes triggers one O(n)
@@ -339,8 +343,8 @@ type AhoCorasickInfo struct {
 	// Nodes is the number of trie nodes (prefixes) in the automaton.
 	// This is typically larger than Keywords as it includes all prefixes.
 	Nodes int
-	// Preset is the engine architecture preset, or the internal default
-	// sentinel (-1) when using the original non-preset engine.
+	// Preset is the engine architecture preset, or PresetNone when using the
+	// original non-preset engine.
 	Preset Preset
 	// MemoryBytes is the estimated memory usage in bytes.
 	// Zero when using the original non-preset engine.
@@ -375,6 +379,24 @@ type AhoCorasickInfo struct {
 //	}
 //	defer ac.Close()
 func Create(args *AhoCorasickArgs) (*AhoCorasick, error) {
+	return CreateContext(context.Background(), args)
+}
+
+// CreateContext is Create with an explicit context governing the setup I/O: the
+// schema check and initialization write, and the initial keyword load. A canceled
+// or expired ctx fails the construction.
+//
+// ctx does not bound the returned instance's lifetime. Background work that must
+// outlive construction — the Pub/Sub subscribe, the invalidation listener, and the
+// version poller — runs on an internal context tied to Close instead, so passing a
+// request-scoped ctx here cannot leave a live instance whose listener has silently
+// stopped. That also means ctx does not bound the subscribe itself.
+// Per-operation cancellation is what the *Context methods (FindContext, AddContext,
+// …) are for.
+func CreateContext(ctx context.Context, args *AhoCorasickArgs) (*AhoCorasick, error) {
+	if args == nil {
+		return nil, ErrNilArgs
+	}
 	if strings.Contains(args.Name, ":") {
 		return nil, ErrInvalidName
 	}
@@ -387,11 +409,16 @@ func Create(args *AhoCorasickArgs) (*AhoCorasick, error) {
 		if args.SchemaVersion == SchemaV1 {
 			return nil, ErrPresetRequiresV2
 		}
-		return createPresetRedis(args)
+		// Rejected rather than ignored: preset mode never reads args.EnableCache, so
+		// setting both used to silently drop the caching the caller asked for.
+		if args.EnableCache {
+			return nil, ErrCacheWithPreset
+		}
+		return createPresetRedis(ctx, args)
 	}
 
 	// --- Branch 3: Original mode (unchanged) ---
-	return createOriginal(args)
+	return createOriginal(ctx, args)
 }
 
 func newLogger(args *AhoCorasickArgs) Logger {
@@ -406,11 +433,10 @@ func newLogger(args *AhoCorasickArgs) Logger {
 }
 
 // createPresetRedis creates a Redis-backed AhoCorasick with a local preset-optimized
-// engine. The internal context is derived from context.Background() since the
-// Create() API does not accept a caller context. Long-lived Pub/Sub and reload
-// operations use this context.
-func createPresetRedis(args *AhoCorasickArgs) (*AhoCorasick, error) {
-	rbAC, err := newRedisBacked(context.Background(), args)
+// engine. ctx covers setup only; newRedisBacked keeps its own Background-derived
+// context for the long-lived Pub/Sub listener and reloads, per CreateContext.
+func createPresetRedis(ctx context.Context, args *AhoCorasickArgs) (*AhoCorasick, error) {
+	rbAC, err := newRedisBacked(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -429,7 +455,7 @@ func createPresetRedis(args *AhoCorasickArgs) (*AhoCorasick, error) {
 	return ac, nil
 }
 
-func createOriginal(args *AhoCorasickArgs) (*AhoCorasick, error) {
+func createOriginal(ctx context.Context, args *AhoCorasickArgs) (*AhoCorasick, error) {
 	logger := newLogger(args)
 
 	redisClient, err := newRedisClient(args)
@@ -473,6 +499,8 @@ func createOriginal(args *AhoCorasickArgs) (*AhoCorasick, error) {
 	}
 	ac.rollbackTimeout = resolveRollbackTimeout(args.RollbackTimeout)
 	ac.caseSensitive = args.CaseSensitive
+	// Background, not the caller's ctx: this context outlives Create and is what
+	// Close cancels. See CreateContext.
 	ac.ctx, ac.cancel = context.WithCancel(context.Background()) //nolint:gosec // G118: storing cancel func is intentional for lifecycle management
 
 	if schemaVersion == SchemaV2 {
@@ -481,7 +509,7 @@ func createOriginal(args *AhoCorasickArgs) (*AhoCorasick, error) {
 		ac.ops = ac.newV1Ops()
 	}
 
-	if err := ac.init(); err != nil {
+	if err := ac.init(ctx); err != nil {
 		ac.cancel()
 		_ = storage.Close()
 		return nil, err
@@ -509,14 +537,17 @@ func (ac *AhoCorasick) SchemaVersion() int {
 	return ac.schemaVersion
 }
 
-func (ac *AhoCorasick) init() error {
+// init performs the one-time schema setup. ctx is the caller's construction
+// context, not ac.ctx: a caller that gave up waiting should not leave Create
+// blocked on Redis.
+func (ac *AhoCorasick) init(ctx context.Context) error {
 	if ac.schemaVersion == SchemaV2 {
-		exists, err := ac.storage.Exists(ac.ctx, trieKey(ac.name))
+		exists, err := ac.storage.Exists(ctx, trieKey(ac.name))
 		if err != nil {
 			return fmt.Errorf("failed to check trie key: %w", err)
 		}
 		if exists == 0 {
-			err := ac.storage.HSet(ac.ctx, trieKey(ac.name), emptyTrieFields())
+			err := ac.storage.HSet(ctx, trieKey(ac.name), emptyTrieFields())
 			if err != nil {
 				return fmt.Errorf("failed to initialize V2 trie: %w", err)
 			}
@@ -529,7 +560,7 @@ func (ac *AhoCorasick) init() error {
 		Score:  initScore,
 		Member: "",
 	}
-	if err := ac.storage.ZAdd(ac.ctx, prefixKey, member); err != nil {
+	if err := ac.storage.ZAdd(ctx, prefixKey, member); err != nil {
 		return fmt.Errorf("failed to initialize V1 prefix key: %w", err)
 	}
 	return nil

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -297,21 +297,19 @@ func (ac *AhoCorasick) rollbackBatch(ctx context.Context, keywords []string, op 
 
 // RemoveMany removes multiple keywords from the Aho-Corasick automaton.
 // This is more efficient than calling Remove repeatedly for large keyword sets.
-// Uses best-effort mode by default. Use RemoveManyWithOptions for batch mode control.
+//
+// The opts parameter controls error handling behavior, exactly as in AddMany:
+//   - nil or BatchModeBestEffort: continues on errors, returns partial results
+//   - BatchModeTransactional: re-adds what it removed on first error
 //
 // Example:
 //
-//	result, err := ac.RemoveMany([]string{"foo", "bar"})
+//	result, err := ac.RemoveMany([]string{"foo", "bar"}, nil)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
 //	fmt.Printf("Removed %d keywords\n", len(result.Removed))
-func (ac *AhoCorasick) RemoveMany(keywords []string) (*BatchResult, error) {
-	return ac.RemoveManyContext(ac.ctx, keywords, nil)
-}
-
-// RemoveManyWithOptions removes multiple keywords with batch options.
-func (ac *AhoCorasick) RemoveManyWithOptions(keywords []string, opts *BatchOptions) (*BatchResult, error) {
+func (ac *AhoCorasick) RemoveMany(keywords []string, opts *BatchOptions) (*BatchResult, error) {
 	return ac.RemoveManyContext(ac.ctx, keywords, opts)
 }
 

--- a/pkg/acor/batch_coalesce_test.go
+++ b/pkg/acor/batch_coalesce_test.go
@@ -115,7 +115,7 @@ func TestRemoveMany_CoalescesRebuild(t *testing.T) {
 	var result *BatchResult
 	n := countInvalidations(t, mr, func() {
 		var err error
-		result, err = ac.RemoveMany(toRemove)
+		result, err = ac.RemoveMany(toRemove, nil)
 		if err != nil {
 			t.Fatalf("RemoveMany: %v", err)
 		}
@@ -157,7 +157,7 @@ func TestRemoveMany_NoOpDoesNotCommit(t *testing.T) {
 	var result *BatchResult
 	n := countInvalidations(t, mr, func() {
 		var err error
-		result, err = ac.RemoveMany([]string{"absent1", "absent2"})
+		result, err = ac.RemoveMany([]string{"absent1", "absent2"}, nil)
 		if err != nil {
 			t.Fatalf("RemoveMany: %v", err)
 		}

--- a/pkg/acor/batch_debug_test.go
+++ b/pkg/acor/batch_debug_test.go
@@ -229,7 +229,7 @@ func TestInitV2HSetError(t *testing.T) {
 		schemaVersion: SchemaV2,
 	}
 
-	err := ac.init()
+	err := ac.init(context.Background())
 	if err == nil {
 		t.Fatal("expected error from closed Redis in init()")
 	}
@@ -248,7 +248,7 @@ func TestInitV1ZAddError(t *testing.T) {
 		ctx:           context.Background(),
 		schemaVersion: SchemaV1,
 	}
-	err := ac.init()
+	err := ac.init(context.Background())
 	if err == nil {
 		t.Fatal("expected error from closed Redis in init() v1")
 	}

--- a/pkg/acor/batch_ops_test.go
+++ b/pkg/acor/batch_ops_test.go
@@ -85,7 +85,7 @@ func TestRemoveManyBestEffortWithError(t *testing.T) {
 
 	mr2.Close()
 
-	result, err := ac.RemoveManyWithOptions([]string{"he"}, &BatchOptions{Mode: BatchModeBestEffort})
+	result, err := ac.RemoveMany([]string{"he"}, &BatchOptions{Mode: BatchModeBestEffort})
 	if err != nil {
 		t.Fatalf("best-effort should not return error: %v", err)
 	}
@@ -104,7 +104,7 @@ func TestRemoveManyTransactionalWithDuplicates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := ac.RemoveManyWithOptions([]string{"he", "he", "her"}, &BatchOptions{Mode: BatchModeTransactional})
+	result, err := ac.RemoveMany([]string{"he", "he", "her"}, &BatchOptions{Mode: BatchModeTransactional})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -334,7 +334,7 @@ func TestAddManyBestEffortDuplicateInput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := ac.RemoveManyWithOptions([]string{"he", "", "him"}, &BatchOptions{Mode: BatchModeBestEffort})
+	result, err := ac.RemoveMany([]string{"he", "", "him"}, &BatchOptions{Mode: BatchModeBestEffort})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -356,7 +356,7 @@ func TestRemoveManyTransactionalWithEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := ac.RemoveManyWithOptions([]string{"he", "", "him"}, &BatchOptions{Mode: BatchModeTransactional})
+	_, err := ac.RemoveMany([]string{"he", "", "him"}, &BatchOptions{Mode: BatchModeTransactional})
 	if !errors.Is(err, ErrEmptyKeyword) {
 		t.Fatalf("expected ErrEmptyKeyword, got %v", err)
 	}
@@ -438,7 +438,7 @@ func TestRemoveManyTransactionalDuplicate(t *testing.T) {
 
 	_, _ = ac.Add("he")
 
-	result, err := ac.RemoveManyWithOptions([]string{"he", "he"}, &BatchOptions{Mode: BatchModeTransactional})
+	result, err := ac.RemoveMany([]string{"he", "he"}, &BatchOptions{Mode: BatchModeTransactional})
 	if err != nil {
 		t.Fatalf("RemoveMany transactional error: %v", err)
 	}
@@ -471,7 +471,7 @@ func TestBatchCaseNormalization(t *testing.T) {
 						schema, caseSensitive, mode, added.Added, added.Skipped)
 				}
 
-				removed, err := ac.RemoveManyWithOptions([]string{"Foo", "foo"}, &BatchOptions{Mode: mode})
+				removed, err := ac.RemoveMany([]string{"Foo", "foo"}, &BatchOptions{Mode: mode})
 				if err != nil {
 					t.Fatalf("schema=%d caseSensitive=%t mode=%v: RemoveMany error: %v",
 						schema, caseSensitive, mode, err)

--- a/pkg/acor/batch_test.go
+++ b/pkg/acor/batch_test.go
@@ -161,7 +161,7 @@ func TestRemoveMany(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := ac.RemoveMany([]string{"he", "her"})
+	result, err := ac.RemoveMany([]string{"he", "her"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,7 +189,7 @@ func TestRemoveManyWithDuplicates(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := ac.RemoveMany([]string{"he", "he", "her"})
+	result, err := ac.RemoveMany([]string{"he", "he", "her"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +212,7 @@ func TestRemoveManyBestEffort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := ac.RemoveManyWithOptions([]string{"he", "", "him"}, &BatchOptions{Mode: BatchModeBestEffort})
+	result, err := ac.RemoveMany([]string{"he", "", "him"}, &BatchOptions{Mode: BatchModeBestEffort})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -244,7 +244,7 @@ func TestRemoveManyNilOpts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := ac.RemoveMany([]string{"he", "", "her"})
+	result, err := ac.RemoveMany([]string{"he", "", "her"}, nil)
 	if err != nil {
 		t.Fatalf("nil opts should default to best-effort, got error: %v", err)
 	}
@@ -278,7 +278,7 @@ func TestRemoveManyTransactional(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := ac.RemoveManyWithOptions([]string{"he", "her"}, &BatchOptions{Mode: BatchModeTransactional})
+	result, err := ac.RemoveMany([]string{"he", "her"}, &BatchOptions{Mode: BatchModeTransactional})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -306,7 +306,7 @@ func TestRemoveManyTransactionalRollbackOnError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err := ac.RemoveManyWithOptions([]string{"he", "", "him"}, &BatchOptions{Mode: BatchModeTransactional})
+	_, err := ac.RemoveMany([]string{"he", "", "him"}, &BatchOptions{Mode: BatchModeTransactional})
 	if !errors.Is(err, ErrEmptyKeyword) {
 		t.Fatalf("expected ErrEmptyKeyword, got %v", err)
 	}

--- a/pkg/acor/create_guards_test.go
+++ b/pkg/acor/create_guards_test.go
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func newPresetAC(t *testing.T, name string) *AhoCorasick {
+	t.Helper()
+	mr := createTestRedisServer(t)
+	ac, err := Create(&AhoCorasickArgs{
+		Addr:   mr.Addr(),
+		Name:   name,
+		Preset: PresetBalanced,
+	})
+	if err != nil {
+		t.Fatalf("Create() error: %v", err)
+	}
+	t.Cleanup(func() { _ = ac.Close() })
+	return ac
+}
+
+// Preset mode holds no Redis client, so both migration entry points used to
+// dereference a nil interface instead of reporting that they do not apply.
+func TestMigrationRejectsPresetMode(t *testing.T) {
+	t.Run("MigrateV1ToV2", func(t *testing.T) {
+		ac := newPresetAC(t, "migrate-preset")
+		result, err := ac.MigrateV1ToV2(nil)
+		if !errors.Is(err, ErrMigrationRequiresRedis) {
+			t.Fatalf("expected ErrMigrationRequiresRedis, got %v", err)
+		}
+		if result != nil {
+			t.Fatalf("expected no result, got %+v", result)
+		}
+	})
+
+	t.Run("RollbackToV1", func(t *testing.T) {
+		ac := newPresetAC(t, "rollback-preset")
+		if err := ac.RollbackToV1(); !errors.Is(err, ErrMigrationRequiresRedis) {
+			t.Fatalf("expected ErrMigrationRequiresRedis, got %v", err)
+		}
+	})
+}
+
+// The Redis-backed modes must keep reaching the real migration logic: the guard
+// above must not reject them. A V2 collection reports ErrAlreadyV2 instead.
+func TestMigrationAllowsRedisBackedMode(t *testing.T) {
+	ac, _ := createAhoCorasick(t)
+	defer ac.Close()
+
+	_, err := ac.MigrateV1ToV2(nil)
+	if errors.Is(err, ErrMigrationRequiresRedis) {
+		t.Fatalf("guard rejected a Redis-backed instance: %v", err)
+	}
+	if !errors.Is(err, ErrAlreadyV2) {
+		t.Fatalf("expected ErrAlreadyV2, got %v", err)
+	}
+}
+
+// EnableCache is never read in the preset path, so accepting the pair silently
+// dropped the caching the caller asked for.
+func TestCreateRejectsCacheWithPreset(t *testing.T) {
+	mr := createTestRedisServer(t)
+	ac, err := Create(&AhoCorasickArgs{
+		Addr:        mr.Addr(),
+		Name:        "cache-and-preset",
+		Preset:      PresetBalanced,
+		EnableCache: true,
+	})
+	if !errors.Is(err, ErrCacheWithPreset) {
+		t.Fatalf("expected ErrCacheWithPreset, got %v", err)
+	}
+	if ac != nil {
+		_ = ac.Close()
+		t.Fatal("expected no instance when the config is rejected")
+	}
+}
+
+// Both constructors read args.Name before anything else, so a nil args used to
+// panic on the very first line of the public entry point.
+func TestCreateRejectsNilArgs(t *testing.T) {
+	if _, err := Create(nil); !errors.Is(err, ErrNilArgs) {
+		t.Fatalf("Create(nil): expected ErrNilArgs, got %v", err)
+	}
+	if _, err := CreateContext(context.Background(), nil); !errors.Is(err, ErrNilArgs) {
+		t.Fatalf("CreateContext(nil): expected ErrNilArgs, got %v", err)
+	}
+}
+
+func TestCreateContextHonorsCanceledContext(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args func(addr string) *AhoCorasickArgs
+	}{
+		{
+			name: "original",
+			args: func(addr string) *AhoCorasickArgs {
+				return &AhoCorasickArgs{Addr: addr, Name: "ctx-original"}
+			},
+		},
+		{
+			name: "preset",
+			args: func(addr string) *AhoCorasickArgs {
+				return &AhoCorasickArgs{Addr: addr, Name: "ctx-preset", Preset: PresetBalanced}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mr := createTestRedisServer(t)
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			ac, err := CreateContext(ctx, tc.args(mr.Addr()))
+			if err == nil {
+				_ = ac.Close()
+				t.Fatal("expected CreateContext to fail on a canceled context")
+			}
+			if ac != nil {
+				_ = ac.Close()
+				t.Fatal("expected no instance when construction fails")
+			}
+		})
+	}
+}
+
+// The construction context must not become the instance's lifetime: canceling it
+// after a successful CreateContext would otherwise stop the preset invalidation
+// listener and leave a live instance that never sees another node's writes.
+func TestCreateContextDoesNotBindInstanceLifetime(t *testing.T) {
+	mr := createTestRedisServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // idempotent; keeps the ctx from leaking if the test fails early
+
+	ac, err := CreateContext(ctx, &AhoCorasickArgs{
+		Addr:   mr.Addr(),
+		Name:   "ctx-lifetime",
+		Preset: PresetBalanced,
+	})
+	if err != nil {
+		t.Fatalf("CreateContext() error: %v", err)
+	}
+	defer ac.Close()
+
+	cancel()
+
+	if _, addErr := ac.Add("he"); addErr != nil {
+		t.Fatalf("Add() after construction ctx cancel: %v", addErr)
+	}
+	matches, findErr := ac.Find("she")
+	if findErr != nil {
+		t.Fatalf("Find() after construction ctx cancel: %v", findErr)
+	}
+	if len(matches) != 1 || matches[0] != "he" {
+		t.Fatalf("expected [he], got %v", matches)
+	}
+}

--- a/pkg/acor/errors.go
+++ b/pkg/acor/errors.go
@@ -26,6 +26,18 @@ var (
 	// ErrSuggestRequiresRedis is returned when Suggest/SuggestIndex is called in
 	// preset mode, which doesn't support prefix-based suggestions.
 	ErrSuggestRequiresRedis = errors.New("suggest requires Redis-backed mode without Preset")
+	// ErrMigrationRequiresRedis is returned when MigrateV1ToV2 or RollbackToV1 is
+	// called in preset mode. Migration walks the collection's V1 keys directly,
+	// which preset mode never opens: it always speaks V2 and serves reads from its
+	// local engine. Migrate with an instance created without a Preset.
+	ErrMigrationRequiresRedis = errors.New("schema migration requires Redis-backed mode without Preset")
+	// ErrNilArgs is returned when Create or CreateContext is called with nil args.
+	// Name is required, so there is no meaningful all-defaults configuration.
+	ErrNilArgs = errors.New("args must not be nil")
+	// ErrCacheWithPreset is returned when EnableCache is combined with a Preset.
+	// Preset mode already answers reads from a local engine kept fresh by the same
+	// Pub/Sub invalidation, so the trie cache would be a redundant second copy.
+	ErrCacheWithPreset = errors.New("EnableCache cannot be combined with Preset")
 )
 
 // OperationError represents an error that occurred during an automaton operation.

--- a/pkg/acor/find_set_test.go
+++ b/pkg/acor/find_set_test.go
@@ -161,7 +161,7 @@ func TestBatchMatchesSequentialWrites(t *testing.T) {
 				if _, err := ac.AddMany(keywords, nil); err != nil {
 					t.Fatalf("AddMany(seed) error: %v", err)
 				}
-				if _, err := ac.RemoveMany(doomed); err != nil {
+				if _, err := ac.RemoveMany(doomed, nil); err != nil {
 					t.Fatalf("RemoveMany error: %v", err)
 				}
 			},
@@ -245,7 +245,7 @@ func TestAddManyReportsCaseFoldedWrites(t *testing.T) {
 			res.Added, res.Skipped)
 	}
 
-	rres, err := ac.RemoveMany([]string{"Hello"})
+	rres, err := ac.RemoveMany([]string{"Hello"}, nil)
 	if err != nil {
 		t.Fatalf("RemoveMany error: %v", err)
 	}

--- a/pkg/acor/integration_test.go
+++ b/pkg/acor/integration_test.go
@@ -112,7 +112,7 @@ func TestIntegrationBatch(t *testing.T) {
 		t.Errorf("FindMany() returned %d entries, want 2", len(results))
 	}
 
-	if _, err := ac.RemoveMany([]string{"he", "her"}); err != nil {
+	if _, err := ac.RemoveMany([]string{"he", "her"}, nil); err != nil {
 		t.Fatalf("RemoveMany() error: %v", err)
 	}
 }

--- a/pkg/acor/keys.go
+++ b/pkg/acor/keys.go
@@ -4,29 +4,6 @@ package acor
 
 import "time"
 
-// Key format constants for the V1 schema, using %s as a placeholder for the
-// collection name.
-//
-// These do not produce the keys ACOR actually writes. A collection name is
-// wrapped in a Redis hash tag so all of a collection's keys hash to one cluster
-// slot, making the real key "{mycoll}:keyword" while
-// fmt.Sprintf(KeywordKey, "mycoll") yields "mycoll:keyword". Nothing in ACOR
-// reads these constants; the key builders hold the correct format. Treat them
-// as informational only — reading Redis directly with a key built from them
-// will not find anything.
-const (
-	// KeywordKey is the suffix pattern for the keywords set. Real key: "{name}:keyword".
-	KeywordKey = "%s:keyword"
-	// PrefixKey is the suffix pattern for the prefixes sorted set. Real key: "{name}:prefix".
-	PrefixKey = "%s:prefix"
-	// SuffixKey is the suffix pattern for the suffixes sorted set. Real key: "{name}:suffix".
-	SuffixKey = "%s:suffix"
-	// OutputKey is the suffix pattern for output sets. Real key: "{name}:output:{state}".
-	OutputKey = "%s:output"
-	// NodeKey is the suffix pattern for node sets. Real key: "{name}:node:{keyword}".
-	NodeKey = "%s:node"
-)
-
 // V2 trie-hash field names. Kept as constants so a typo can't silently break a
 // Redis read or write.
 const (

--- a/pkg/acor/migration.go
+++ b/pkg/acor/migration.go
@@ -41,6 +41,16 @@ const (
 	migrationLockTTL       = 300 * time.Second
 )
 
+// requireRedisBacked rejects the migration entry points in preset mode, where
+// createPresetRedis leaves redisClient nil — every Redis call below it would
+// otherwise dereference a nil interface.
+func (ac *AhoCorasick) requireRedisBacked() error {
+	if ac.mode != modeOriginal || ac.redisClient == nil {
+		return ErrMigrationRequiresRedis
+	}
+	return nil
+}
+
 func (ac *AhoCorasick) migrationLockKey() string {
 	return keyPrefix(ac.name) + migrationLockKeySuffix
 }
@@ -87,7 +97,13 @@ func (ac *AhoCorasick) releaseMigrationLock() error {
 //	    log.Fatal(err)
 //	}
 //	fmt.Printf("Migrated %d keywords in %dms\n", result.Keywords, result.DurationMs)
+//
+// Returns ErrMigrationRequiresRedis when the instance was created with a Preset:
+// preset mode holds no Redis client for the V1 key walk.
 func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, error) { //nolint:gocyclo,funlen // Complex migration logic with multiple stages
+	if err := ac.requireRedisBacked(); err != nil {
+		return nil, err
+	}
 	if opts == nil {
 		opts = DefaultMigrationOptions()
 	}
@@ -330,7 +346,13 @@ func (ac *AhoCorasick) MigrateV1ToV2(opts *MigrationOptions) (*MigrationResult, 
 //
 // Note: This deletes V2 keys and switches the instance to use V1 operations.
 // Any keywords added after migration to V2 will be lost.
+//
+// Returns ErrMigrationRequiresRedis when the instance was created with a Preset,
+// for the reason MigrateV1ToV2 documents.
 func (ac *AhoCorasick) RollbackToV1() error {
+	if err := ac.requireRedisBacked(); err != nil {
+		return err
+	}
 	v1Exists, err := ac.redisClient.Exists(ac.ctx, keywordKey(ac.name)).Result()
 	if err != nil {
 		return fmt.Errorf("failed to check V1 keys: %w", err)

--- a/pkg/acor/redis_backed.go
+++ b/pkg/acor/redis_backed.go
@@ -52,7 +52,10 @@ type redisBackedAC struct {
 // current keywords from Redis, builds the local automaton, and starts a
 // Pub/Sub listener for cross-instance invalidation.
 func newRedisBacked(ctx context.Context, args *AhoCorasickArgs) (*redisBackedAC, error) {
-	if args == nil || strings.Contains(args.Name, ":") {
+	if args == nil {
+		return nil, ErrNilArgs
+	}
+	if strings.Contains(args.Name, ":") {
 		return nil, ErrInvalidName
 	}
 
@@ -67,7 +70,12 @@ func newRedisBacked(ctx context.Context, args *AhoCorasickArgs) (*redisBackedAC,
 	}
 
 	storage := newRedisStorage(redisClient)
-	acCtx, acCancel := context.WithCancel(ctx)
+	// Background, not ctx: ctx is the construction context (see CreateContext) and
+	// may be request-scoped, while acCtx drives the subscribe, listener, and poller
+	// until Close. Deriving it from ctx would stop them the moment the caller's
+	// request ended. initTrie and reloadFromRedis below still take ctx, so
+	// construction honors its deadline for everything except the subscribe.
+	acCtx, acCancel := context.WithCancel(context.Background())
 
 	ac := &redisBackedAC{
 		engine:        matchengine.New(preset),

--- a/pkg/acor/schema.go
+++ b/pkg/acor/schema.go
@@ -5,8 +5,15 @@ package acor
 // Schema version constants define the storage format used by the automaton.
 const (
 	// SchemaV1 represents the legacy V1 schema version.
-	// V1 uses multiple Redis keys: one per prefix, suffix, output, and node.
-	// Suitable for small collections but creates many keys.
+	// V1 uses multiple Redis keys: one per prefix, suffix, output, and node, so a
+	// collection's key count grows with the dictionary.
+	//
+	// It stays readable and writable so existing collections keep working, and
+	// MigrateV1ToV2 converts them in place. It gains no new features: Preset engines
+	// and EnableCache both require V2.
+	//
+	// Deprecated: use SchemaV2 (the default). New collections should not select V1;
+	// support for it may be removed in a future major version.
 	SchemaV1 = 1
 	// SchemaV2 represents the current V2 schema version (default).
 	// V2 consolidates data into 3 Redis keys using JSON and Lua scripts.

--- a/server/go.mod
+++ b/server/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/rs/zerolog v1.35.1
-	github.com/skyoo2003/acor v0.8.0
+	github.com/skyoo2003/acor v0.10.1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
@@ -45,4 +45,11 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 )
 
+// Local development and CI build the server against the core in this checkout.
+// Go ignores a dependency's replace directives, so an external consumer resolves
+// the require above instead — keep it at a released core tag, not a stale one.
+//
+// This module is experimental and versioned separately from the core: it carries
+// no vX.Y.Z tags of its own and is not covered by the core's compatibility
+// promise. See docs/content/operations/monitoring.md.
 replace github.com/skyoo2003/acor => ../


### PR DESCRIPTION
# Pull Request

## Description

Clears the defects and the freeze-forever warts found while reviewing v1
readiness, so the compatibility promise starts on a surface worth keeping.

Three of these are release blockers; the rest are cheap now and impossible after
a v1 tag.

### Correctness

- **`MigrateV1ToV2` / `RollbackToV1` panicked in preset mode.** `createPresetRedis`
  never sets `redisClient`, and `migration.go` dereferences it in 15 places —
  a legal call on a public method produced a nil pointer dereference. They now
  return the new `ErrMigrationRequiresRedis`. The CLI already refused the
  combination, so the guard moved to the shared path every caller routes through.
- **`Create` silently ignored `EnableCache` when a `Preset` was set.** The preset
  path never reads the field, so the caller's request just vanished. Now
  `ErrCacheWithPreset`.
- **`Create(nil)` panicked.** `args.Name` was read before any nil check; the
  `args == nil` guard down in `newRedisBacked` was unreachable. Now `ErrNilArgs`.
- **The CLI let `version` skip validation** (stray arguments and misapplied flags
  passed with exit 0) and only rejected `migrate`/`migrate-rollback` under
  `-preset`, so `-preset speed suggest` connected and loaded the whole dictionary
  before failing.

### API

- **`CreateContext`** bounds the setup I/O (schema check, initialization write,
  initial keyword load) with a caller context. It deliberately does **not** bound
  the instance lifetime — a request-scoped ctx must not be able to stop the
  invalidation listener and leave a live instance serving stale data. `Create` is
  now a thin wrapper.
- **`RemoveMany` takes `*BatchOptions`** like `AddMany`; `RemoveManyWithOptions` is
  removed. Three call shapes for two operations would have frozen at v1.
- **The exported V1 key-format constants are removed.** Their own doc comment
  admitted they never produce the keys ACOR writes (a real key is hash-tagged,
  `{name}:keyword`) and that nothing reads them.
- **`SchemaV1` is deprecated.** V1 stays readable and writable and `MigrateV1ToV2`
  still converts in place; it just gains no new features and may be removed in a
  future major version.
- `Info().Preset`'s doc claimed non-preset mode reports an internal `-1` sentinel.
  It returns `PresetNone`; the comment was wrong.

### CLI

- New `version`, `find-set`, `find-matches`, and `contains` commands, with
  `-match-kind` and `-whole-word` scoped to `find-matches`. The `#188` matching
  API had no CLI surface.
- Release builds stamp the version through `ldflags`, so a bug report says which
  release it came from. `acor version` needs no Redis — it is what you run when
  the CLI misbehaves.

### Docs

- The security policy listed supported `v1.8 – v1.x` and `v2.x` lines. **Neither
  was ever released** (latest tag: `v0.10.1`). Replaced with a policy that names
  no version numbers, so it cannot rot again.
- The `acor/server` module is labeled experimental and separately versioned. It
  publishes no tags, has no `main`, and its `require` on the core was pinned at
  `v0.8.0` — and because Go ignores a dependency's `replace`, that stale require is
  exactly what an external consumer resolved. Bumped to a released tag.
- The repository's three-module layout is documented, including why the library
  import path keeps its `pkg/` segment.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog
- [x] Commit messages follow guidelines

## Additional Notes

### Breaking changes and how to migrate

| Before | After |
| ------ | ----- |
| `ac.RemoveMany(kw)` | `ac.RemoveMany(kw, nil)` |
| `ac.RemoveManyWithOptions(kw, opts)` | `ac.RemoveMany(kw, opts)` |
| `acor.KeywordKey` and siblings | removed — no replacement; they never produced real keys |

### Verification

```
make lint          0 issues (root + server)
go vet             all three modules
go test -race      full suite, coverage 86.3% -> 86.5%
make docs-verify   16/16 blocks compiled (was 12 — four new markers)
fuzz               FuzzFind / FuzzAdd
```

Binary smoke tests: `version extra` -> exit 2, `-dry-run version` -> exit 2,
`-preset speed suggest` -> exit 2 with `"suggest" is unavailable in preset mode`,
`version` -> stamped version, exit 0.

### Not in this PR

`v0.11.0` should ship this, and `v1.0.0` should follow as a separate tag — the
version bump is not part of these changes.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).
