### PR TITLE
fix: retract v1.0.0-v1.4.0 ahead of the v1.5.0 release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,10 +8,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # v1.4.1 only carries the go.mod retractions (see RELEASE.md); releasing it
-    # would create v1-alpine and move latest-alpine onto retracted code. The
-    # match is exact, not a `v1.` prefix, so a real v1.5.0 still releases here.
-    if: ${{ github.ref_name != 'v1.4.1' }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,11 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # v1.4.1 exists only to carry the go.mod retractions (see RELEASE.md), so it
-    # must not publish anything: releasing it would create v1-alpine and move
-    # latest-alpine onto retracted code. Matched exactly, not by `v1.` prefix, so
-    # a real v1.5.0 releases with no edit here and any other stray v1 tag still
-    # runs and fails loudly on the changie guard below.
+    # v1.4.1 only carries the go.mod retractions (see RELEASE.md); releasing it
+    # would create v1-alpine and move latest-alpine onto retracted code. The
+    # match is exact, not a `v1.` prefix, so a real v1.5.0 still releases here.
     if: ${{ github.ref_name != 'v1.4.1' }}
     permissions:
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,10 +8,12 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # The v1.x line is retracted in go.mod, so a v1 tag can only be a
-    # retraction placeholder. Publishing it would create v1-alpine and move
-    # latest-alpine onto retracted code. Drop this when a real v1 ships.
-    if: ${{ !startsWith(github.ref_name, 'v1.') }}
+    # v1.4.1 exists only to carry the go.mod retractions (see RELEASE.md), so it
+    # must not publish anything: releasing it would create v1-alpine and move
+    # latest-alpine onto retracted code. Matched exactly, not by `v1.` prefix, so
+    # a real v1.5.0 releases with no edit here and any other stray v1 tag still
+    # runs and fails loudly on the changie guard below.
+    if: ${{ github.ref_name != 'v1.4.1' }}
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # The v1.x line is retracted in go.mod, so a v1 tag can only be a
+    # retraction placeholder. Publishing it would create v1-alpine and move
+    # latest-alpine onto retracted code. Drop this when a real v1 ships.
+    if: ${{ !startsWith(github.ref_name, 'v1.') }}
     permissions:
       contents: write
       packages: write

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -89,8 +89,7 @@ YAML fragment under `changes/unreleased/`. Commit it with your change.
 
 ## What the tag build does
 
-`release.yaml` runs on any `v*` tag except `v1.4.1`
-(see [Retracted versions](#retracted-versions)) and:
+`release.yaml` runs on any `v*` tag and:
 
 1. **Guards** that `changes/<tag>.md` exists — fails fast if you forgot
    `changie batch` / `changie merge`.
@@ -136,62 +135,35 @@ to that older version. When redoing an older release, re-tag the newest one last
 `v1.0.0`-`v1.4.0` were published from tags that no longer exist here. Deleting a
 tag does not unpublish a module version — `proxy.golang.org` caches it forever —
 so they stayed resolvable, and `go get github.com/skyoo2003/acor` picked
-`v1.4.0` over the v0.x line. The whole range is retracted in the root `go.mod`:
+`v1.4.0` over the v0.x line. They are retracted in the root `go.mod`:
 
 ```go
-retract [v1.0.0, v1.4.1]
+retract [v1.0.0, v1.4.0]
 ```
 
-`v1.4.1` carries that block and retracts itself, which is what makes `@latest`
-fall back to the highest v0.x. It is cut from `main`, so it publishes the current
-v0.x tree under a v1 number — harmless because it is retracted, but it is not an
-empty tag.
+**v1.5.0 is the first supported v1 release.** That is why the numbering jumps
+from v0.11.x: everything below v1.5.0 in the v1 line is retracted, and the range
+stops at `v1.4.0` so it can never cover a real release.
 
-Two rules when editing this:
+There is no separate step to publish the retractions — they take effect with the
+release whose `go.mod` carries them. Two rules when editing this:
 
 - **Keep the block on `main`.** The go command reads retractions only from the
-  highest published version's `go.mod`, so a future v1 tag without it would
-  un-retract the whole line.
+  highest published version's `go.mod`, so the next release silently un-retracts
+  the old versions if the block is missing.
 - **Only the first comment line reaches users.** The go command truncates a
   retraction rationale at the first newline, so keep that line a complete,
   actionable sentence.
 
-`release.yaml` skips its job for exactly this tag
-(`if: ${{ github.ref_name != 'v1.4.1' }}`), so GoReleaser never publishes
-`v1-alpine` or moves `latest-alpine` onto retracted code. The match is exact
-rather than a `v1.` prefix so that a real **v1.5.0** releases with no edit here,
-and any other stray v1 tag fails loudly on the changie guard instead of skipping
-in silence.
+After tagging a release that carries the block, verify from a scratch module
+outside this repo:
 
-### Publishing the retraction tag
+```sh
+curl -s https://proxy.golang.org/github.com/skyoo2003/acor/@v/v1.5.0.info
+go list -m github.com/skyoo2003/acor@latest     # want v1.5.0
+go list -m -versions github.com/skyoo2003/acor  # v1.0.0-v1.4.0 must be gone
+```
 
-**Not reversible** — the proxy caches whatever you push. A `v1.4.1` tag cut from
-a commit *without* the `retract` block becomes the highest published version and
-carries no retractions, so `go get` resolves to it: permanently worse than the
-state you are fixing.
-
-1. Merge the `retract` block to `main` first.
-2. Tag the merge commit, never a release branch:
-
-   ```sh
-   git switch main && git pull
-   grep -A1 'retract' go.mod        # the block must be there
-   git tag v1.4.1
-   git push origin v1.4.1
-   ```
-
-3. Expect a skipped workflow run, no GitHub release, and no `changes/v1.4.1.md`.
-4. Verify from a scratch module outside this repo:
-
-   ```sh
-   curl -s https://proxy.golang.org/github.com/skyoo2003/acor/@v/v1.4.1.info
-   go list -m github.com/skyoo2003/acor@latest     # want the highest v0.x
-   go list -m -versions github.com/skyoo2003/acor  # v1.x must be gone
-   ```
-
-   The `curl` is needed because the proxy has to fetch the retraction-carrying
-   version before retractions apply. Do not add `-retracted`: it lists retracted
-   versions alongside the rest, so the output is the same before and after.
-
-A real v1 starts at **v1.5.0**, which `[v1.0.0, v1.4.1]` already excludes, so
-leave both the range and the workflow condition alone.
+The `curl` is needed because the proxy has to fetch the release before its
+retractions apply. Do not add `-retracted`: it lists retracted versions alongside
+the rest, so the output is the same before and after.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -89,7 +89,8 @@ YAML fragment under `changes/unreleased/`. Commit it with your change.
 
 ## What the tag build does
 
-`release.yaml` runs on any `v*` tag and:
+`release.yaml` runs on any `v*` tag except `v1.*` (see [Retracted
+versions](#retracted-versions)) and:
 
 1. **Guards** that `changes/<tag>.md` exists — fails fast if you forgot
    `changie batch` / `changie merge`.
@@ -129,3 +130,40 @@ in GHCR — they stay until a build overwrites them. And `latest-alpine` (plus
 `vMAJOR-alpine` / `vMAJOR.MINOR-alpine`) always points at whichever tag built
 *last*, so re-running an older tag's build silently drags `latest-alpine` back
 to that older version. When redoing an older release, re-tag the newest one last.
+
+## Retracted versions
+
+`v1.0.0`-`v1.4.0` were published from tags that have since been deleted from
+this repository. Deleting a tag does not unpublish a module version:
+`proxy.golang.org` caches them permanently, so they stayed resolvable and
+`go get github.com/skyoo2003/acor` picked `v1.4.0` over the v0.x line. The whole
+range is retracted in the root `go.mod`:
+
+```go
+retract [v1.0.0, v1.4.1]
+```
+
+`v1.4.1` is a retraction-only tag: it carries that block and nothing else, and
+it retracts itself, which is what makes `@latest` fall back to the highest v0.x.
+Keep the `retract` block on `main` — the go command reads retractions only from
+the highest published version's `go.mod`, so a future v1 tag without it would
+silently un-retract the whole line.
+
+Because of this, `release.yaml` skips its entire job for any `v1.*` tag
+(`if: ${{ !startsWith(github.ref_name, 'v1.') }}`). Without that condition
+GoReleaser would publish `v1-alpine` and drag `latest-alpine` onto retracted
+code.
+
+When a real v1 ships it starts at **v1.5.0**: drop the workflow condition and
+leave the retract range alone — `[v1.0.0, v1.4.1]` already excludes v1.5.0.
+
+To verify a retraction took effect, from a scratch module outside this repo:
+
+```sh
+curl -s https://proxy.golang.org/github.com/skyoo2003/acor/@v/v1.4.1.info
+go list -m github.com/skyoo2003/acor@latest              # want the highest v0.x
+go list -m -retracted -versions github.com/skyoo2003/acor
+```
+
+The proxy has to fetch the retraction-holding version before retractions apply,
+which is what the `curl` is for.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -89,8 +89,8 @@ YAML fragment under `changes/unreleased/`. Commit it with your change.
 
 ## What the tag build does
 
-`release.yaml` runs on any `v*` tag except `v1.4.1` (see [Retracted
-versions](#retracted-versions)) and:
+`release.yaml` runs on any `v*` tag except `v1.4.1`
+(see [Retracted versions](#retracted-versions)) and:
 
 1. **Guards** that `changes/<tag>.md` exists — fails fast if you forgot
    `changie batch` / `changie merge`.
@@ -133,68 +133,65 @@ to that older version. When redoing an older release, re-tag the newest one last
 
 ## Retracted versions
 
-`v1.0.0`-`v1.4.0` were published from tags that have since been deleted from
-this repository. Deleting a tag does not unpublish a module version:
-`proxy.golang.org` caches them permanently, so they stayed resolvable and
-`go get github.com/skyoo2003/acor` picked `v1.4.0` over the v0.x line. The whole
-range is retracted in the root `go.mod`:
+`v1.0.0`-`v1.4.0` were published from tags that no longer exist here. Deleting a
+tag does not unpublish a module version — `proxy.golang.org` caches it forever —
+so they stayed resolvable, and `go get github.com/skyoo2003/acor` picked
+`v1.4.0` over the v0.x line. The whole range is retracted in the root `go.mod`:
 
 ```go
 retract [v1.0.0, v1.4.1]
 ```
 
-`v1.4.1` is the retraction carrier: it exists only so the `retract` block sits on
-a published version, and it retracts itself, which is what makes `@latest` fall
-back to the highest v0.x. It is cut from `main`, so it does publish the current
-v0.x tree under a v1 number — harmless, because it is retracted, but it is not an
-empty tag. Keep the `retract` block on `main`: the go command reads retractions
-only from the highest published version's `go.mod`, so a future v1 tag without it
-would silently un-retract the whole line.
+`v1.4.1` carries that block and retracts itself, which is what makes `@latest`
+fall back to the highest v0.x. It is cut from `main`, so it publishes the current
+v0.x tree under a v1 number — harmless because it is retracted, but it is not an
+empty tag.
 
-Only the **first line** of the comment above the `retract` directive reaches
-users — the go command truncates a retraction rationale at the first newline — so
-keep that line a complete, actionable sentence.
+Two rules when editing this:
+
+- **Keep the block on `main`.** The go command reads retractions only from the
+  highest published version's `go.mod`, so a future v1 tag without it would
+  un-retract the whole line.
+- **Only the first comment line reaches users.** The go command truncates a
+  retraction rationale at the first newline, so keep that line a complete,
+  actionable sentence.
 
 `release.yaml` skips its job for exactly this tag
 (`if: ${{ github.ref_name != 'v1.4.1' }}`), so GoReleaser never publishes
-`v1-alpine` or drags `latest-alpine` onto retracted code. The condition is an
-exact match rather than a `v1.` prefix on purpose: a real **v1.5.0** then
-releases with no edit here, and any other stray v1 tag still runs and fails
-loudly on the changie guard instead of silently skipping.
+`v1-alpine` or moves `latest-alpine` onto retracted code. The match is exact
+rather than a `v1.` prefix so that a real **v1.5.0** releases with no edit here,
+and any other stray v1 tag fails loudly on the changie guard instead of skipping
+in silence.
 
 ### Publishing the retraction tag
 
-Order matters and is **not reversible** — the proxy caches whatever you push. A
-`v1.4.1` tag cut from a commit *without* the `retract` block becomes the highest
-published version with no retractions, and `go get` would then resolve to
-`v1.4.1`: strictly worse than the state you are fixing, permanently.
+**Not reversible** — the proxy caches whatever you push. A `v1.4.1` tag cut from
+a commit *without* the `retract` block becomes the highest published version and
+carries no retractions, so `go get` resolves to it: permanently worse than the
+state you are fixing.
 
-1. Merge the `retract` block to `main` first, and confirm it is there.
-2. Tag the merge commit — never a release branch:
+1. Merge the `retract` block to `main` first.
+2. Tag the merge commit, never a release branch:
 
    ```sh
    git switch main && git pull
-   grep -A1 'retract' go.mod
+   grep -A1 'retract' go.mod        # the block must be there
    git tag v1.4.1
    git push origin v1.4.1
    ```
 
-3. Expect no `changes/v1.4.1.md`, no GitHub release, and a skipped workflow run.
-4. Verify below.
+3. Expect a skipped workflow run, no GitHub release, and no `changes/v1.4.1.md`.
+4. Verify from a scratch module outside this repo:
 
-When a real v1 ships it starts at **v1.5.0**. Leave the retract range and the
-workflow condition alone — `[v1.0.0, v1.4.1]` already excludes v1.5.0.
+   ```sh
+   curl -s https://proxy.golang.org/github.com/skyoo2003/acor/@v/v1.4.1.info
+   go list -m github.com/skyoo2003/acor@latest     # want the highest v0.x
+   go list -m -versions github.com/skyoo2003/acor  # v1.x must be gone
+   ```
 
-To verify a retraction took effect, from a scratch module outside this repo:
+   The `curl` is needed because the proxy has to fetch the retraction-carrying
+   version before retractions apply. Do not add `-retracted`: it lists retracted
+   versions alongside the rest, so the output is the same before and after.
 
-```sh
-curl -s https://proxy.golang.org/github.com/skyoo2003/acor/@v/v1.4.1.info
-go list -m github.com/skyoo2003/acor@latest                # want the highest v0.x
-go list -m -versions github.com/skyoo2003/acor             # v1.x must be gone
-go list -m -retracted -versions github.com/skyoo2003/acor  # v1.x back, for contrast
-```
-
-The proxy has to fetch the retraction-holding version before retractions apply,
-which is what the `curl` is for. The check that proves anything is the one
-*without* `-retracted`: with that flag retracted versions are listed alongside
-the rest, so its output is identical before and after the retraction lands.
+A real v1 starts at **v1.5.0**, which `[v1.0.0, v1.4.1]` already excludes, so
+leave both the range and the workflow condition alone.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -89,7 +89,7 @@ YAML fragment under `changes/unreleased/`. Commit it with your change.
 
 ## What the tag build does
 
-`release.yaml` runs on any `v*` tag except `v1.*` (see [Retracted
+`release.yaml` runs on any `v*` tag except `v1.4.1` (see [Retracted
 versions](#retracted-versions)) and:
 
 1. **Guards** that `changes/<tag>.md` exists — fails fast if you forgot
@@ -143,27 +143,58 @@ range is retracted in the root `go.mod`:
 retract [v1.0.0, v1.4.1]
 ```
 
-`v1.4.1` is a retraction-only tag: it carries that block and nothing else, and
-it retracts itself, which is what makes `@latest` fall back to the highest v0.x.
-Keep the `retract` block on `main` — the go command reads retractions only from
-the highest published version's `go.mod`, so a future v1 tag without it would
-silently un-retract the whole line.
+`v1.4.1` is the retraction carrier: it exists only so the `retract` block sits on
+a published version, and it retracts itself, which is what makes `@latest` fall
+back to the highest v0.x. It is cut from `main`, so it does publish the current
+v0.x tree under a v1 number — harmless, because it is retracted, but it is not an
+empty tag. Keep the `retract` block on `main`: the go command reads retractions
+only from the highest published version's `go.mod`, so a future v1 tag without it
+would silently un-retract the whole line.
 
-Because of this, `release.yaml` skips its entire job for any `v1.*` tag
-(`if: ${{ !startsWith(github.ref_name, 'v1.') }}`). Without that condition
-GoReleaser would publish `v1-alpine` and drag `latest-alpine` onto retracted
-code.
+Only the **first line** of the comment above the `retract` directive reaches
+users — the go command truncates a retraction rationale at the first newline — so
+keep that line a complete, actionable sentence.
 
-When a real v1 ships it starts at **v1.5.0**: drop the workflow condition and
-leave the retract range alone — `[v1.0.0, v1.4.1]` already excludes v1.5.0.
+`release.yaml` skips its job for exactly this tag
+(`if: ${{ github.ref_name != 'v1.4.1' }}`), so GoReleaser never publishes
+`v1-alpine` or drags `latest-alpine` onto retracted code. The condition is an
+exact match rather than a `v1.` prefix on purpose: a real **v1.5.0** then
+releases with no edit here, and any other stray v1 tag still runs and fails
+loudly on the changie guard instead of silently skipping.
+
+### Publishing the retraction tag
+
+Order matters and is **not reversible** — the proxy caches whatever you push. A
+`v1.4.1` tag cut from a commit *without* the `retract` block becomes the highest
+published version with no retractions, and `go get` would then resolve to
+`v1.4.1`: strictly worse than the state you are fixing, permanently.
+
+1. Merge the `retract` block to `main` first, and confirm it is there.
+2. Tag the merge commit — never a release branch:
+
+   ```sh
+   git switch main && git pull
+   grep -A1 'retract' go.mod
+   git tag v1.4.1
+   git push origin v1.4.1
+   ```
+
+3. Expect no `changes/v1.4.1.md`, no GitHub release, and a skipped workflow run.
+4. Verify below.
+
+When a real v1 ships it starts at **v1.5.0**. Leave the retract range and the
+workflow condition alone — `[v1.0.0, v1.4.1]` already excludes v1.5.0.
 
 To verify a retraction took effect, from a scratch module outside this repo:
 
 ```sh
 curl -s https://proxy.golang.org/github.com/skyoo2003/acor/@v/v1.4.1.info
-go list -m github.com/skyoo2003/acor@latest              # want the highest v0.x
-go list -m -retracted -versions github.com/skyoo2003/acor
+go list -m github.com/skyoo2003/acor@latest                # want the highest v0.x
+go list -m -versions github.com/skyoo2003/acor             # v1.x must be gone
+go list -m -retracted -versions github.com/skyoo2003/acor  # v1.x back, for contrast
 ```
 
 The proxy has to fetch the retraction-holding version before retractions apply,
-which is what the `curl` is for.
+which is what the `curl` is for. The check that proves anything is the one
+*without* `-retracted`: with that flag retracted versions are listed alongside
+the rest, so its output is identical before and after the retraction lands.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Supported Versions
 
-ACOR is pre-1.0. Security patches go to the **latest released minor line only**,
-shipped as a new patch release. There is no long-term support branch, and earlier
-minor lines are not backported to.
+Security patches go to the **latest released minor line only**, shipped as a new
+patch release. There is no long-term support branch, and earlier minor lines are
+not backported to.
 
 | Version                | Supported |
 | ---------------------- | --------- |
@@ -15,10 +15,9 @@ See the [latest release](https://github.com/skyoo2003/acor/releases/latest) for
 which version that is, and upgrade to it before reporting a vulnerability so the
 report is against supported code.
 
-The whole `v1.x` line — `v1.0.0` through `v1.4.1` — is **retracted**, including
-`v1.4.1`, which only carries the retractions. None of them receive fixes, and
-`go get` will not select them. If you pinned a v1 version, move to the latest
-v0.x release.
+`v1.0.0`-`v1.4.0` were published in error and are **retracted**. They receive no
+fixes, and `go get` will not select them — v1.5.0 is the first supported v1
+release. If you pinned one of them, upgrade.
 
 The experimental `acor/server` module publishes no tags of its own; fixes for it
 land on `main` and are consumed from there.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,10 +15,10 @@ See the [latest release](https://github.com/skyoo2003/acor/releases/latest) for
 which version that is, and upgrade to it before reporting a vulnerability so the
 report is against supported code.
 
-The whole `v1.x` line — `v1.0.0` through `v1.4.1` — was published in error and is
-**retracted**. `v1.4.1` exists only to carry the retractions and retracts itself,
-so it is no safer than the rest. None of them receive fixes, and `go get` will
-not select them. If you pinned any v1 version, move to the latest v0.x release.
+The whole `v1.x` line — `v1.0.0` through `v1.4.1` — is **retracted**, including
+`v1.4.1`, which only carries the retractions. None of them receive fixes, and
+`go get` will not select them. If you pinned a v1 version, move to the latest
+v0.x release.
 
 The experimental `acor/server` module publishes no tags of its own; fixes for it
 land on `main` and are consumed from there.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,9 +15,10 @@ See the [latest release](https://github.com/skyoo2003/acor/releases/latest) for
 which version that is, and upgrade to it before reporting a vulnerability so the
 report is against supported code.
 
-Versions `v1.0.0`-`v1.4.0` were published in error and are **retracted**
-(`v1.4.1` carries the retractions). They receive no fixes, and `go get` will not
-select them. If you pinned one, move to the latest v0.x release.
+The whole `v1.x` line — `v1.0.0` through `v1.4.1` — was published in error and is
+**retracted**. `v1.4.1` exists only to carry the retractions and retracts itself,
+so it is no safer than the rest. None of them receive fixes, and `go get` will
+not select them. If you pinned any v1 version, move to the latest v0.x release.
 
 The experimental `acor/server` module publishes no tags of its own; fixes for it
 land on `main` and are consumed from there.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,6 +15,10 @@ See the [latest release](https://github.com/skyoo2003/acor/releases/latest) for
 which version that is, and upgrade to it before reporting a vulnerability so the
 report is against supported code.
 
+Versions `v1.0.0`-`v1.4.0` were published in error and are **retracted**
+(`v1.4.1` carries the retractions). They receive no fixes, and `go get` will not
+select them. If you pinned one, move to the latest v0.x release.
+
 The experimental `acor/server` module publishes no tags of its own; fixes for it
 land on `main` and are consumed from there.
 

--- a/changes/unreleased/Deprecated-20260805-204635.yaml
+++ b/changes/unreleased/Deprecated-20260805-204635.yaml
@@ -1,11 +1,10 @@
 kind: Deprecated
 body: >-
-  Retracted the whole `v1.x` line (`[v1.0.0, v1.4.1]`). The `v1.0.0`-`v1.4.0` tags
-  were deleted long ago, but the module proxy caches versions permanently, so
-  `go get github.com/skyoo2003/acor` still resolved to `v1.4.0` instead of the
-  supported v0.x line. `v1.4.1` carries the retractions and retracts itself, so
-  `go get` now selects the latest v0.x release. Existing v1 pins keep building and
-  report the retraction on `go list -m -u`
+  Retracted `v1.0.0`-`v1.4.0`. Their tags were deleted long ago, but the module
+  proxy caches versions permanently, so `go get github.com/skyoo2003/acor` still
+  resolved to `v1.4.0` instead of the supported line. This release is the first
+  supported v1, which is why the numbering jumps from v0.11.x. Existing pins to a
+  retracted version keep building and report it on `go list -m -u`
 time: 2026-08-05T20:46:35.000000+09:00
 custom:
     Issue: "198"

--- a/changes/unreleased/Deprecated-20260805-204635.yaml
+++ b/changes/unreleased/Deprecated-20260805-204635.yaml
@@ -1,11 +1,11 @@
 kind: Deprecated
 body: >-
-  Retracted the whole `v1.x` line (`[v1.0.0, v1.4.1]`). The `v1.0.0`-`v1.4.0` git
-  tags were deleted long ago, but the module proxy caches versions permanently, so
-  they stayed resolvable and `go get github.com/skyoo2003/acor` selected `v1.4.0`
-  over the supported v0.x line. `v1.4.1` is a retraction-only tag that also
-  retracts itself, so `go get` now resolves to the latest v0.x release. Existing
-  pins to a v1 version keep building and report the retraction on `go list -m -u`
+  Retracted the whole `v1.x` line (`[v1.0.0, v1.4.1]`). The `v1.0.0`-`v1.4.0` tags
+  were deleted long ago, but the module proxy caches versions permanently, so
+  `go get github.com/skyoo2003/acor` still resolved to `v1.4.0` instead of the
+  supported v0.x line. `v1.4.1` carries the retractions and retracts itself, so
+  `go get` now selects the latest v0.x release. Existing v1 pins keep building and
+  report the retraction on `go list -m -u`
 time: 2026-08-05T20:46:35.000000+09:00
 custom:
     Issue: "198"

--- a/changes/unreleased/Deprecated-20260805-204635.yaml
+++ b/changes/unreleased/Deprecated-20260805-204635.yaml
@@ -1,11 +1,11 @@
 kind: Deprecated
 body: >-
-  Retracted the `v1.0.0`-`v1.4.0` releases. Their git tags were deleted long ago,
-  but the module proxy caches versions permanently, so they stayed resolvable and
-  `go get github.com/skyoo2003/acor` selected `v1.4.0` over the supported v0.x
-  line. `v1.4.1` is a retraction-only tag that also retracts itself, so `go get`
-  now resolves to the latest v0.x release. Existing pins to a v1 version keep
-  building and report the retraction on `go list -m -u`
+  Retracted the whole `v1.x` line (`[v1.0.0, v1.4.1]`). The `v1.0.0`-`v1.4.0` git
+  tags were deleted long ago, but the module proxy caches versions permanently, so
+  they stayed resolvable and `go get github.com/skyoo2003/acor` selected `v1.4.0`
+  over the supported v0.x line. `v1.4.1` is a retraction-only tag that also
+  retracts itself, so `go get` now resolves to the latest v0.x release. Existing
+  pins to a v1 version keep building and report the retraction on `go list -m -u`
 time: 2026-08-05T20:46:35.000000+09:00
 custom:
     Issue: "198"

--- a/changes/unreleased/Deprecated-20260805-204635.yaml
+++ b/changes/unreleased/Deprecated-20260805-204635.yaml
@@ -1,0 +1,11 @@
+kind: Deprecated
+body: >-
+  Retracted the `v1.0.0`-`v1.4.0` releases. Their git tags were deleted long ago,
+  but the module proxy caches versions permanently, so they stayed resolvable and
+  `go get github.com/skyoo2003/acor` selected `v1.4.0` over the supported v0.x
+  line. `v1.4.1` is a retraction-only tag that also retracts itself, so `go get`
+  now resolves to the latest v0.x release. Existing pins to a v1 version keep
+  building and report the retraction on `go list -m -u`
+time: 2026-08-05T20:46:35.000000+09:00
+custom:
+    Issue: "198"

--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,11 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 )
+
+// The v1.x line was published from tags that no longer exist in this
+// repository, but proxy.golang.org caches versions permanently, so
+// `go get github.com/skyoo2003/acor` resolved to v1.4.0 instead of the
+// supported v0.x line. v1.4.1 carries these retractions and nothing else;
+// it retracts itself so @latest falls back to the highest v0.x.
+// A real v1 will start at v1.5.0 - do not widen this range past v1.4.1.
+retract [v1.0.0, v1.4.1]

--- a/go.mod
+++ b/go.mod
@@ -15,9 +15,9 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 )
 
-// Published in error; use the latest v0.x release instead.
+// Published in error; upgrade to v1.5.0 or later.
 // Only the line above reaches users: the go command truncates a retraction
 // rationale at the first newline, so keep it a complete sentence.
-// v1.4.1 retracts itself, so @latest falls back to the highest v0.x.
-// See RELEASE.md. A real v1 starts at v1.5.0 - do not widen this range.
-retract [v1.0.0, v1.4.1]
+// v1.5.0 is the first supported v1 release. Never let this range reach it.
+// See RELEASE.md.
+retract [v1.0.0, v1.4.0]

--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,12 @@ require (
 	golang.org/x/sys v0.45.0 // indirect
 )
 
-// The v1.x line was published from tags that no longer exist in this
-// repository, but proxy.golang.org caches versions permanently, so
-// `go get github.com/skyoo2003/acor` resolved to v1.4.0 instead of the
-// supported v0.x line. v1.4.1 carries these retractions and nothing else;
-// it retracts itself so @latest falls back to the highest v0.x.
-// A real v1 will start at v1.5.0 - do not widen this range past v1.4.1.
+// Published in error; use the latest v0.x release instead.
+// Only this first line reaches users - the go command truncates a retraction
+// rationale at the first newline - so keep it a complete, actionable sentence.
+// The v1.x tags were deleted from this repository, but proxy.golang.org caches
+// versions permanently, so `go get github.com/skyoo2003/acor` resolved to
+// v1.4.0 instead of the supported v0.x line. v1.4.1 is the retraction carrier
+// and retracts itself, so @latest falls back to the highest v0.x.
+// A real v1 starts at v1.5.0 - do not widen this range past v1.4.1.
 retract [v1.0.0, v1.4.1]

--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,8 @@ require (
 )
 
 // Published in error; use the latest v0.x release instead.
-// Only this first line reaches users - the go command truncates a retraction
-// rationale at the first newline - so keep it a complete, actionable sentence.
-// The v1.x tags were deleted from this repository, but proxy.golang.org caches
-// versions permanently, so `go get github.com/skyoo2003/acor` resolved to
-// v1.4.0 instead of the supported v0.x line. v1.4.1 is the retraction carrier
-// and retracts itself, so @latest falls back to the highest v0.x.
-// A real v1 starts at v1.5.0 - do not widen this range past v1.4.1.
+// Only the line above reaches users: the go command truncates a retraction
+// rationale at the first newline, so keep it a complete sentence.
+// v1.4.1 retracts itself, so @latest falls back to the highest v0.x.
+// See RELEASE.md. A real v1 starts at v1.5.0 - do not widen this range.
 retract [v1.0.0, v1.4.1]


### PR DESCRIPTION
# Pull Request

## Description

`go get github.com/skyoo2003/acor` installs **v1.4.0**, not v0.11.0:

```
$ go list -m github.com/skyoo2003/acor@latest
github.com/skyoo2003/acor v1.4.0
```

`v1.0.0`–`v1.4.0` were published from tags that have since been deleted. Deleting a
tag does not unpublish a module version — `proxy.golang.org` caches it forever, and
its version list still serves all five:

```
$ curl -s https://proxy.golang.org/github.com/skyoo2003/acor/@v/list
v0.0.0 … v0.11.0, v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.4.0
```

Since v0.x and v1.x share the module path, v1.4.0 outranks v0.11.0 for `@latest`, so
new users get a tree pinned to `go-redis/v8`, `otel`, and `grpc v1.71.0-dev` — an API
generation that no longer exists.

`retract` is the only mechanism that fixes this. A module-level `// Deprecated:`
comment is **not** usable: per the [modules reference][deprecated] a deprecation
"applies to all minor versions of a module", and v0.x shares this module path, so it
would flag the line we are shipping.

### Changes

- **`go.mod`** — `retract [v1.0.0, v1.4.0]`. The range covers exactly what was
  published and stops short of **v1.5.0**, which becomes the first supported v1
  release. Nothing self-retracts, so `@latest` resolves to v1.5.0 directly.

  The comment's first line is the entire user-visible message — `ShortMessage`
  ([`modload/modfile.go`][shortmessage]) truncates a rationale at the first newline —
  so it leads with a complete, actionable sentence: *"Published in error; upgrade to
  v1.5.0 or later."*

- **`SECURITY.md`** — records the retracted range and names v1.5.0 as the first
  supported v1. Also drops "ACOR is pre-1.0", which v1.5.0 would make false; the
  table under it already states the policy without naming a line.

- **`RELEASE.md`** — a "Retracted versions" section: why the numbering jumps from
  v0.11.x, that the retractions take effect with the release carrying them (no
  separate step), and the two rules for editing the block — keep it on `main`, and
  keep the first comment line a complete sentence.

No workflow change is needed: v1.5.0 is an ordinary release that must publish
normally, so `release.yaml` is untouched. Only the root module needs this —
`acor/server` and `benchmarks` publish nothing to the proxy (both `@v/list`
responses are empty).

### How this lands

This PR only adds the `retract` block and the docs. It takes effect when **v1.5.0**
is released through the normal flow in RELEASE.md, alongside whatever features go
into it. Verify afterwards from a scratch module outside the repo:

```sh
curl -s https://proxy.golang.org/github.com/skyoo2003/acor/@v/v1.5.0.info
go list -m github.com/skyoo2003/acor@latest     # want v1.5.0
go list -m -versions github.com/skyoo2003/acor  # v1.0.0-v1.4.0 must be gone
```

The `curl` is needed because the proxy has to fetch the release before its
retractions apply. No `-retracted` on the last command: per `go help list` it lists
retracted versions alongside the rest, so its output is the same before and after.

[deprecated]: https://go.dev/ref/mod#go-mod-file-module
[shortmessage]: https://github.com/golang/go/blob/master/src/cmd/go/internal/modload/modfile.go

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`)
- [x] Commit messages follow guidelines

## Additional Notes

Retraction is advisory for existing pins: a `go.mod` already requiring v1.4.0 keeps
building and only reports the retraction on `go list -m -u` / `go get`. Third-party
mirrors honor it once they refresh their version list.

Because v0.x and v1.x share the module path, `go get -u` moves current v0.11.0 users
to v1.5.0 once it is out — normal for a v0-to-v1 step, but worth calling out in the
v1.5.0 release notes.

If the retract block is ever missing from the highest published version's `go.mod`,
the old versions silently stop being retracted. It has to stay on `main`.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).