### PR TITLE
docs: write down what the v1 compatibility promise covers

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -22,11 +22,12 @@ ACOR accepts contributions from the community. All contributions are reviewed by
 
 ## Release Process
 
-ACOR follows [Semantic Versioning](https://semver.org/):
+ACOR follows [Semantic Versioning](https://semver.org/). What a major version actually
+promises — which surfaces are covered, which are excluded, and what counts as a breaking
+change — is defined in the [compatibility policy](docs/content/reference/compatibility.md).
+That page is the single source; these rules are not restated here.
 
-- **Patch** (x.x.Z): Bug fixes, no API changes
-- **Minor** (x.Y.0): New features, backward-compatible API additions
-- **Major** (X.0.0): Breaking API changes
+The decision to cut a major version is the project lead's.
 
 Releases are managed via [Changie](https://github.com/miniscruff/changie) for changelog generation.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ multi-instance invalidation safety.
 
 - [Getting started and Redis topologies](docs/content/getting-started/quick-start.md)
 - [Matching and streaming API](docs/content/reference/api.md)
+- [Compatibility](docs/content/reference/compatibility.md) — what the `v1` line promises
 - [Batch operations](docs/content/guides/batch-operations.md) and [parallel matching](docs/content/guides/parallel-matching.md)
 - [Schema V2 and migration](docs/content/reference/schema-v2.md) and [benchmarks](docs/content/reference/benchmarks.md)
 - [Deployment](docs/content/operations/deployment.md), [monitoring](docs/content/operations/monitoring.md), and [troubleshooting](docs/content/operations/troubleshooting.md)

--- a/changes/unreleased/Documentation-20260805-225012.yaml
+++ b/changes/unreleased/Documentation-20260805-225012.yaml
@@ -1,0 +1,5 @@
+kind: Documentation
+body: 'Documented the v1 compatibility promise: `pkg/acor`''s exported API, its documented behavior, sentinel error identity, and additive-only changes to the on-Redis V2 format are covered for every `v1.x.y` release, so mixed-version fleets stay safe during a rolling deploy. The CLI contract, the experimental `acor/server` module, and `internal/...` are excluded. Callers must construct option structs with field names, and the five exported interfaces gain no methods inside v1'
+time: 2026-08-05T22:50:12.994369+09:00
+custom:
+    Issue: "200"

--- a/changes/unreleased/Documentation-20260805-225012.yaml
+++ b/changes/unreleased/Documentation-20260805-225012.yaml
@@ -1,5 +1,5 @@
 kind: Documentation
-body: 'Documented the v1 compatibility promise: `pkg/acor`''s exported API, its documented behavior, sentinel error identity, and additive-only changes to the on-Redis V2 format are covered for every `v1.x.y` release, so mixed-version fleets stay safe during a rolling deploy. The CLI contract, the experimental `acor/server` module, and `internal/...` are excluded. Callers must construct option structs with field names, and the five exported interfaces gain no methods inside v1'
+body: 'Documented the v1 compatibility promise: `pkg/acor`''s exported API, its documented behavior, sentinel error identity, and additive-only changes to the on-Redis V2 format are covered for every `v1.x.y` release, so mixed-version fleets stay safe during a rolling deploy. The CLI contract, the experimental `acor/server` module, and `internal/...` are excluded. Callers must construct option structs with field names and must not dot-import the package, and the five exported interfaces gain no methods inside v1'
 time: 2026-08-05T22:50:12.994369+09:00
 custom:
     Issue: "200"

--- a/docs/content/reference/_index.md
+++ b/docs/content/reference/_index.md
@@ -10,8 +10,10 @@ Technical reference documentation for ACOR.
 ## Sections
 
 - [API Reference](api/) - Public API documentation (unified `Create` API with `Preset` options)
+- [Compatibility](compatibility/) - What the `v1` line promises, and what it excludes
 - [Schema V1](schema-v1/) - Legacy schema details
 - [Schema V2](schema-v2/) - Optimized schema (recommended)
+- [Benchmarks](benchmarks/) - Measured performance and how to reproduce it
 
 ## Navigation
 

--- a/docs/content/reference/benchmarks.md
+++ b/docs/content/reference/benchmarks.md
@@ -1,6 +1,6 @@
 ---
 title: "Benchmarks"
-weight: 4
+weight: 5
 ---
 
 # Benchmarks

--- a/docs/content/reference/compatibility.md
+++ b/docs/content/reference/compatibility.md
@@ -1,0 +1,146 @@
+---
+title: "Compatibility"
+weight: 2
+---
+
+# Compatibility
+
+Code that imports `github.com/skyoo2003/acor/pkg/acor` keeps compiling, and keeps
+behaving as documented, across every `v1.x.y` release. Nothing is removed from that
+surface inside `v1`. Taking something back requires a `v2` import path, and no `v2` is
+scheduled.
+
+`v1.5.0` is the first supported `v1` release, and the promise is measured from its
+surface. `v1.0.0`-`v1.4.0` are retracted and were never covered — see
+[Retracted versions](https://github.com/skyoo2003/acor/blob/main/RELEASE.md#retracted-versions)
+for why the numbering starts there.
+
+**Upgrading from `v0.x` is a one-time exception.** `v1.5.0` removes deprecated members and
+closes paths that `v0.11.x` still allowed, so that upgrade can require changes to your
+code. Specifically:
+
+- `PresetUltimate` is removed. It was an alias for `PresetBalanced`; rename it.
+- `InMemoryInfo` is removed. No exported function accepted or returned it.
+- **V1 collections are read-only.** `Add` and `Remove` return `ErrV1ReadOnly`. Reads,
+  `Suggest`, `Info`, `Flush`, and `MigrateV1ToV2` still work, so an existing V1
+  collection can be read and converted, but it takes no new keywords. Migrate to V2.
+
+Every upgrade *after* `v1.5.0`, within `v1`, is covered by everything below. Each of
+those three would be a promise violation in `v1.6.0`; `v1.5.0` is the only release that
+can make them.
+
+## What is covered
+
+| Surface                                  | Covered by `v1`   |
+| ---------------------------------------- | ----------------- |
+| Exported identifiers of `pkg/acor`       | ✅                |
+| Documented behavior of those identifiers | ✅                |
+| Sentinel error identity (`errors.Is`)    | ✅                |
+| On-Redis V2 data format                  | ✅ additions only |
+| Everything in the next section           | ❌                |
+
+## What is not covered
+
+- **The CLI.** Flags, output format, and exit codes of the `acor` command can change in
+  any release. If you need a stable contract, call the library rather than parsing CLI
+  output.
+- **`acor/server`.** A separate, experimental module that publishes no tags of its own,
+  versioned independently of the core.
+- **`internal/...`.** Not importable, and free to change in any release.
+- **The `benchmarks` module.** A measurement harness, not an API.
+- **Documentation wording.** Pages get rewritten. What they describe is pinned by this
+  page, not by their phrasing.
+- **The V1 schema layout.** Deprecated, and not evolved further. See
+  [Deprecation](#deprecation).
+
+## Two conditions on your code
+
+The promise holds for code that follows both. Neither is something the compiler can
+enforce on your behalf.
+
+### Construct option structs with field names
+
+`AhoCorasickArgs`, `MatchOptions`, `BatchOptions`, `ParallelOptions`, and
+`MigrationOptions` gain fields in minor releases. That is not a breaking change for a
+keyed literal:
+
+<!-- doccheck -->
+```go
+args := &acor.AhoCorasickArgs{
+    Addr:   "localhost:6379",
+    Name:   "sample",
+    Preset: acor.PresetBalanced,
+}
+_ = args
+```
+
+An unkeyed literal breaks the moment any field is added, and is not covered by this
+promise:
+
+```go
+// Not covered: positional fields break when a field is added.
+args := &acor.AhoCorasickArgs{"localhost:6379", "sample"}
+```
+
+`go vet`'s `composites` check reports unkeyed literals of another package's structs, so
+this condition is verifiable in your own build.
+
+### Do not expect the exported interfaces to grow
+
+Five exported interfaces can be implemented from outside the module: `Logger`,
+`KVStorage`, `StringMapResult`, `Subscription`, and `Pipeliner`. No method is added to
+any of them inside `v1` — doing so would break every existing implementation.
+
+## The on-Redis data format
+
+ACOR exists so that several instances share one dictionary, which means a rolling deploy
+runs two ACOR versions against the same Redis keys at the same time. The Go API promise
+says nothing about that case. This section does.
+
+Inside `v1`, changes to the V2 format are **additive only**:
+
+- Key names, hash tags, and the names and meanings of existing fields do not change.
+- New fields may be added. An ACOR version that does not recognize a field ignores it.
+- A mixed-version fleet therefore keeps working in both directions for the whole `v1`
+  line, and a rolling deploy needs no coordinated restart.
+
+The cost lands on new features rather than on availability: a feature that depends on a
+newly added field does not take effect until every instance writing to the collection is
+upgraded. Expect it to appear after the rollout finishes, not during it.
+
+## What counts as a breaking change
+
+Removing or renaming an exported identifier, changing a signature, and narrowing a return
+type are the obvious cases, and tooling catches them. These count too, and tooling does
+not catch any of them:
+
+- **Adding a field to an option struct**, for callers using unkeyed literals — which is
+  why the condition above exists.
+- **No longer returning a sentinel error** for the situation that returns it today.
+  `errors.Is(err, ErrCacheWithPreset)` continuing to hold is part of the promise; the
+  variable merely continuing to exist is not enough.
+- **Changing documented behavior** — match ordering, `MatchKind` semantics, `FindSet`'s
+  first-match order, `FindParallel`'s deduplication contract.
+- **Changing the meaning of an existing V2 field**, per the section above.
+
+Undocumented detail is not covered. Sort order among equally-ranked matches, the exact
+wording of an error string, allocation counts, and round-trip counts can change in any
+release.
+
+## Deprecation
+
+A deprecated identifier keeps working for the rest of `v1`. It carries a `Deprecated:`
+line naming its replacement, gains no new capability, and is removed no earlier than
+`v2`.
+
+Deprecated today: `SchemaV1`, which is read-only and whose read path is removed no
+earlier than `v2`.
+
+## `v2`
+
+A `v2` would ship as the module `github.com/skyoo2003/acor/v2`, imported as
+`github.com/skyoo2003/acor/v2/pkg/acor`. `v1` stays importable and unchanged at its own
+path, so nothing breaks by the act of publishing `v2`. There is no schedule.
+
+Security patches follow the [security policy](https://github.com/skyoo2003/acor/blob/main/SECURITY.md),
+which covers the latest released minor line only.

--- a/docs/content/reference/compatibility.md
+++ b/docs/content/reference/compatibility.md
@@ -15,15 +15,23 @@ surface. `v1.0.0`-`v1.4.0` are retracted and were never covered — see
 [Retracted versions](https://github.com/skyoo2003/acor/blob/main/RELEASE.md#retracted-versions)
 for why the numbering starts there.
 
-**Upgrading from `v0.x` is a one-time exception.** `v1.5.0` removes deprecated members and
-closes paths that `v0.11.x` still allowed, so that upgrade can require changes to your
-code. Specifically:
+**Upgrading from `v0.11.x` is a one-time exception.** `v1.5.0` removes deprecated members
+and closes paths that `v0.11.x` still allowed, so that upgrade can require changes to your
+code. From `v0.10.x` or earlier, `v0.11.0`'s own breaking changes apply first — the
+`RemoveMany` signature, the removal of `RemoveManyWithOptions`, and the removal of the
+exported V1 key constants — so upgrade through `v0.11.x` and follow the
+[changelog](https://github.com/skyoo2003/acor/blob/main/CHANGELOG.md); this page does not
+restate them.
+
+From `v0.11.x`, specifically:
 
 - `PresetUltimate` is removed. It was an alias for `PresetBalanced`; rename it.
 - `InMemoryInfo` is removed. No exported function accepted or returned it.
 - **V1 collections are read-only.** `Add` and `Remove` return `ErrV1ReadOnly`. Reads,
-  `Suggest`, `Info`, `Flush`, and `MigrateV1ToV2` still work, so an existing V1
-  collection can be read and converted, but it takes no new keywords. Migrate to V2.
+  `Suggest`, `Info`, and `MigrateV1ToV2` still work, so an existing V1 collection can be
+  read and converted, but it takes no new keywords. Migrate to V2. `Flush` also still
+  works — and still deletes every key in the collection. Read-only means keyword writes
+  are refused, not that the collection cannot be destroyed.
 
 Every upgrade *after* `v1.5.0`, within `v1`, is covered by everything below. Each of
 those three would be a promise violation in `v1.6.0`; `v1.5.0` is the only release that
@@ -44,8 +52,9 @@ can make them.
 - **The CLI.** Flags, output format, and exit codes of the `acor` command can change in
   any release. If you need a stable contract, call the library rather than parsing CLI
   output.
-- **`acor/server`.** A separate, experimental module that publishes no tags of its own,
-  versioned independently of the core.
+- **`acor/server`.** A separate, experimental module. It publishes no tags of its own, so
+  it can only be required by pseudo-version, and the core's version numbers say nothing
+  about it.
 - **`internal/...`.** Not importable, and free to change in any release.
 - **The `benchmarks` module.** A measurement harness, not an API.
 - **Documentation wording.** Pages get rewritten. What they describe is pinned by this
@@ -53,10 +62,10 @@ can make them.
 - **The V1 schema layout.** Deprecated, and not evolved further. See
   [Deprecation](#deprecation).
 
-## Two conditions on your code
+## Conditions on your code
 
-The promise holds for code that follows both. Neither is something the compiler can
-enforce on your behalf.
+The promise holds for code that follows all three. None of them is something the compiler
+can enforce on your behalf.
 
 ### Construct option structs with field names
 
@@ -79,17 +88,25 @@ promise:
 
 ```go
 // Not covered: positional fields break when a field is added.
-args := &acor.AhoCorasickArgs{"localhost:6379", "sample"}
+opts := acor.MatchOptions{acor.MatchKindLeftmostLongest, true, nil}
 ```
 
-`go vet`'s `composites` check reports unkeyed literals of another package's structs, so
-this condition is verifiable in your own build.
+That literal compiles against `v1.5.0` and stops compiling the moment `MatchOptions` gains
+a fourth field. `go vet`'s `composites` check reports unkeyed literals of another package's
+structs, so this condition is verifiable in your own build.
 
 ### Do not expect the exported interfaces to grow
 
 Five exported interfaces can be implemented from outside the module: `Logger`,
 `KVStorage`, `StringMapResult`, `Subscription`, and `Pipeliner`. No method is added to
 any of them inside `v1` — doing so would break every existing implementation.
+
+### Do not dot-import the package
+
+`import . "github.com/skyoo2003/acor/pkg/acor"` puts every exported name into your file's
+scope, so a name added in a minor release can collide with one of your own declarations and
+stop the file compiling. A normal import cannot: additions land behind the `acor.`
+qualifier, where they collide with nothing.
 
 ## The on-Redis data format
 
@@ -100,15 +117,26 @@ says nothing about that case. This section does.
 Inside `v1`, changes to the V2 format are **additive only**:
 
 - Key names, hash tags, and the names and meanings of existing fields do not change.
-- New fields may be added. An ACOR version that does not recognize a field ignores it.
+- New fields may be added to the `{name}:trie` hash, or under a new key. An ACOR version
+  that does not recognize a field there ignores it: that hash is read by looking its
+  fields up by name.
+- Nothing is added to the `{name}:outputs` hash. Its field names are automaton states and
+  every value in it is read as match data, so it has no room for metadata.
 - A mixed-version fleet therefore keeps working in both directions for the whole `v1`
   line, and a rolling deploy needs no coordinated restart.
+
+`Flush` rewrites `{name}:trie` in full, so a `Flush` issued by an older instance drops
+fields a newer one added. The next write from an upgraded instance restores them.
 
 The cost lands on new features rather than on availability: a feature that depends on a
 newly added field does not take effect until every instance writing to the collection is
 upgraded. Expect it to appear after the rollout finishes, not during it.
 
 ## What counts as a breaking change
+
+A patch release (`x.y.Z`) carries bug fixes and no surface change; a minor release
+(`x.Y.0`) adds to the surface without breaking it; a breaking change requires a new major
+version.
 
 Removing or renaming an exported identifier, changing a signature, and narrowing a return
 type are the obvious cases, and tooling catches them. These count too, and tooling does
@@ -143,4 +171,4 @@ A `v2` would ship as the module `github.com/skyoo2003/acor/v2`, imported as
 path, so nothing breaks by the act of publishing `v2`. There is no schedule.
 
 Security patches follow the [security policy](https://github.com/skyoo2003/acor/blob/main/SECURITY.md),
-which covers the latest released minor line only.
+which defines which lines receive them.

--- a/docs/content/reference/schema-v1.md
+++ b/docs/content/reference/schema-v1.md
@@ -7,9 +7,11 @@ weight: 3
 
 V1 is the original ACOR storage schema. It uses multiple Redis keys per collection.
 
-> **V1 is deprecated and read-only as of `v1.5.0`.** Reads, `Suggest`, `Info`, and
-> `Flush` work, and `MigrateV1ToV2` converts a collection in place, but `Add` and
-> `Remove` return `ErrV1ReadOnly`. It gains no features either: preset engines and
+> **V1 is deprecated and read-only as of `v1.5.0`.** Reads, `Suggest`, and `Info` work,
+> and `MigrateV1ToV2` converts a collection in place, but `Add` and `Remove` return
+> `ErrV1ReadOnly`. `Flush` also still works, and still deletes every key in the
+> collection — read-only refuses keyword writes, it does not protect the collection from
+> `Flush`. It gains no features either: preset engines and
 > `EnableCache` both require V2. New collections should use the default V2 schema.
 > The read path stays for the whole `v1` line and is removed no earlier than `v2`.
 

--- a/docs/content/reference/schema-v1.md
+++ b/docs/content/reference/schema-v1.md
@@ -1,16 +1,17 @@
 ---
 title: "Schema V1 (Deprecated)"
-weight: 2
+weight: 3
 ---
 
 # Schema V1 (Deprecated)
 
 V1 is the original ACOR storage schema. It uses multiple Redis keys per collection.
 
-> **V1 is deprecated.** It stays readable and writable so existing collections keep
-> working, and `MigrateV1ToV2` converts them in place, but it gains no new features:
-> preset engines and `EnableCache` both require V2. New collections should use the
-> default V2 schema. Support for V1 may be removed in a future major version.
+> **V1 is deprecated and read-only as of `v1.5.0`.** Reads, `Suggest`, `Info`, and
+> `Flush` work, and `MigrateV1ToV2` converts a collection in place, but `Add` and
+> `Remove` return `ErrV1ReadOnly`. It gains no features either: preset engines and
+> `EnableCache` both require V2. New collections should use the default V2 schema.
+> The read path stays for the whole `v1` line and is removed no earlier than `v2`.
 
 ## Overview
 
@@ -29,7 +30,7 @@ V1 creates approximately 5 keys per 100 keywords:
 | Operation | Complexity |
 |-----------|------------|
 | Find() | O(N×3-5) RTT |
-| Add() | O(M×3-10) RTT |
+| Add() | O(M×3-10) RTT — no longer reachable; kept to explain the migration's value |
 
 Where:
 - N = number of trie states visited

--- a/docs/content/reference/schema-v2.md
+++ b/docs/content/reference/schema-v2.md
@@ -1,6 +1,6 @@
 ---
 title: "Schema V2 (Optimized)"
-weight: 3
+weight: 4
 ---
 
 # Schema V2 (Optimized)

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -19,11 +19,13 @@
 // # Compatibility
 //
 // Every v1.x.y release keeps this package's exported identifiers compiling and behaving
-// as documented. v1.5.0 is the first supported v1 release. Two conditions apply to
+// as documented. v1.5.0 is the first supported v1 release. Three conditions apply to
 // calling code: construct AhoCorasickArgs, MatchOptions, BatchOptions, ParallelOptions,
 // and MigrationOptions with field names, since those structs gain fields in minor
-// releases; and do not expect Logger, KVStorage, StringMapResult, Subscription, or
-// Pipeliner to gain methods, since they will not inside v1.
+// releases; do not expect Logger, KVStorage, StringMapResult, Subscription, or
+// Pipeliner to gain methods, since they will not inside v1; and do not dot-import this
+// package, since a name added in a minor release can then collide with a declaration of
+// your own.
 //
 // The full policy — including the on-Redis format rules that make mixed-version fleets
 // safe, and what the promise excludes — is at

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -16,6 +16,19 @@
 //   - Parallel text matching for improved performance on large texts
 //   - Prefix-based keyword suggestions
 //
+// # Compatibility
+//
+// Every v1.x.y release keeps this package's exported identifiers compiling and behaving
+// as documented. v1.5.0 is the first supported v1 release. Two conditions apply to
+// calling code: construct AhoCorasickArgs, MatchOptions, BatchOptions, ParallelOptions,
+// and MigrationOptions with field names, since those structs gain fields in minor
+// releases; and do not expect Logger, KVStorage, StringMapResult, Subscription, or
+// Pipeliner to gain methods, since they will not inside v1.
+//
+// The full policy — including the on-Redis format rules that make mixed-version fleets
+// safe, and what the promise excludes — is at
+// https://skyoo2003.github.io/acor/reference/compatibility/
+//
 // # Quick Start
 //
 // Basic usage with a standalone Redis instance:


### PR DESCRIPTION
# Pull Request

## Description

GOVERNANCE.md stated SemVer generically and nothing said what was in scope, so "v1" would
have meant whatever a reader assumed. v1.5.0 makes that permanent: inside a major version
Go permits additions only, and taking something back needs a `/v2` import path.

Adds `docs/content/reference/compatibility.md` as the single place the scope is defined:

- **Covered** — exported identifiers of `pkg/acor`, their documented behavior, sentinel
  error identity (`errors.Is`), and additive-only changes to the on-Redis V2 format.
- **Not covered** — the CLI contract, the experimental `acor/server` module,
  `internal/...`, the `benchmarks` module, doc wording, and the deprecated V1 layout.
- **Conditions on calling code** — keyed option-struct literals, no new methods expected
  on the five externally implementable interfaces, no dot-import.
- **What counts as breaking** — including the cases tooling does not catch: a new field
  breaking unkeyed literals, no longer returning a sentinel, changed documented behavior,
  changed meaning of a V2 field.
- **Rolling deploys** — the V2 format section spells out why a mixed-version fleet keeps
  working in both directions for the whole v1 line, and what that costs (a feature
  depending on a new field lands after the rollout, not during it).

The v0.11.x → v1.5.0 upgrade exceptions (`PresetUltimate`, `InMemoryInfo`, V1 collections
becoming read-only) are documented here because v1.5.0 is the only release that can make
them; the code changes they describe follow in the stacked PRs below.

GOVERNANCE.md now points at that page instead of restating SemVer, the package doc in
`pkg/acor/acor.go` carries a summary so `go doc` has it, and the reference index, README,
and schema pages link to it.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

No functional change: the only Go edit is a doc comment in `pkg/acor/acor.go`.

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) — `changes/unreleased/Documentation-20260805-225012.yaml`
- [x] Commit messages follow guidelines

## Additional Notes

Milestone 1 of the v1 API stability work. First of four stacked PRs; merge in order:

1. **#200 → `main`** (this PR) — the compatibility promise
2. #201 → #200 — narrow the public API surface for v1
3. #202 → #201 — expose local cache statistics via `CacheStats`
4. #203 → #202 — gate the public API surface and the retraction block

The promise is written first so the following three have something to be measured against.
Each was committed with the full pre-commit suite green (golangci-lint, go test, go build,
go mod tidy).

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).
