### PR TITLE
feat: expose local cache statistics via CacheStats

### DIFF
--- a/changes/unreleased/Added-20260806-044132.yaml
+++ b/changes/unreleased/Added-20260806-044132.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: '`AhoCorasick.CacheStats()` reports local cache hit rate, rebuild cost, and the lag of the last peer invalidation, with no Redis I/O. Previously only the experimental `server/` module exposed metrics, so a library user could observe the cache only by inferring it from latency. Counters are per instance and per process; `CacheStats` is returned, never constructed, so it may gain fields inside v1.'
+time: 2026-08-06T04:41:32.142197+09:00
+custom:
+    Issue: "202"

--- a/changes/unreleased/Documentation-20260806-044132.yaml
+++ b/changes/unreleased/Documentation-20260806-044132.yaml
@@ -1,0 +1,5 @@
+kind: Documentation
+body: Rewrote the monitoring page to separate the core library from the experimental `server/` module, and documented how to read the new cache statistics — including why `Rebuilds` does not equal `Misses` and why `LastInvalidationLag` carries clock skew.
+time: 2026-08-06T04:41:32.152243+09:00
+custom:
+    Issue: "202"

--- a/docs/content/operations/monitoring.md
+++ b/docs/content/operations/monitoring.md
@@ -68,11 +68,19 @@ stays yours.
 - **`Rebuilds` will not equal `Misses`.** Concurrent misses coalesce onto one build, so
   `Misses - Rebuilds` is what that coalescing saved; local writes rebuild off the read
   path and push the count the other way. In `Preset` mode `Rebuilds` starts at 1, from
-  the build during `Create`.
-- **`LastInvalidationLag` includes clock skew.** The publish timestamp comes from
-  another machine's clock, so this is an upper bound on delivery delay, not a network
-  measurement. Watch it for step changes rather than trusting the absolute value, and
-  check NTP before concluding Pub/Sub is slow.
+  the build during `Create`. Both counters are `uint64`, so check `Misses > Rebuilds`
+  before subtracting — a write-heavy instance is routinely the other way round, and the
+  difference wraps to roughly 1.8e19 rather than going negative.
+- **One read is one scan, not one call.** `FindParallel` and `FindIndexParallel` scan
+  chunk by chunk, so a text split into N chunks adds N to `Hits`+`Misses`. Their hit
+  rate is not comparable to a serial workload's without dividing that out.
+- **`LastInvalidationLag` needs a listener, and carries clock skew.** It is populated
+  only in `Preset` mode and in V2 with `EnableCache`; the other modes subscribe to
+  nothing, so a zero there means unavailable, not fast. Where it is populated, the
+  publish timestamp comes from another machine's clock, so the value is the real delay
+  plus that clock's offset — it can understate the delay as readily as overstate it, and
+  bounds it in neither direction. Watch it for step changes rather than trusting the
+  absolute value, and check NTP before concluding Pub/Sub is slow.
 - **A zero hit rate is not always a bug.** Without `Preset` or `EnableCache` every read
   still checks Redis for freshness; a hit there means only that the automaton was
   reused, not that the round trip was skipped.
@@ -92,7 +100,7 @@ graph LR
     D --> G[Jaeger/Zipkin]
 ```
 
-## Metrics
+### Metrics
 
 Import the metrics package:
 
@@ -100,7 +108,7 @@ Import the metrics package:
 import "github.com/skyoo2003/acor/server/metrics"
 ```
 
-### Available Metrics
+#### Available Metrics
 
 | Metric                                  | Type      | Description                                 |
 | --------------------------------------- | --------- | ------------------------------------------- |
@@ -117,7 +125,7 @@ gRPC metrics use the standard `grpc_server_*` names from
 `go-grpc-middleware/providers/prometheus`, wired via
 `NewGRPCServerWithObservability`.
 
-### Exposing Metrics
+#### Exposing Metrics
 
 ```go
 import (
@@ -137,7 +145,7 @@ func main() {
 }
 ```
 
-## Logging
+### Logging
 
 Import the logging package:
 
@@ -145,7 +153,7 @@ Import the logging package:
 import "github.com/skyoo2003/acor/server/logging"
 ```
 
-### Structured Logging
+#### Structured Logging
 
 `NewLogger` takes an `io.Writer` and a level string (`debug`, `info`, `warn`,
 `error`) and returns a zerolog-based logger that always emits structured JSON.
@@ -178,14 +186,14 @@ func main() {
 }
 ```
 
-### Log Levels
+#### Log Levels
 
 - `debug`: Detailed debugging info
 - `info`: General operational info
 - `warn`: Warning conditions
 - `error`: Error conditions
 
-## Tracing
+### Tracing
 
 Import the tracing package:
 
@@ -193,7 +201,7 @@ Import the tracing package:
 import "github.com/skyoo2003/acor/server/tracing"
 ```
 
-### OpenTelemetry Setup
+#### OpenTelemetry Setup
 
 <!-- doccheck:server -->
 ```go
@@ -209,7 +217,7 @@ if err != nil {
 defer tracer.Shutdown()
 ```
 
-### Spans
+#### Spans
 
 The core `pkg/acor` library does not emit its own spans. Request spans are
 created by the `server/tracing` middleware for incoming traffic:
@@ -220,16 +228,16 @@ created by the `server/tracing` middleware for incoming traffic:
 To trace individual `Add`/`Find`/`Remove` calls, wrap them in your own spans
 using the OpenTelemetry API.
 
-## Dashboards
+### Dashboards
 
-### Key Metrics to Monitor
+#### Key Metrics to Monitor
 
 1. **Operation Latency**: P50, P95, P99
 2. **Error Rate**: Operations failing
 3. **Keyword Count**: Collection size
 4. **Redis Connections**: Pool utilization
 
-### Grafana Dashboard
+#### Grafana Dashboard
 
 Create a Grafana dashboard using the metrics above. Key panels to include:
 
@@ -238,7 +246,7 @@ Create a Grafana dashboard using the metrics above. Key panels to include:
 3. **Keyword Count**: Gauge `acor_keywords_total`
 4. **Trie Nodes**: Gauge `acor_trie_nodes_total`
 
-## Alerting Rules
+### Alerting Rules
 
 ```yaml
 groups:

--- a/docs/content/operations/monitoring.md
+++ b/docs/content/operations/monitoring.md
@@ -20,11 +20,66 @@ Monitor ACOR performance with built-in observability support.
 
 ## Overview
 
-ACOR provides three pillars of observability:
+Two layers, and which one you get depends on how you run ACOR:
 
-- **Metrics**: Prometheus-compatible metrics
-- **Logging**: Structured JSON logging
-- **Tracing**: OpenTelemetry distributed tracing
+| Layer | What it gives you | Covered by the `v1` promise |
+| ----- | ----------------- | --------------------------- |
+| `pkg/acor` — the library | `CacheStats()`: cache hit rate, rebuild cost, invalidation lag | ✅ |
+| `acor/server` — the service | Prometheus metrics, structured JSON logs, OpenTelemetry traces | ❌ experimental |
+
+Embedding the library gets you the first row only. Everything after the next section is
+`server/*`, which means importing a separate, experimental module — reach for it when
+you run ACOR as a service, not to instrument your own process.
+
+## Core library: cache statistics
+
+`CacheStats()` answers the three questions that decide whether ACOR is behaving: how
+often reads avoid Redis, how much a peer's write costs every reader, and how fast
+invalidations propagate. It does no Redis I/O, so scraping it on a timer is cheap.
+
+<!-- doccheck -->
+```go
+stats := ac.CacheStats()
+
+// Hits+Misses is the read count. Both are zero before the first read.
+hitRate := 0.0
+if reads := stats.Hits + stats.Misses; reads > 0 {
+    hitRate = float64(stats.Hits) / float64(reads)
+}
+
+// What one rebuild costs — the price a write makes every reader pay.
+meanRebuild := time.Duration(0)
+if stats.Rebuilds > 0 {
+    meanRebuild = stats.RebuildDuration / time.Duration(stats.Rebuilds)
+}
+
+lag := stats.LastInvalidationLag
+_, _, _ = hitRate, meanRebuild, lag
+```
+
+Wire those three into whatever you already run — a Prometheus collector, an OTel
+meter, a log line. ACOR deliberately depends on no metrics library, so the choice
+stays yours.
+
+### Reading the numbers
+
+- **The counters are per instance and per process.** Nothing is aggregated through
+  Redis, so in a fleet you scrape every instance. A restart resets them.
+- **`Rebuilds` will not equal `Misses`.** Concurrent misses coalesce onto one build, so
+  `Misses - Rebuilds` is what that coalescing saved; local writes rebuild off the read
+  path and push the count the other way. In `Preset` mode `Rebuilds` starts at 1, from
+  the build during `Create`.
+- **`LastInvalidationLag` includes clock skew.** The publish timestamp comes from
+  another machine's clock, so this is an upper bound on delivery delay, not a network
+  measurement. Watch it for step changes rather than trusting the absolute value, and
+  check NTP before concluding Pub/Sub is slow.
+- **A zero hit rate is not always a bug.** Without `Preset` or `EnableCache` every read
+  still checks Redis for freshness; a hit there means only that the automaton was
+  reused, not that the round trip was skipped.
+- **What is not here**: match counts, keyword counts, and Redis latency. Keyword and
+  node counts come from `Info()`, which does read Redis.
+
+## Service layer: `server/*`
 
 ```mermaid
 graph LR

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -297,7 +297,7 @@ type CacheStats struct {
     Misses              uint64        // Reads that waited for a rebuild
     Rebuilds            uint64        // Automaton builds (starts at 1 in Preset mode)
     RebuildDuration     time.Duration // Cumulative build time, excluding Redis I/O
-    LastInvalidationLag time.Duration // Delay of the last peer invalidation (includes clock skew)
+    LastInvalidationLag time.Duration // Last peer invalidation delay (Preset/EnableCache only; carries clock skew)
 }
 ```
 

--- a/docs/content/reference/api.md
+++ b/docs/content/reference/api.md
@@ -240,6 +240,20 @@ info, err := ac.Info()
 // Returns: &AhoCorasickInfo{Keywords: N, Nodes: M, Preset: ..., MemoryBytes: ..., TrieDepth: ...}
 ```
 
+### CacheStats
+
+Get local cache statistics. Unlike `Info`, this performs no Redis I/O, so it is cheap
+enough to scrape on a timer.
+
+```go
+stats := ac.CacheStats()
+// Returns: CacheStats{Hits: N, Misses: M, Rebuilds: R, RebuildDuration: ..., LastInvalidationLag: ...}
+```
+
+The counters are per instance and per process — scrape every instance in a fleet. See
+[Monitoring](../../operations/monitoring/) for how to read them, including why
+`Rebuilds` does not equal `Misses` and why `LastInvalidationLag` carries clock skew.
+
 ### Flush
 
 Clear all data from the collection.
@@ -271,6 +285,21 @@ type AhoCorasickInfo struct {
 }
 ```
 <!-- AUTO-GENERATED:types:end -->
+
+### CacheStats (type)
+
+A snapshot of one instance's local cache activity. Returned by `CacheStats()`, never
+constructed by callers — fields may be added inside `v1`.
+
+```go
+type CacheStats struct {
+    Hits                uint64        // Reads served without rebuilding the automaton
+    Misses              uint64        // Reads that waited for a rebuild
+    Rebuilds            uint64        // Automaton builds (starts at 1 in Preset mode)
+    RebuildDuration     time.Duration // Cumulative build time, excluding Redis I/O
+    LastInvalidationLag time.Duration // Delay of the last peer invalidation (includes clock skew)
+}
+```
 
 ### Preset
 

--- a/docs/content/reference/compatibility.md
+++ b/docs/content/reference/compatibility.md
@@ -95,6 +95,12 @@ That literal compiles against `v1.5.0` and stops compiling the moment `MatchOpti
 a fourth field. `go vet`'s `composites` check reports unkeyed literals of another package's
 structs, so this condition is verifiable in your own build.
 
+The structs ACOR *returns* run the other way. `AhoCorasickInfo`, `MigrationResult`,
+`BatchResult`, and `CacheStats` are built by ACOR and read by you, so a new field cannot
+break a reader — and they do gain fields inside `v1`. The condition on them is only that
+you not construct or whole-value compare one: assert on the fields you care about, and a
+later release adding a sixth counter stays invisible to your code.
+
 ### Do not expect the exported interfaces to grow
 
 Five exported interfaces can be implemented from outside the module: `Logger`,

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -129,6 +129,9 @@
 // Cache synchronization uses Redis Pub/Sub. When any instance modifies the collection,
 // all instances receive an invalidation message and reload on next Find().
 //
+// CacheStats reports how that is going — hit rate, rebuild cost, and the lag of the last
+// invalidation received — without touching Redis, so it is cheap to scrape on a timer.
+//
 // # Thread Safety
 //
 // All operations are safe for concurrent use. V2 schema uses optimistic locking
@@ -346,6 +349,7 @@ type AhoCorasick struct {
 	caseSensitive   bool
 
 	cache     *trieCache
+	stats     *cacheStats
 	pubsub    Subscription
 	stopCh    chan struct{}
 	closeOnce sync.Once
@@ -464,6 +468,9 @@ func createPresetRedis(ctx context.Context, args *AhoCorasickArgs) (*AhoCorasick
 		logger:        newLogger(args),
 		schemaVersion: SchemaV2,
 		ops:           rbAC,
+		// Same counters the engine records into, not a second set: newRedisBacked owns
+		// them because it builds the first automaton before this struct exists.
+		stats:         rbAC.stats,
 		mode:          modePresetRedis,
 		caseSensitive: args.CaseSensitive,
 		ctx:           context.Background(),
@@ -513,6 +520,7 @@ func createOriginal(ctx context.Context, args *AhoCorasickArgs) (*AhoCorasick, e
 		logger:        logger,
 		schemaVersion: schemaVersion,
 		cache:         cache,
+		stats:         &cacheStats{},
 		mode:          modeOriginal,
 	}
 	ac.rollbackTimeout = resolveRollbackTimeout(args.RollbackTimeout)
@@ -613,6 +621,10 @@ func (ac *AhoCorasick) newV2Ops(cache *trieCache) operations {
 		cache:         cache,
 		logger:        ac.logger,
 		caseSensitive: ac.caseSensitive,
+		stats:         ac.stats,
+		// The memo shares the same counters, so an uncached V2 instance still reports a
+		// hit rate: it skips the rebuild even though the freshness read remains.
+		engines: engineMemo{stats: ac.stats},
 	}
 }
 
@@ -624,7 +636,19 @@ func (ac *AhoCorasick) newV1Ops() operations {
 		ac:              ac,
 		caseSensitive:   ac.caseSensitive,
 		rollbackTimeout: ac.rollbackTimeout,
+		engines:         engineMemo{stats: ac.stats},
 	}
+}
+
+// CacheStats returns a snapshot of this instance's local cache activity: hit rate,
+// rebuild cost, and the lag of the last invalidation received from a peer. See
+// CacheStats for what each field counts and what it does not.
+//
+// It performs no Redis I/O, takes no lock the read path contends on, and is safe to
+// call concurrently and after Close — so it is cheap enough to scrape on a timer.
+// The counters are process-local: in a fleet, scrape every instance.
+func (ac *AhoCorasick) CacheStats() CacheStats {
+	return ac.stats.snapshot()
 }
 
 // Add inserts a keyword into the Aho-Corasick automaton.

--- a/pkg/acor/engine_memo.go
+++ b/pkg/acor/engine_memo.go
@@ -21,6 +21,9 @@ type engineMemo struct {
 	mu     sync.Mutex
 	engine *matchengine.Engine
 	digest uint64
+	// stats is shared with the operations that own this memo, so a hit here counts
+	// toward the same CacheStats as a hit in the other modes. Nil records nothing.
+	stats *cacheStats
 }
 
 // engineDigestSeed keys the digests, which are only ever compared against
@@ -37,9 +40,11 @@ func (m *engineMemo) engineFor(digest uint64, build func() (*matchengine.Engine,
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.engine != nil && m.digest == digest {
+		m.stats.hit()
 		return m.engine, nil
 	}
-	engine, err := build()
+	m.stats.miss()
+	engine, err := timeRebuild(m.stats, build)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/acor/invalidation.go
+++ b/pkg/acor/invalidation.go
@@ -138,13 +138,18 @@ func isSelfEcho(payload, name string, skip *selfSkipSet) bool {
 // for CacheStats.LastInvalidationLag. It reads the timestamp newInvalidationID
 // already puts in front of every ID, so measuring lag needs no extra wire format.
 //
-// It reports false rather than a zero duration for a payload it cannot parse, so a
-// corrupt message is left out of the statistics instead of recorded as instant
-// delivery. The two timestamps come from two machines, so the result carries their
-// clock skew; recordInvalidationLag discards a negative value for that reason.
-func invalidationLag(payload string) (time.Duration, bool) {
+// It reports false rather than a zero duration for a payload it cannot parse or one
+// naming another collection — the same two conditions isSelfEcho screens on — so a
+// message this instance did not publish the format of is left out of the statistics
+// instead of recorded as instant delivery. Only the timestamp's syntax is checked,
+// though: a publisher whose clock is years off still yields a parseable, absurd,
+// recorded lag, which the gauge then holds until the next message replaces it.
+//
+// The two timestamps come from two machines, so the result carries their clock skew;
+// recordInvalidationLag discards a negative value for that reason.
+func invalidationLag(payload, name string) (time.Duration, bool) {
 	parts := strings.SplitN(payload, ":", invalidatePayloadSplitMax)
-	if len(parts) != invalidatePayloadSplitMax {
+	if len(parts) != invalidatePayloadSplitMax || parts[0] != name {
 		return 0, false
 	}
 	// parts[1] is the ID, itself "<unixnano>:<random>".
@@ -157,6 +162,24 @@ func invalidationLag(payload string) (time.Duration, bool) {
 		return 0, false
 	}
 	return time.Since(time.Unix(0, published)), true
+}
+
+// foreignInvalidation reports whether payload is a peer's invalidation rather than
+// this instance's own echo, recording its delivery lag on the way through.
+//
+// Both listeners — the V2 trie cache and the preset engine — need exactly this pair
+// of steps before they act, so they live here once instead of in two callbacks that
+// would drift. Only foreign messages are measured: a self-echo returned above, and
+// timing this process against its own clock says nothing about how fast peers reach
+// us.
+func foreignInvalidation(payload, name string, skip *selfSkipSet, stats *cacheStats) bool {
+	if isSelfEcho(payload, name, skip) {
+		return false
+	}
+	if lag, ok := invalidationLag(payload, name); ok {
+		stats.recordInvalidationLag(lag)
+	}
+	return true
 }
 
 // subscribeInvalidations subscribes to the collection's invalidation channel and

--- a/pkg/acor/invalidation.go
+++ b/pkg/acor/invalidation.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -131,6 +132,31 @@ func isSelfEcho(payload, name string, skip *selfSkipSet) bool {
 		return false
 	}
 	return skip.claim(parts[1])
+}
+
+// invalidationLag reports how long ago the invalidation in payload was published,
+// for CacheStats.LastInvalidationLag. It reads the timestamp newInvalidationID
+// already puts in front of every ID, so measuring lag needs no extra wire format.
+//
+// It reports false rather than a zero duration for a payload it cannot parse, so a
+// corrupt message is left out of the statistics instead of recorded as instant
+// delivery. The two timestamps come from two machines, so the result carries their
+// clock skew; recordInvalidationLag discards a negative value for that reason.
+func invalidationLag(payload string) (time.Duration, bool) {
+	parts := strings.SplitN(payload, ":", invalidatePayloadSplitMax)
+	if len(parts) != invalidatePayloadSplitMax {
+		return 0, false
+	}
+	// parts[1] is the ID, itself "<unixnano>:<random>".
+	nanos, _, found := strings.Cut(parts[1], ":")
+	if !found {
+		return 0, false
+	}
+	published, err := strconv.ParseInt(nanos, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return time.Since(time.Unix(0, published)), true
 }
 
 // subscribeInvalidations subscribes to the collection's invalidation channel and

--- a/pkg/acor/pubsub.go
+++ b/pkg/acor/pubsub.go
@@ -22,13 +22,8 @@ func (ac *AhoCorasick) startCacheListener() error {
 		if cache == nil {
 			return
 		}
-		if isSelfEcho(payload, ac.name, &cache.selfSkip) {
+		if !foreignInvalidation(payload, ac.name, &cache.selfSkip, stats) {
 			return
-		}
-		// Foreign invalidations only: a self-echo returned above, and timing this
-		// process against its own clock would say nothing about how fast peers reach us.
-		if lag, ok := invalidationLag(payload); ok {
-			stats.recordInvalidationLag(lag)
 		}
 		cache.invalidate()
 	})

--- a/pkg/acor/pubsub.go
+++ b/pkg/acor/pubsub.go
@@ -15,12 +15,20 @@ func (ac *AhoCorasick) startCacheListener() error {
 	// Bind the cache once per message: RollbackToV1 clears ac.cache, so re-reading
 	// the field mid-callback can hand us a nil pointer between the guard and the use.
 	cache := ac.cache
+	// Bound alongside cache for the same reason: the callback runs on its own
+	// goroutine, so it reads neither field live.
+	stats := ac.stats
 	pubsub, err := subscribeInvalidations(ac.ctx, ac.storage, ac.name, ac.stopCh, func(payload string) {
 		if cache == nil {
 			return
 		}
 		if isSelfEcho(payload, ac.name, &cache.selfSkip) {
 			return
+		}
+		// Foreign invalidations only: a self-echo returned above, and timing this
+		// process against its own clock would say nothing about how fast peers reach us.
+		if lag, ok := invalidationLag(payload); ok {
+			stats.recordInvalidationLag(lag)
 		}
 		cache.invalidate()
 	})

--- a/pkg/acor/redis_backed.go
+++ b/pkg/acor/redis_backed.go
@@ -164,17 +164,29 @@ func buildEngine(preset Preset, keywordSet map[string]struct{}) *matchengine.Eng
 	return e
 }
 
+// rebuildEngine replaces the engine from the current keyword set and records the
+// build. Every build in this mode routes through here, not just the reload path: a
+// single-keyword write and a flush rebuild directly, and a build the counters miss
+// inflates the mean rebuild cost that a write is supposed to explain.
+//
+// The timing covers the build alone. The Redis round trip that fetched the keywords
+// happened in the caller, and folding it in would report the network as build time.
+//
+// Caller holds ac.mu.
+func (ac *redisBackedAC) rebuildEngine() {
+	start := time.Now()
+	engine := buildEngine(ac.preset, ac.keywordSet)
+	ac.stats.recordRebuild(time.Since(start))
+	ac.engine = engine
+}
+
 func (ac *redisBackedAC) applyReload(snap *trieSnapshot) {
 	keywordSet := make(map[string]struct{}, len(snap.Keywords))
 	for _, kw := range snap.Keywords {
 		keywordSet[kw] = struct{}{}
 	}
 	ac.keywordSet = keywordSet
-	// Timed around the build alone: readTrieSnapshot already happened in the caller,
-	// and counting its round trip as build time would misattribute the network.
-	start := time.Now()
-	ac.engine = buildEngine(ac.preset, keywordSet)
-	ac.stats.recordRebuild(time.Since(start))
+	ac.rebuildEngine()
 	ac.localVersion = snap.Version
 	ac.stale = false
 }
@@ -258,7 +270,13 @@ const (
 func (ac *redisBackedAC) startListener() error {
 	ac.stopCh = make(chan struct{})
 
-	pubsub, err := subscribeInvalidations(ac.ctx, ac.storage, ac.name, ac.stopCh, ac.handleInvalidation)
+	// Bind the counters once, as AhoCorasick.startCacheListener does: the callback
+	// runs on its own goroutine, so reading the field live would race anything that
+	// reassigns it (the stats benchmark switches recording off that way).
+	stats := ac.stats
+	pubsub, err := subscribeInvalidations(ac.ctx, ac.storage, ac.name, ac.stopCh, func(payload string) {
+		ac.handleInvalidation(stats, payload)
+	})
 	if err != nil {
 		return err
 	}
@@ -267,15 +285,9 @@ func (ac *redisBackedAC) startListener() error {
 	return nil
 }
 
-func (ac *redisBackedAC) handleInvalidation(payload string) {
-	if isSelfEcho(payload, ac.name, &ac.selfSkip) {
+func (ac *redisBackedAC) handleInvalidation(stats *cacheStats, payload string) {
+	if !foreignInvalidation(payload, ac.name, &ac.selfSkip, stats) {
 		return
-	}
-	// Only foreign invalidations are measured. A self-echo returned above, and its lag
-	// would time this process against its own clock — a number that says nothing about
-	// how fast peers reach us.
-	if lag, ok := invalidationLag(payload); ok {
-		ac.stats.recordInvalidationLag(lag)
 	}
 	ac.markStale()
 }

--- a/pkg/acor/redis_backed.go
+++ b/pkg/acor/redis_backed.go
@@ -38,6 +38,8 @@ type redisBackedAC struct {
 	stale        bool
 	pollInterval time.Duration
 
+	stats *cacheStats
+
 	selfSkip    selfSkipSet
 	reloadGroup singleflight.Group
 	pubsub      Subscription
@@ -85,6 +87,7 @@ func newRedisBacked(ctx context.Context, args *AhoCorasickArgs) (*redisBackedAC,
 		storage:       storage,
 		redisClient:   redisClient,
 		keywordSet:    make(map[string]struct{}),
+		stats:         &cacheStats{},
 		pollInterval:  args.InvalidationPollInterval,
 		ctx:           acCtx,
 		cancel:        acCancel,
@@ -167,7 +170,11 @@ func (ac *redisBackedAC) applyReload(snap *trieSnapshot) {
 		keywordSet[kw] = struct{}{}
 	}
 	ac.keywordSet = keywordSet
+	// Timed around the build alone: readTrieSnapshot already happened in the caller,
+	// and counting its round trip as build time would misattribute the network.
+	start := time.Now()
 	ac.engine = buildEngine(ac.preset, keywordSet)
+	ac.stats.recordRebuild(time.Since(start))
 	ac.localVersion = snap.Version
 	ac.stale = false
 }
@@ -208,9 +215,16 @@ func (ac *redisBackedAC) ensureValid(ctx context.Context) error {
 	ac.mu.RLock()
 	if !ac.stale {
 		ac.mu.RUnlock()
+		ac.stats.hit()
 		return nil
 	}
 	ac.mu.RUnlock()
+
+	// Counted before the singleflight, not inside it: this read found stale state and
+	// waits for a rebuild whether or not it performs one. Readers coalesced onto
+	// another goroutine's reload therefore still count as misses, which is what makes
+	// Misses-Rebuilds the work the coalescing saved.
+	ac.stats.miss()
 
 	_, err, _ := ac.reloadGroup.Do("reload", func() (interface{}, error) {
 		ac.mu.Lock()
@@ -256,6 +270,12 @@ func (ac *redisBackedAC) startListener() error {
 func (ac *redisBackedAC) handleInvalidation(payload string) {
 	if isSelfEcho(payload, ac.name, &ac.selfSkip) {
 		return
+	}
+	// Only foreign invalidations are measured. A self-echo returned above, and its lag
+	// would time this process against its own clock — a number that says nothing about
+	// how fast peers reach us.
+	if lag, ok := invalidationLag(payload); ok {
+		ac.stats.recordInvalidationLag(lag)
 	}
 	ac.markStale()
 }

--- a/pkg/acor/redis_backed_ops.go
+++ b/pkg/acor/redis_backed_ops.go
@@ -76,7 +76,7 @@ func (ac *redisBackedAC) applyLocalWrite(keyword string, add bool, newVersion in
 	}
 	ac.localVersion = newVersion
 	if rebuild {
-		ac.engine = buildEngine(ac.preset, ac.keywordSet)
+		ac.rebuildEngine()
 		ac.stale = false
 	} else {
 		ac.stale = true
@@ -193,7 +193,7 @@ func (ac *redisBackedAC) flush(ctx context.Context) error {
 
 	ac.mu.Lock()
 	ac.keywordSet = make(map[string]struct{})
-	ac.engine = buildEngine(ac.preset, ac.keywordSet)
+	ac.rebuildEngine()
 	ac.stale = false
 	ac.mu.Unlock()
 

--- a/pkg/acor/stats.go
+++ b/pkg/acor/stats.go
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// CacheStats is a point-in-time snapshot of one instance's local cache activity.
+// Obtain it from AhoCorasick.CacheStats; it is returned by value and never
+// constructed by callers, so fields may be added in a later v1 release without
+// breaking code that reads it.
+//
+// Every counter is process-local and cumulative since Create. Nothing here is read
+// from or written to Redis, so a peer instance's activity is invisible: scrape each
+// instance separately rather than expecting a fleet-wide total.
+type CacheStats struct {
+	// Hits is the number of reads served from the local automaton without rebuilding
+	// it.
+	//
+	// What that saves depends on the mode. With Preset or EnableCache a hit means no
+	// Redis round trip happened at all. Without either, the freshness read still
+	// happens on every call and a hit means only that the automaton did not have to be
+	// rebuilt from the bytes that read returned.
+	Hits uint64
+	// Misses is the number of reads that had to wait for the local automaton to be
+	// rebuilt, whether because a peer's write invalidated it or because nothing was
+	// cached yet.
+	//
+	// Hits+Misses is the read count, so the hit rate is Hits/(Hits+Misses). Both are
+	// zero on a fresh instance, so guard that division.
+	Misses uint64
+	// Rebuilds is the number of automaton builds. It starts at 1 in Preset mode, which
+	// builds once during Create before any read.
+	//
+	// It is deliberately not equal to Misses in either direction. Concurrent misses
+	// coalesce onto one build, so Misses-Rebuilds is the work that coalescing saved;
+	// and a local write rebuilds off the read path, which pushes Rebuilds the other way.
+	Rebuilds uint64
+	// RebuildDuration is the total time spent building automatons, excluding the Redis
+	// fetch and any wait for the rebuild lock. RebuildDuration/Rebuilds is the mean
+	// cost of one rebuild — what a write to a large collection makes every reader pay.
+	RebuildDuration time.Duration
+	// LastInvalidationLag is the delay between a peer publishing an invalidation and
+	// this instance receiving it, for the most recent one. Zero means none has arrived:
+	// a fresh instance, or a collection nobody else is writing.
+	//
+	// The two timestamps come from two machines' clocks, so this includes clock skew
+	// and is not a pure network measurement. Under NTP skew it can exceed the real
+	// delay by orders of magnitude, and a negative result is discarded rather than
+	// recorded. Treat a step change as the signal and the absolute value as an upper
+	// bound.
+	LastInvalidationLag time.Duration
+}
+
+// cacheStats holds the counters behind CacheStats. One instance is shared by an
+// AhoCorasick and its operations, so all four modes that keep local state record into
+// the same place.
+//
+// Every method tolerates a nil receiver. The call sites sit on the read path in four
+// different modes, and a nil check at each would be noise; a construction path that
+// does not wire the counters — or a test building an ops struct directly — then simply
+// does not record.
+type cacheStats struct {
+	// atomic.Uint64/Int64 rather than bare integers with atomic.AddUint64: the wrapper
+	// types guarantee 8-byte alignment on 386/arm (both released by goreleaser, where a
+	// misaligned 64-bit atomic panics) instead of leaving it to field order, for the
+	// same reason selfSkipSet.publishCount uses one.
+	hits         atomic.Uint64
+	misses       atomic.Uint64
+	rebuilds     atomic.Uint64
+	rebuildNanos atomic.Int64
+	lastLagNanos atomic.Int64
+}
+
+func (s *cacheStats) hit() {
+	if s != nil {
+		s.hits.Add(1)
+	}
+}
+
+func (s *cacheStats) miss() {
+	if s != nil {
+		s.misses.Add(1)
+	}
+}
+
+// recordRebuild adds one build and its duration. Callers time the build alone, not
+// the lock acquisition in front of it: a goroutine queued behind another's rebuild
+// waited, but it did not spend that time building.
+func (s *cacheStats) recordRebuild(d time.Duration) {
+	if s == nil {
+		return
+	}
+	s.rebuilds.Add(1)
+	s.rebuildNanos.Add(int64(d))
+}
+
+// recordInvalidationLag stores the delay of the invalidation just received and drops
+// a negative one. Negative means the publisher's clock is ahead of ours, which makes
+// the value meaningless rather than merely imprecise — the same reason
+// selfSkipSet.claim distrusts a negative age instead of using it.
+func (s *cacheStats) recordInvalidationLag(d time.Duration) {
+	if s == nil || d < 0 {
+		return
+	}
+	s.lastLagNanos.Store(int64(d))
+}
+
+func (s *cacheStats) snapshot() CacheStats {
+	if s == nil {
+		return CacheStats{}
+	}
+	return CacheStats{
+		Hits:                s.hits.Load(),
+		Misses:              s.misses.Load(),
+		Rebuilds:            s.rebuilds.Load(),
+		RebuildDuration:     time.Duration(s.rebuildNanos.Load()),
+		LastInvalidationLag: time.Duration(s.lastLagNanos.Load()),
+	}
+}
+
+// timeRebuild runs build and records how long it took, returning what build returned.
+// A build that fails is not counted: nothing was rebuilt, and folding its duration in
+// would inflate the mean cost of a successful one.
+func timeRebuild[T any](s *cacheStats, build func() (T, error)) (T, error) {
+	start := time.Now()
+	out, err := build()
+	if err == nil {
+		s.recordRebuild(time.Since(start))
+	}
+	return out, err
+}

--- a/pkg/acor/stats.go
+++ b/pkg/acor/stats.go
@@ -10,7 +10,9 @@ import (
 // CacheStats is a point-in-time snapshot of one instance's local cache activity.
 // Obtain it from AhoCorasick.CacheStats; it is returned by value and never
 // constructed by callers, so fields may be added in a later v1 release without
-// breaking code that reads it.
+// breaking code that reads it. Read the fields you care about rather than comparing
+// a whole value against another: a snapshot taken before a new field existed does
+// not compare equal to one taken after.
 //
 // Every counter is process-local and cumulative since Create. Nothing here is read
 // from or written to Redis, so a peer instance's activity is invisible: scrape each
@@ -23,13 +25,20 @@ type CacheStats struct {
 	// Redis round trip happened at all. Without either, the freshness read still
 	// happens on every call and a hit means only that the automaton did not have to be
 	// rebuilt from the bytes that read returned.
+	//
+	// A read here is one scan of the automaton, not one call into ACOR. FindParallel
+	// and FindIndexParallel scan chunk by chunk, so one call over a text split into N
+	// chunks records N reads; a parallel workload's hit rate is therefore not directly
+	// comparable to a serial one's.
 	Hits uint64
 	// Misses is the number of reads that had to wait for the local automaton to be
 	// rebuilt, whether because a peer's write invalidated it or because nothing was
-	// cached yet.
+	// cached yet. A read whose Redis fetch then failed is counted here too: it waited
+	// and came back without an automaton.
 	//
 	// Hits+Misses is the read count, so the hit rate is Hits/(Hits+Misses). Both are
-	// zero on a fresh instance, so guard that division.
+	// zero on a fresh instance, so guard that division. See Hits for what one read
+	// means under FindParallel.
 	Misses uint64
 	// Rebuilds is the number of automaton builds. It starts at 1 in Preset mode, which
 	// builds once during Create before any read.
@@ -37,20 +46,34 @@ type CacheStats struct {
 	// It is deliberately not equal to Misses in either direction. Concurrent misses
 	// coalesce onto one build, so Misses-Rebuilds is the work that coalescing saved;
 	// and a local write rebuilds off the read path, which pushes Rebuilds the other way.
+	//
+	// Both counters are unsigned, so test Misses > Rebuilds before taking that
+	// difference. Rebuilds exceeding Misses is ordinary rather than exceptional — a
+	// Preset instance opens at Rebuilds 1 with no reads at all — and the subtraction
+	// wraps to something near 2^64 instead of going negative.
 	Rebuilds uint64
 	// RebuildDuration is the total time spent building automatons, excluding the Redis
-	// fetch and any wait for the rebuild lock. RebuildDuration/Rebuilds is the mean
-	// cost of one rebuild — what a write to a large collection makes every reader pay.
+	// fetch and the wait for the lock that serializes rebuilds. The brief cache write
+	// lock a finished build takes to publish itself is included.
+	// RebuildDuration/Rebuilds is the mean cost of one rebuild — what a write to a
+	// large collection makes every reader pay.
 	RebuildDuration time.Duration
 	// LastInvalidationLag is the delay between a peer publishing an invalidation and
-	// this instance receiving it, for the most recent one. Zero means none has arrived:
-	// a fresh instance, or a collection nobody else is writing.
+	// this instance receiving it, for the most recent one.
 	//
-	// The two timestamps come from two machines' clocks, so this includes clock skew
-	// and is not a pure network measurement. Under NTP skew it can exceed the real
-	// delay by orders of magnitude, and a negative result is discarded rather than
-	// recorded. Treat a step change as the signal and the absolute value as an upper
-	// bound.
+	// It is populated only where an invalidation listener runs: Preset mode, and V2
+	// with EnableCache. The default V2 mode and V1 subscribe to nothing, so there it
+	// stays zero however busy the peers are — read that as unavailable, not as fast.
+	// Where a listener does run, zero means none has arrived yet: a fresh instance, or
+	// a collection nobody else is writing.
+	//
+	// The two timestamps come from two machines' clocks, so the value is the real
+	// delivery delay plus their offset. That offset has no known bound and no fixed
+	// sign: skew that runs the publisher's clock ahead understates the delay just as
+	// readily as the other direction overstates it, so this is a skew-contaminated
+	// estimate and not a bound either way. Only an outright negative result is
+	// discarded, which drops the samples the skew distorted most rather than
+	// correcting the rest. Treat a step change as the signal.
 	LastInvalidationLag time.Duration
 }
 
@@ -98,9 +121,11 @@ func (s *cacheStats) recordRebuild(d time.Duration) {
 }
 
 // recordInvalidationLag stores the delay of the invalidation just received and drops
-// a negative one. Negative means the publisher's clock is ahead of ours, which makes
-// the value meaningless rather than merely imprecise — the same reason
-// selfSkipSet.claim distrusts a negative age instead of using it.
+// a negative one. Negative means the publisher's clock is ahead of ours by more than
+// the delivery delay, which makes the value meaningless rather than merely imprecise —
+// the same reason selfSkipSet.claim distrusts a negative age instead of using it. A
+// positive one is not thereby correct: it carries whatever the clock offset is, in
+// either direction. See CacheStats.LastInvalidationLag.
 func (s *cacheStats) recordInvalidationLag(d time.Duration) {
 	if s == nil || d < 0 {
 		return

--- a/pkg/acor/stats_test.go
+++ b/pkg/acor/stats_test.go
@@ -130,6 +130,20 @@ func TestCacheStatsPreset(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertStats(t, ac.CacheStats(), 1, 1, 2)
+
+	// A single-keyword write rebuilds directly rather than going through the reload
+	// path, and a flush does too. Both move Rebuilds without touching either read
+	// counter — miss these and the reported mean rebuild cost drifts high on any
+	// instance that writes.
+	if _, err := ac.Add("he"); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 1, 1, 3)
+
+	if err := ac.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 1, 1, 4)
 }
 
 // TestCacheStatsInvalidationLagEndToEnd is the only test that proves lag survives the
@@ -182,10 +196,13 @@ func TestInvalidationLag(t *testing.T) {
 		{"id without random suffix", "coll:12345", false},
 		{"non-numeric timestamp", "coll:notanumber:a1b2", false},
 		{"empty", "", false},
+		// Screened for the same reason isSelfEcho screens it: a payload naming another
+		// collection is not this instance's peer traffic, so it must not move the gauge.
+		{"other collection", fmt.Sprintf("other:%d:a1b2c3d4", published.UnixNano()), false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			lag, ok := invalidationLag(tc.payload)
+			lag, ok := invalidationLag(tc.payload, "coll")
 			if ok != tc.wantOK {
 				t.Fatalf("invalidationLag(%q) ok = %v, want %v", tc.payload, ok, tc.wantOK)
 			}

--- a/pkg/acor/stats_test.go
+++ b/pkg/acor/stats_test.go
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package acor
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+)
+
+// assertStats compares the fields that are deterministic. RebuildDuration and
+// LastInvalidationLag are wall-clock and get their own targeted assertions.
+func assertStats(t *testing.T, got CacheStats, hits, misses, rebuilds uint64) {
+	t.Helper()
+	if got.Hits != hits || got.Misses != misses || got.Rebuilds != rebuilds {
+		t.Errorf("stats = {hits:%d misses:%d rebuilds:%d}, want {hits:%d misses:%d rebuilds:%d}",
+			got.Hits, got.Misses, got.Rebuilds, hits, misses, rebuilds)
+	}
+}
+
+// TestCacheStatsUncachedV2 covers the mode most likely to look broken: without
+// EnableCache or Preset there is no cache to hit, yet the memo still skips the
+// rebuild, so the counters must move rather than sit at zero.
+func TestCacheStatsUncachedV2(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+
+	if _, err := ac.Add("he"); err != nil {
+		t.Fatal(err)
+	}
+	if s := ac.CacheStats(); s.Hits != 0 || s.Misses != 0 {
+		t.Fatalf("a write must not count as a read: %+v", s)
+	}
+
+	if _, err := ac.Find("she"); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 0, 1, 1)
+
+	// Same keywords, so the raw payload digests identically and the automaton is
+	// reused even though the freshness read happened again.
+	if _, err := ac.Find("she"); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 1, 1, 1)
+
+	if got := ac.CacheStats().RebuildDuration; got <= 0 {
+		t.Errorf("RebuildDuration = %v, want > 0 after a rebuild", got)
+	}
+}
+
+// TestCacheStatsUncachedV2Rebuilds proves the digest is doing real work: a changed
+// keyword set must miss, not hit.
+func TestCacheStatsUncachedV2Rebuilds(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+
+	if _, err := ac.Add("he"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ac.Find("she"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ac.Add("her"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ac.Find("she"); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 0, 2, 2)
+}
+
+func TestCacheStatsCachedV2(t *testing.T) {
+	mr := createTestRedisServer(t)
+	defer mr.Close()
+
+	ac, err := Create(&AhoCorasickArgs{Addr: mr.Addr(), Name: "stats-cached", EnableCache: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ac.Close() }()
+
+	if _, err := ac.Add("he"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ac.Find("she"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ac.Find("she"); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 1, 1, 1)
+
+	// Stand in for a peer's write. Going through ac.Add would invalidate too, but it
+	// would also publish and rebuild through the write path, which is not what this
+	// assertion is about.
+	ac.cache.invalidate()
+	if _, err := ac.Find("she"); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 1, 2, 2)
+}
+
+func TestCacheStatsPreset(t *testing.T) {
+	mr := createTestRedisServer(t)
+	defer mr.Close()
+
+	ac, err := Create(&AhoCorasickArgs{Addr: mr.Addr(), Name: "stats-preset", Preset: PresetBalanced})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ac.Close() }()
+
+	// Preset builds during Create, before any read: one rebuild, no reads.
+	assertStats(t, ac.CacheStats(), 0, 0, 1)
+
+	if _, err := ac.Find("she"); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 1, 0, 1)
+
+	rb, ok := ac.ops.(*redisBackedAC)
+	if !ok {
+		t.Fatalf("expected *redisBackedAC, got %T", ac.ops)
+	}
+	rb.markStale()
+	if _, err := ac.Find("she"); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 1, 1, 2)
+}
+
+// TestCacheStatsInvalidationLagEndToEnd is the only test that proves lag survives the
+// real publish/subscribe round trip. The unit test below pins the parsing; this pins
+// that the payload a writer actually publishes is the one the reader can parse, which
+// is the coupling that would break silently if the ID format ever changed.
+func TestCacheStatsInvalidationLagEndToEnd(t *testing.T) {
+	mr := createTestRedisServer(t)
+	defer mr.Close()
+
+	newInstance := func(name string) *AhoCorasick {
+		ac, err := Create(&AhoCorasickArgs{Addr: mr.Addr(), Name: name, EnableCache: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = ac.Close() })
+		return ac
+	}
+
+	reader := newInstance("stats-lag")
+	writer := newInstance("stats-lag")
+
+	if _, err := writer.Add("he"); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if reader.CacheStats().LastInvalidationLag > 0 {
+			// No upper bound asserted: the value includes the gap between two clock
+			// reads, and pinning a ceiling would make this flaky on a loaded machine.
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("reader never recorded an invalidation lag from the writer's publish")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestInvalidationLag(t *testing.T) {
+	published := time.Now().Add(-50 * time.Millisecond)
+	tests := []struct {
+		name    string
+		payload string
+		wantOK  bool
+	}{
+		{"real payload", fmt.Sprintf("coll:%d:a1b2c3d4", published.UnixNano()), true},
+		{"no id at all", "coll", false},
+		{"id without random suffix", "coll:12345", false},
+		{"non-numeric timestamp", "coll:notanumber:a1b2", false},
+		{"empty", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lag, ok := invalidationLag(tc.payload)
+			if ok != tc.wantOK {
+				t.Fatalf("invalidationLag(%q) ok = %v, want %v", tc.payload, ok, tc.wantOK)
+			}
+			if !ok {
+				// A corrupt payload must not read as instant delivery.
+				if lag != 0 {
+					t.Errorf("lag = %v on unparseable payload, want 0", lag)
+				}
+				return
+			}
+			if lag < 50*time.Millisecond {
+				t.Errorf("lag = %v, want at least the 50ms the payload was backdated by", lag)
+			}
+		})
+	}
+}
+
+// TestCacheStatsDiscardsNegativeLag pins the clock-skew rule: a publisher whose clock
+// is ahead of ours produces a negative lag, which is meaningless rather than merely
+// imprecise, so it must not overwrite a good value.
+func TestCacheStatsDiscardsNegativeLag(t *testing.T) {
+	var s cacheStats
+
+	s.recordInvalidationLag(-time.Second)
+	if got := s.snapshot().LastInvalidationLag; got != 0 {
+		t.Errorf("after a negative lag, LastInvalidationLag = %v, want 0", got)
+	}
+
+	s.recordInvalidationLag(30 * time.Millisecond)
+	s.recordInvalidationLag(-time.Hour)
+	if got := s.snapshot().LastInvalidationLag; got != 30*time.Millisecond {
+		t.Errorf("a negative lag overwrote a good one: got %v, want 30ms", got)
+	}
+}
+
+// TestCacheStatsNilReceiver covers the construction paths that never wire counters —
+// tests build v2Operations literals directly (see v2_cache_test.go), and a nil check
+// at every record site would be noise.
+func TestCacheStatsNilReceiver(t *testing.T) {
+	var s *cacheStats
+	s.hit()
+	s.miss()
+	s.recordRebuild(time.Second)
+	s.recordInvalidationLag(time.Second)
+	if got := s.snapshot(); got != (CacheStats{}) {
+		t.Errorf("nil cacheStats snapshot = %+v, want zero value", got)
+	}
+}
+
+// BenchmarkCacheStatsOverhead measures what the counters cost the read path, by
+// running the same Find with recording on and off. Setting stats to nil is what the
+// nil-receiver contract is for, so the two arms differ only in whether the atomics
+// execute — no build tag, no second code path.
+//
+// The counters sit on the cache-check path, not inside the scan loop, so the cost is
+// per Find rather than per matched byte. If this gap ever grows past a few percent of
+// Preset/Cached, move the counter rather than keeping it.
+func BenchmarkCacheStatsOverhead(b *testing.B) {
+	modes := []struct {
+		name string
+		args *AhoCorasickArgs
+	}{
+		{"Preset", &AhoCorasickArgs{Preset: PresetBalanced}},
+		{"Cached", &AhoCorasickArgs{EnableCache: true}},
+	}
+	for _, mode := range modes {
+		for _, recording := range []bool{true, false} {
+			label := "on"
+			if !recording {
+				label = "off"
+			}
+			b.Run(mode.name+"/recording="+label, func(b *testing.B) {
+				mr := miniredis.RunT(b)
+				defer mr.Close()
+
+				args := *mode.args
+				args.Addr = mr.Addr()
+				args.Name = "bench-stats"
+				ac, err := Create(&args)
+				if err != nil {
+					b.Fatal(err)
+				}
+				defer func() { _ = ac.Close() }()
+
+				if _, err := ac.Add("greeting"); err != nil {
+					b.Fatal(err)
+				}
+				if _, err := ac.Find("warm up the cache"); err != nil {
+					b.Fatal(err)
+				}
+				if !recording {
+					disableStats(ac)
+				}
+
+				b.ResetTimer()
+				for range b.N {
+					if _, err := ac.Find("a greeting in a longer sentence"); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	}
+}
+
+// disableStats nils every counter reference an instance holds, so the recording calls
+// become the nil-receiver no-op. Benchmark-only: production has no way to switch the
+// counters off, and none is wanted — CacheStats exists to be always available.
+func disableStats(ac *AhoCorasick) {
+	ac.stats = nil
+	switch ops := ac.ops.(type) {
+	case *redisBackedAC:
+		ops.stats = nil
+	case *v2Operations:
+		ops.stats = nil
+		ops.engines.stats = nil
+	case *v1Operations:
+		ops.engines.stats = nil
+	}
+}
+
+// TestCacheStatsAfterClose documents that scraping a closed instance is safe: a
+// metrics goroutine racing shutdown must not panic.
+func TestCacheStatsAfterClose(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+
+	if _, err := ac.Add("he"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ac.Find("she"); err != nil {
+		t.Fatal(err)
+	}
+	before := ac.CacheStats()
+	if err := ac.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if after := ac.CacheStats(); after != before {
+		t.Errorf("stats changed across Close: %+v then %+v", before, after)
+	}
+}

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -31,6 +31,7 @@ type v2Operations struct {
 	logger        Logger
 	caseSensitive bool
 	engines       engineMemo
+	stats         *cacheStats
 }
 
 // --- operations interface methods ---
@@ -230,7 +231,11 @@ func (o *v2Operations) loadCache(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Timed around set alone, which is where the automaton is built. fetchTrieData
+	// above is Redis I/O, and folding it in would report the network as build time.
+	start := time.Now()
 	o.cache.set(outputs)
+	o.stats.recordRebuild(time.Since(start))
 	return nil
 }
 
@@ -266,17 +271,21 @@ func (o *v2Operations) loadEngine(ctx context.Context) (*matchengine.Engine, err
 	}
 
 	if engine, valid := o.cache.getEngine(); valid {
+		o.stats.hit()
 		return engine, nil
 	}
 
 	o.cache.loadMu.Lock()
 	defer o.cache.loadMu.Unlock()
 
-	// Double-check after acquiring lock.
+	// Double-check after acquiring lock. Still a hit: another goroutine did the load
+	// while this one waited, so this read cost no fetch of its own.
 	if engine, valid := o.cache.getEngine(); valid {
+		o.stats.hit()
 		return engine, nil
 	}
 
+	o.stats.miss()
 	if err := o.loadCache(ctx); err != nil {
 		return nil, err
 	}

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -275,17 +275,22 @@ func (o *v2Operations) loadEngine(ctx context.Context) (*matchengine.Engine, err
 		return engine, nil
 	}
 
+	// Counted before the lock for the same reason redisBackedAC.ensureValid counts
+	// before its singleflight: this read found the cache invalid and waits for a
+	// rebuild whether or not it performs one. Coalesced readers therefore stay misses
+	// here too, which is what makes Misses-Rebuilds the work the coalescing saved.
+	o.stats.miss()
+
 	o.cache.loadMu.Lock()
 	defer o.cache.loadMu.Unlock()
 
-	// Double-check after acquiring lock. Still a hit: another goroutine did the load
-	// while this one waited, so this read cost no fetch of its own.
+	// Double-check after acquiring lock: another goroutine loaded while this one
+	// waited, so no fetch of its own is needed — but it still waited, so it was
+	// counted a miss above.
 	if engine, valid := o.cache.getEngine(); valid {
-		o.stats.hit()
 		return engine, nil
 	}
 
-	o.stats.miss()
 	if err := o.loadCache(ctx); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Pull Request

## Description

Every metric ACOR documented came from `server/*`, the separate experimental module, so a library user had no way to see whether the local cache was working — they had to infer it from latency. This lands before v1.5.0 because a surface can be added to after the freeze but never reshaped.

This PR adds one method returning one read-only struct: `AhoCorasick.CacheStats()` with `Hits`, `Misses`, `Rebuilds`, `RebuildDuration`, and `LastInvalidationLag`. No Redis I/O; counters are per instance and per process.

The shape was chosen for which direction it freezes:

- **Not an `Observer` interface** — that would freeze three signatures plus the timing of every callback, and `compatibility.md` forbids adding a method to an exported interface inside v1.
- **A struct ACOR returns and the caller only reads is the inverse** — new fields are additive for every reader, so the type can grow inside v1.
- **Not an extension of `AhoCorasickInfo`** — `Info()` does Redis I/O, which would make scraping cost round trips.

Instrumented on all four read paths: `EnableCache`, `Preset`, uncached V2 through the engine memo, and V1 through the same memo. `Rebuilds` is deliberately not equal to `Misses` — concurrent misses coalesce onto one build, so `Misses - Rebuilds` is what the coalescing saved, and a local write rebuilds off the read path. Misses are counted before the singleflight so `Hits + Misses` stays the read count.

`LastInvalidationLag` reuses the timestamp `newInvalidationID` already puts in front of every ID, so measuring it needs no change to the on-Redis format. The two timestamps come from two machines, so it carries clock skew; a negative result is discarded rather than recorded, mirroring how `selfSkipSet.claim` distrusts a negative age.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — skip for internal-only changes (CI, tests, refactors); see [RELEASE.md](../RELEASE.md)
- [x] Commit messages follow guidelines

## Additional Notes

**Stacked on #201** — the base branch is `v1-ga/2-narrow-public-surface`. Review and merge that first; this is milestone 4 of the v1 GA sequence.

**Overhead.** The counters are nil-tolerant, which keeps a nil check out of eight read-path call sites and lets `BenchmarkCacheStatsOverhead` A/B the recording cost directly: 155.3 vs 150.6 ns/op in Preset mode and 148.8 vs 154.1 ns/op cached. Recording measured *faster* in one of the two, so the overhead is inside noise.

**Docs touched:** `docs/content/operations/monitoring.md` (rewritten to separate the core library from the experimental `server/` module), `docs/content/reference/api.md`, `docs/content/reference/compatibility.md`.

**Changelog fragments** (`changes/unreleased/`, `Issue: "202"`): one `Added` (`CacheStats()`) and one `Documentation` (monitoring page rewrite).

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).
