### PR TITLE
fix: load the automaton once per call, not once per chunk

### DIFF
--- a/changes/unreleased/Fixed-20260807-075928.yaml
+++ b/changes/unreleased/Fixed-20260807-075928.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: FindParallel, FindIndexParallel, and FindMany now cost one Redis round trip per call instead of one per chunk or per text. Each chunk called into Find, and every Find reloaded the automaton, so a 63-chunk text issued 63 HGETALL calls of the full outputs hash where a serial Find issues one at any input size — at the default chunk size a 1 MB input was roughly 1000 concurrent reads. The automaton is now loaded once per call and every chunk or text is scanned against that one snapshot, which also gives them a consistent view of the dictionary that per-chunk loads did not guarantee. CacheStats correspondingly records one read per call rather than N
+time: 2026-08-07T07:59:28.686193+09:00
+custom:
+    Issue: "206"

--- a/changes/unreleased/Fixed-20260807-075928.yaml
+++ b/changes/unreleased/Fixed-20260807-075928.yaml
@@ -1,5 +1,5 @@
 kind: Fixed
-body: FindParallel, FindIndexParallel, and FindMany now cost one Redis round trip per call instead of one per chunk or per text. Each chunk called into Find, and every Find reloaded the automaton, so a 63-chunk text issued 63 HGETALL calls of the full outputs hash where a serial Find issues one at any input size — at the default chunk size a 1 MB input was roughly 1000 concurrent reads. The automaton is now loaded once per call and every chunk or text is scanned against that one snapshot, which also gives them a consistent view of the dictionary that per-chunk loads did not guarantee. CacheStats correspondingly records one read per call rather than N
+body: '`FindParallel`, `FindIndexParallel`, and `FindMany` now cost one Redis round trip per call instead of one per chunk or text. Every chunk went through `Find`, which reloads the automaton, so a 63-chunk text issued 63 `HGETALL` calls against the full outputs hash — roughly 1000 concurrent reads for a 1 MB input at the default chunk size, where a serial `Find` costs one at any size. The automaton is now loaded once per call and every chunk is scanned against that snapshot, so they also see a consistent dictionary. `CacheStats` records one read per call accordingly'
 time: 2026-08-07T07:59:28.686193+09:00
 custom:
     Issue: "206"

--- a/docs/content/operations/monitoring.md
+++ b/docs/content/operations/monitoring.md
@@ -71,9 +71,10 @@ stays yours.
   the build during `Create`. Both counters are `uint64`, so check `Misses > Rebuilds`
   before subtracting — a write-heavy instance is routinely the other way round, and the
   difference wraps to roughly 1.8e19 rather than going negative.
-- **One read is one scan, not one call.** `FindParallel` and `FindIndexParallel` scan
-  chunk by chunk, so a text split into N chunks adds N to `Hits`+`Misses`. Their hit
-  rate is not comparable to a serial workload's without dividing that out.
+- **One call is one read, whatever it scans.** `FindParallel`, `FindIndexParallel`, and
+  `FindMany` load the automaton once per call and scan every chunk or text against that
+  snapshot, so each adds 1 to `Hits`+`Misses` and their hit rate is directly comparable
+  to a serial workload's. Before `v1.5.0` they loaded per chunk, which added N.
 - **`LastInvalidationLag` needs a listener, and carries clock skew.** It is populated
   only in `Preset` mode and in V2 with `EnableCache`; the other modes subscribe to
   nothing, so a zero there means unavailable, not fast. Where it is populated, the

--- a/docs/content/operations/monitoring.md
+++ b/docs/content/operations/monitoring.md
@@ -71,10 +71,11 @@ stays yours.
   the build during `Create`. Both counters are `uint64`, so check `Misses > Rebuilds`
   before subtracting — a write-heavy instance is routinely the other way round, and the
   difference wraps to roughly 1.8e19 rather than going negative.
-- **One call is one read, whatever it scans.** `FindParallel`, `FindIndexParallel`, and
-  `FindMany` load the automaton once per call and scan every chunk or text against that
-  snapshot, so each adds 1 to `Hits`+`Misses` and their hit rate is directly comparable
-  to a serial workload's. Before `v1.5.0` they loaded per chunk, which added N.
+- **One scanning call is one read, whatever it scans over.** `FindParallel`,
+  `FindIndexParallel`, and `FindMany` load the automaton once per call and scan every
+  chunk or text against that snapshot, so each adds 1 to `Hits`+`Misses` and their hit
+  rate is directly comparable to a serial workload's. Calls that never reach the
+  automaton — writes, `Suggest`, `Info` — add nothing to either counter.
 - **`LastInvalidationLag` needs a listener, and carries clock skew.** It is populated
   only in `Preset` mode and in V2 with `EnableCache`; the other modes subscribe to
   nothing, so a zero there means unavailable, not fast. Where it is populated, the

--- a/docs/content/reference/benchmarks.md
+++ b/docs/content/reference/benchmarks.md
@@ -26,6 +26,8 @@ CI fails.
 | `Find()` | 1 | 1 |
 | `Find()` with `EnableCache`, warm | n/a | 0 |
 | `Find()` with a `Preset` engine | n/a | 0 |
+| `FindParallel()` / `FindIndexParallel()`, 63 chunks | 1 | 1 |
+| `FindMany()`, 3 texts | 1 | 1 |
 | `Add()`, 5-character keyword | 53 | 2 |
 | `Add()`, 26-character keyword | 507 | 2 |
 
@@ -33,6 +35,11 @@ Both schemas read in a single round trip: V1 issues one `SMEMBERS`, V2 pipelines
 two `HGETALL` calls into one trip. V1's round-trip cost is on **writes**, where it
 walks the trie node by node, so the cost grows with the length of the keyword being
 added rather than with the size of the dictionary.
+
+The multi-scan reads cost the same as one `Find()`, and the count does not grow with
+the chunk count or the batch size: the automaton is loaded once per call and every
+chunk or text is scanned against that one snapshot. Before `v1.5.0` each chunk loaded
+its own, so a 63-chunk text issued 63 reads.
 
 ```sh
 go test -run RTT ./pkg/acor

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -429,9 +429,13 @@ func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []s
 // FindMany searches for keywords in multiple texts and returns a map of text to matches.
 // This is convenient when you need to match against many texts at once.
 //
+// The automaton is loaded once for the whole batch and every text is scanned
+// against that one snapshot, so a batch of any size costs the single read one
+// Find costs, and every text sees the same dictionary. Splitting a batch into
+// individual Find or FindParallel calls costs one read each instead.
+//
 // Note: If the same text appears multiple times in the input slice, only one result
-// entry will be stored (last occurrence wins). For large batches, consider using
-// parallel processing with individual FindParallel calls.
+// entry will be stored (last occurrence wins).
 //
 // Example:
 //

--- a/pkg/acor/context_ops.go
+++ b/pkg/acor/context_ops.go
@@ -2,7 +2,11 @@
 
 package acor
 
-import "context"
+import (
+	"context"
+
+	matchengine "github.com/skyoo2003/acor/internal/engine"
+)
 
 // AddContext inserts a keyword with context for cancellation and timeout propagation.
 func (ac *AhoCorasick) AddContext(ctx context.Context, keyword string) (int, error) {
@@ -85,17 +89,15 @@ func (ac *AhoCorasick) RemoveManyContext(ctx context.Context, keywords []string,
 // FindManyContext searches for keywords in multiple texts with context.
 func (ac *AhoCorasick) FindManyContext(ctx context.Context, texts []string) (map[string][]string, error) {
 	results := make(map[string][]string, len(texts))
-	if len(texts) == 0 {
-		return results, nil
-	}
 
 	// One engine for the whole batch. Calling ops.find per text reloaded it every
 	// time, so N texts cost N round trips where a single Find costs one — the same
 	// defect the parallel paths below had (#205).
-	eng, err := ac.ops.loadEngine(ctx)
-	if err != nil {
-		return nil, err
-	}
+	//
+	// Loaded on the first text that actually needs it, not up front: a batch that is
+	// empty or all-empty-strings has never touched Redis, and loading an engine to
+	// scan nothing with would newly cost a round trip (see FindParallelContext).
+	var eng *matchengine.Engine
 
 	for _, text := range texts {
 		if err := ctx.Err(); err != nil {
@@ -104,6 +106,13 @@ func (ac *AhoCorasick) FindManyContext(ctx context.Context, texts []string) (map
 		if text == "" {
 			results[text] = []string{}
 			continue
+		}
+		if eng == nil {
+			loaded, err := ac.ops.loadEngine(ctx)
+			if err != nil {
+				return nil, err
+			}
+			eng = loaded
 		}
 		results[text] = eng.Find(normalizeText(text, ac.caseSensitive))
 	}
@@ -125,9 +134,6 @@ func (ac *AhoCorasick) FindParallelContext(ctx context.Context, text string, opt
 	}
 
 	chunks := splitChunks(text, opts)
-	if len(chunks) == 0 {
-		return []string{}, nil
-	}
 
 	// One engine for the whole call, not one per chunk. Each ops.find reloaded it,
 	// so an N-chunk text cost N round trips where serial Find costs one at any
@@ -147,7 +153,12 @@ func (ac *AhoCorasick) FindParallelContext(ctx context.Context, text string, opt
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		return eng.Find(normalizeText(c.text, ac.caseSensitive)), nil
+		// FindSet, not Find: the result of this call is a set, so every duplicate
+		// occurrence Find reports is built only to be dropped by
+		// dedupPreservingOrder below. On match-dense text that per-occurrence slice
+		// is most of the scan's allocation, and it is accumulated across every chunk
+		// before the dedup runs.
+		return eng.FindSet(normalizeText(c.text, ac.caseSensitive)), nil
 	})
 	if err != nil {
 		return nil, err
@@ -172,9 +183,6 @@ func (ac *AhoCorasick) FindIndexParallelContext(ctx context.Context, text string
 	}
 
 	chunks := splitChunks(text, opts)
-	if len(chunks) == 0 {
-		return map[string][]int{}, nil
-	}
 
 	// One engine for the whole call; see FindParallelContext.
 	eng, err := ac.ops.loadEngine(ctx)

--- a/pkg/acor/context_ops.go
+++ b/pkg/acor/context_ops.go
@@ -84,14 +84,28 @@ func (ac *AhoCorasick) RemoveManyContext(ctx context.Context, keywords []string,
 
 // FindManyContext searches for keywords in multiple texts with context.
 func (ac *AhoCorasick) FindManyContext(ctx context.Context, texts []string) (map[string][]string, error) {
-	results := make(map[string][]string)
+	results := make(map[string][]string, len(texts))
+	if len(texts) == 0 {
+		return results, nil
+	}
+
+	// One engine for the whole batch. Calling ops.find per text reloaded it every
+	// time, so N texts cost N round trips where a single Find costs one — the same
+	// defect the parallel paths below had (#205).
+	eng, err := ac.ops.loadEngine(ctx)
+	if err != nil {
+		return nil, err
+	}
 
 	for _, text := range texts {
-		matches, err := ac.ops.find(ctx, text)
-		if err != nil {
+		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		results[text] = matches
+		if text == "" {
+			results[text] = []string{}
+			continue
+		}
+		results[text] = eng.Find(normalizeText(text, ac.caseSensitive))
 	}
 
 	return results, nil
@@ -104,14 +118,36 @@ func (ac *AhoCorasick) FindParallelContext(ctx context.Context, text string, opt
 	if opts.ChunkSize <= 0 {
 		return nil, ErrInvalidChunkSize
 	}
+	// Before loadEngine: an empty text has never touched Redis, and loading an
+	// engine to scan nothing with would newly cost a round trip.
+	if text == "" {
+		return []string{}, nil
+	}
 
 	chunks := splitChunks(text, opts)
 	if len(chunks) == 0 {
 		return []string{}, nil
 	}
 
+	// One engine for the whole call, not one per chunk. Each ops.find reloaded it,
+	// so an N-chunk text cost N round trips where serial Find costs one at any
+	// input size — the fixed read cost V2 is built around (#205). Loading once also
+	// gives every chunk the same dictionary snapshot, which per-chunk loads did not
+	// guarantee.
+	eng, err := ac.ops.loadEngine(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	perChunk, err := scanChunks(ctx, chunks, opts.Workers, func(ctx context.Context, c chunk) ([]string, error) {
-		return ac.ops.find(ctx, c.text)
+		// Per chunk, not once above: the in-memory scan is not ctx-threaded, and in
+		// Preset mode loadEngine touches no Redis, so this is the only place a
+		// canceled context is noticed. Checking here also stops chunks that have not
+		// started yet, which the old per-chunk ops.find did.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return eng.Find(normalizeText(c.text, ac.caseSensitive)), nil
 	})
 	if err != nil {
 		return nil, err
@@ -130,14 +166,27 @@ func (ac *AhoCorasick) FindIndexParallelContext(ctx context.Context, text string
 	if opts.ChunkSize <= 0 {
 		return nil, ErrInvalidChunkSize
 	}
+	// See FindParallelContext: empty text stays off Redis.
+	if text == "" {
+		return map[string][]int{}, nil
+	}
 
 	chunks := splitChunks(text, opts)
 	if len(chunks) == 0 {
 		return map[string][]int{}, nil
 	}
 
+	// One engine for the whole call; see FindParallelContext.
+	eng, err := ac.ops.loadEngine(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	perChunk, err := scanChunks(ctx, chunks, opts.Workers, func(ctx context.Context, c chunk) (map[string][]int, error) {
-		return ac.ops.findIndex(ctx, c.text)
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		return eng.FindIndex(normalizeText(c.text, ac.caseSensitive)), nil
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/acor/parallel.go
+++ b/pkg/acor/parallel.go
@@ -148,6 +148,10 @@ func scanChunks[T any](ctx context.Context, chunks []chunk, workers int, scan fu
 // single chunk is scanned by a single worker, so it pays no parallelization cost
 // while still returning the same shape as a multi-chunk scan.
 //
+// The automaton is loaded once per call however many chunks the text splits into,
+// so the read cost matches Find's at any input size and every chunk is scanned
+// against the same dictionary snapshot. FindIndexParallel does the same.
+//
 // Note: Due to chunk overlap for boundary handling, duplicate matches are
 // automatically deduplicated in the returned slice, so each keyword appears at
 // most once regardless of how many times or in how many chunks it occurs. (Find

--- a/pkg/acor/rtt_claims_test.go
+++ b/pkg/acor/rtt_claims_test.go
@@ -141,6 +141,33 @@ func parallelRTTOptions() *ParallelOptions {
 	return &ParallelOptions{Workers: 4, ChunkSize: 100, Overlap: 5, Boundary: ChunkBoundaryWord}
 }
 
+func newRTTV2(t *testing.T) *AhoCorasick {
+	t.Helper()
+	ac, mr := createAhoCorasick(t)
+	t.Cleanup(func() { ac.Close(); mr.Close() })
+	return ac
+}
+
+func newRTTV1(t *testing.T) *AhoCorasick {
+	t.Helper()
+	ac, mr := createAhoCorasickV1(t)
+	t.Cleanup(func() { ac.Close(); mr.Close() })
+	return ac
+}
+
+// rttSchemas is both columns of the published round-trip table. A claim measured
+// on V2 alone leaves the V1 column of
+// docs/content/reference/benchmarks.md unenforced, which is the same as
+// unmeasured — and V1 reaches the engine by a different route (SMEMBERS of the
+// keyword set, not HGETALL of the outputs hash), so it can regress on its own.
+var rttSchemas = []struct {
+	name  string
+	build func(t *testing.T) *AhoCorasick
+}{
+	{"V2", newRTTV2},
+	{"V1", newRTTV1},
+}
+
 // TestRTTParallelFindIsFixed pins FindParallel and FindIndexParallel at one round
 // trip whatever the chunk count.
 //
@@ -153,46 +180,48 @@ func parallelRTTOptions() *ParallelOptions {
 // Flatness is the claim, not the number 1: a version that regressed to per-chunk
 // loads only above some size would pass a single-size assertion.
 func TestRTTParallelFindIsFixed(t *testing.T) {
-	ac, mr := createAhoCorasick(t)
-	defer mr.Close()
-	defer ac.Close()
+	for _, schema := range rttSchemas {
+		t.Run(schema.name, func(t *testing.T) {
+			ac := schema.build(t)
 
-	for _, kw := range []string{"he", "her", "him"} {
-		if _, err := ac.Add(kw); err != nil {
-			t.Fatalf("Add(%q) error: %v", kw, err)
-		}
-	}
+			for _, kw := range []string{"he", "her", "him"} {
+				if _, err := ac.Add(kw); err != nil {
+					t.Fatalf("Add(%q) error: %v", kw, err)
+				}
+			}
 
-	opts := parallelRTTOptions()
-	c := countRTT(t, ac)
-	maxChunks := 0
+			opts := parallelRTTOptions()
+			c := countRTT(t, ac)
+			maxChunks := 0
 
-	for _, reps := range []int{8, 40, 160, 480} {
-		text := strings.Repeat("he is here. ", reps)
-		chunks := len(splitChunks(text, opts))
-		maxChunks = max(maxChunks, chunks)
+			for _, reps := range []int{8, 40, 160, 480} {
+				text := strings.Repeat("he is here. ", reps)
+				chunks := len(splitChunks(text, opts))
+				maxChunks = max(maxChunks, chunks)
 
-		c.reset()
-		if _, err := ac.FindParallel(text, opts); err != nil {
-			t.Fatalf("FindParallel() error: %v", err)
-		}
-		if got := c.count(); got != 1 {
-			t.Fatalf("FindParallel() over %d chunks = %d round trips, want 1 (published in docs/content/reference/benchmarks.md)", chunks, got)
-		}
+				c.reset()
+				if _, err := ac.FindParallel(text, opts); err != nil {
+					t.Fatalf("FindParallel() error: %v", err)
+				}
+				if got := c.count(); got != 1 {
+					t.Fatalf("FindParallel() over %d chunks = %d round trips, want 1 (published in docs/content/reference/benchmarks.md)", chunks, got)
+				}
 
-		c.reset()
-		if _, err := ac.FindIndexParallel(text, opts); err != nil {
-			t.Fatalf("FindIndexParallel() error: %v", err)
-		}
-		if got := c.count(); got != 1 {
-			t.Fatalf("FindIndexParallel() over %d chunks = %d round trips, want 1", chunks, got)
-		}
-	}
+				c.reset()
+				if _, err := ac.FindIndexParallel(text, opts); err != nil {
+					t.Fatalf("FindIndexParallel() error: %v", err)
+				}
+				if got := c.count(); got != 1 {
+					t.Fatalf("FindIndexParallel() over %d chunks = %d round trips, want 1", chunks, got)
+				}
+			}
 
-	// Without this the whole test passes vacuously if chunking ever stops
-	// splitting: one chunk at every size proves nothing about a fixed cost.
-	if maxChunks < 20 {
-		t.Fatalf("largest text split into only %d chunks; this test no longer varies chunk count and proves nothing", maxChunks)
+			// Without this the whole test passes vacuously if chunking ever stops
+			// splitting: one chunk at every size proves nothing about a fixed cost.
+			if maxChunks < 20 {
+				t.Fatalf("largest text split into only %d chunks; this test no longer varies chunk count and proves nothing", maxChunks)
+			}
+		})
 	}
 }
 
@@ -200,29 +229,42 @@ func TestRTTParallelFindIsFixed(t *testing.T) {
 // batch. It had the same per-call engine load as the parallel paths above — N
 // texts cost N round trips — and the same fix.
 func TestRTTFindManyIsOneRoundTrip(t *testing.T) {
-	ac, mr := createAhoCorasick(t)
-	defer mr.Close()
-	defer ac.Close()
+	for _, schema := range rttSchemas {
+		t.Run(schema.name, func(t *testing.T) {
+			ac := schema.build(t)
 
-	if _, err := ac.Add("he"); err != nil {
-		t.Fatalf("Add() error: %v", err)
-	}
+			if _, err := ac.Add("he"); err != nil {
+				t.Fatalf("Add() error: %v", err)
+			}
 
-	c := countRTT(t, ac)
+			c := countRTT(t, ac)
 
-	for _, n := range []int{1, 5, 50} {
-		texts := make([]string, n)
-		for i := range texts {
-			texts[i] = fmt.Sprintf("he is here %d", i)
-		}
+			for _, n := range []int{1, 5, 50} {
+				texts := make([]string, n)
+				for i := range texts {
+					texts[i] = fmt.Sprintf("he is here %d", i)
+				}
 
-		c.reset()
-		if _, err := ac.FindMany(texts); err != nil {
-			t.Fatalf("FindMany() error: %v", err)
-		}
-		if got := c.count(); got != 1 {
-			t.Fatalf("FindMany() over %d texts = %d round trips, want 1", n, got)
-		}
+				c.reset()
+				if _, err := ac.FindMany(texts); err != nil {
+					t.Fatalf("FindMany() error: %v", err)
+				}
+				if got := c.count(); got != 1 {
+					t.Fatalf("FindMany() over %d texts = %d round trips, want 1", n, got)
+				}
+			}
+
+			// A batch with nothing to scan must not load an engine to scan it with:
+			// the empty-text guard is what keeps FindMany off Redis, and losing it
+			// would turn every all-empty batch into a read.
+			c.reset()
+			if _, err := ac.FindMany([]string{"", ""}); err != nil {
+				t.Fatalf("FindMany(empty texts) error: %v", err)
+			}
+			if got := c.count(); got != 0 {
+				t.Fatalf("FindMany() over empty texts = %d round trips, want 0", got)
+			}
+		})
 	}
 }
 
@@ -448,18 +490,7 @@ func TestRTTPublishedTable(t *testing.T) {
 		})
 	}
 
-	newV2 := func(t *testing.T) *AhoCorasick {
-		t.Helper()
-		ac, mr := createAhoCorasick(t)
-		t.Cleanup(func() { ac.Close(); mr.Close() })
-		return ac
-	}
-	newV1 := func(t *testing.T) *AhoCorasick {
-		t.Helper()
-		ac, mr := createAhoCorasickV1(t)
-		t.Cleanup(func() { ac.Close(); mr.Close() })
-		return ac
-	}
+	newV2, newV1 := newRTTV2, newRTTV1
 
 	addSome := func(ac *AhoCorasick) error {
 		for _, kw := range []string{"he", "her", "him"} {
@@ -490,4 +521,5 @@ func TestRTTPublishedTable(t *testing.T) {
 	measure("V1 Find (3 keywords)", newV1, addSome, find)
 	measure("V1 Add", newV1, addSome, add)
 	measure(fmt.Sprintf("V1 FindParallel (%d chunks)", chunks), newV1, addSome, findParallel)
+	measure("V1 FindMany (3 texts)", newV1, addSome, findMany)
 }

--- a/pkg/acor/rtt_claims_test.go
+++ b/pkg/acor/rtt_claims_test.go
@@ -4,6 +4,7 @@ package acor //nolint:errcheck // claim pinning focuses on round-trip counts
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -131,6 +132,97 @@ func TestRTTV2FindIsFixed(t *testing.T) {
 	if cSmall.count() != cLarge.count() {
 		t.Fatalf("V2 Find() cost varies with dictionary size: 10 keywords = %d RTT, 500 keywords = %d RTT; the 'fixed' claim is false",
 			cSmall.count(), cLarge.count())
+	}
+}
+
+// parallelRTTOptions splits the fixture text below into 1, 6, 21, and 63 chunks
+// at the four sizes TestRTTParallelFindIsFixed measures.
+func parallelRTTOptions() *ParallelOptions {
+	return &ParallelOptions{Workers: 4, ChunkSize: 100, Overlap: 5, Boundary: ChunkBoundaryWord}
+}
+
+// TestRTTParallelFindIsFixed pins FindParallel and FindIndexParallel at one round
+// trip whatever the chunk count.
+//
+// They cost one *per chunk* until this test measured it: each chunk called
+// ops.find, and every find reloaded the engine, so a 63-chunk text issued 63
+// HGETALLs of the full outputs hash where serial Find issues one at any input
+// size. A 1 MB input at the default chunk size is roughly 1000 concurrent reads —
+// a burst, not a trickle (#205).
+//
+// Flatness is the claim, not the number 1: a version that regressed to per-chunk
+// loads only above some size would pass a single-size assertion.
+func TestRTTParallelFindIsFixed(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	for _, kw := range []string{"he", "her", "him"} {
+		if _, err := ac.Add(kw); err != nil {
+			t.Fatalf("Add(%q) error: %v", kw, err)
+		}
+	}
+
+	opts := parallelRTTOptions()
+	c := countRTT(t, ac)
+	maxChunks := 0
+
+	for _, reps := range []int{8, 40, 160, 480} {
+		text := strings.Repeat("he is here. ", reps)
+		chunks := len(splitChunks(text, opts))
+		maxChunks = max(maxChunks, chunks)
+
+		c.reset()
+		if _, err := ac.FindParallel(text, opts); err != nil {
+			t.Fatalf("FindParallel() error: %v", err)
+		}
+		if got := c.count(); got != 1 {
+			t.Fatalf("FindParallel() over %d chunks = %d round trips, want 1 (published in docs/content/reference/benchmarks.md)", chunks, got)
+		}
+
+		c.reset()
+		if _, err := ac.FindIndexParallel(text, opts); err != nil {
+			t.Fatalf("FindIndexParallel() error: %v", err)
+		}
+		if got := c.count(); got != 1 {
+			t.Fatalf("FindIndexParallel() over %d chunks = %d round trips, want 1", chunks, got)
+		}
+	}
+
+	// Without this the whole test passes vacuously if chunking ever stops
+	// splitting: one chunk at every size proves nothing about a fixed cost.
+	if maxChunks < 20 {
+		t.Fatalf("largest text split into only %d chunks; this test no longer varies chunk count and proves nothing", maxChunks)
+	}
+}
+
+// TestRTTFindManyIsOneRoundTrip pins FindMany at one round trip for the whole
+// batch. It had the same per-call engine load as the parallel paths above — N
+// texts cost N round trips — and the same fix.
+func TestRTTFindManyIsOneRoundTrip(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer ac.Close()
+
+	if _, err := ac.Add("he"); err != nil {
+		t.Fatalf("Add() error: %v", err)
+	}
+
+	c := countRTT(t, ac)
+
+	for _, n := range []int{1, 5, 50} {
+		texts := make([]string, n)
+		for i := range texts {
+			texts[i] = fmt.Sprintf("he is here %d", i)
+		}
+
+		c.reset()
+		if _, err := ac.FindMany(texts); err != nil {
+			t.Fatalf("FindMany() error: %v", err)
+		}
+		if got := c.count(); got != 1 {
+			t.Fatalf("FindMany() over %d texts = %d round trips, want 1", n, got)
+		}
 	}
 }
 
@@ -380,8 +472,22 @@ func TestRTTPublishedTable(t *testing.T) {
 	find := func(ac *AhoCorasick) error { _, err := ac.Find("he is him"); return err }
 	add := func(ac *AhoCorasick) error { _, err := ac.Add("new-keyword"); return err }
 
+	longText := strings.Repeat("he is here. ", 480)
+	chunks := len(splitChunks(longText, parallelRTTOptions()))
+	findParallel := func(ac *AhoCorasick) error {
+		_, err := ac.FindParallel(longText, parallelRTTOptions())
+		return err
+	}
+	findMany := func(ac *AhoCorasick) error {
+		_, err := ac.FindMany([]string{"he is him", "her hat", "nothing here"})
+		return err
+	}
+
 	measure("V2 Find", newV2, addSome, find)
 	measure("V2 Add", newV2, addSome, add)
+	measure(fmt.Sprintf("V2 FindParallel (%d chunks)", chunks), newV2, addSome, findParallel)
+	measure("V2 FindMany (3 texts)", newV2, addSome, findMany)
 	measure("V1 Find (3 keywords)", newV1, addSome, find)
 	measure("V1 Add", newV1, addSome, add)
+	measure(fmt.Sprintf("V1 FindParallel (%d chunks)", chunks), newV1, addSome, findParallel)
 }

--- a/pkg/acor/stats.go
+++ b/pkg/acor/stats.go
@@ -26,10 +26,11 @@ type CacheStats struct {
 	// happens on every call and a hit means only that the automaton did not have to be
 	// rebuilt from the bytes that read returned.
 	//
-	// A read here is one scan of the automaton, not one call into ACOR. FindParallel
-	// and FindIndexParallel scan chunk by chunk, so one call over a text split into N
-	// chunks records N reads; a parallel workload's hit rate is therefore not directly
-	// comparable to a serial one's.
+	// One call into ACOR is one read, whatever it scans. FindParallel,
+	// FindIndexParallel, and FindMany load the automaton once and scan every chunk
+	// or text against that one snapshot, so their hit rate is directly comparable to
+	// a serial workload's. (Before v1.5.0 they loaded per chunk and recorded N reads
+	// for an N-chunk text, which also cost N Redis round trips.)
 	Hits uint64
 	// Misses is the number of reads that had to wait for the local automaton to be
 	// rebuilt, whether because a peer's write invalidated it or because nothing was
@@ -38,7 +39,7 @@ type CacheStats struct {
 	//
 	// Hits+Misses is the read count, so the hit rate is Hits/(Hits+Misses). Both are
 	// zero on a fresh instance, so guard that division. See Hits for what one read
-	// means under FindParallel.
+	// means.
 	Misses uint64
 	// Rebuilds is the number of automaton builds. It starts at 1 in Preset mode, which
 	// builds once during Create before any read.

--- a/pkg/acor/stats.go
+++ b/pkg/acor/stats.go
@@ -26,11 +26,11 @@ type CacheStats struct {
 	// happens on every call and a hit means only that the automaton did not have to be
 	// rebuilt from the bytes that read returned.
 	//
-	// One call into ACOR is one read, whatever it scans. FindParallel,
-	// FindIndexParallel, and FindMany load the automaton once and scan every chunk
-	// or text against that one snapshot, so their hit rate is directly comparable to
-	// a serial workload's. (Before v1.5.0 they loaded per chunk and recorded N reads
-	// for an N-chunk text, which also cost N Redis round trips.)
+	// One call that scans the automaton is one read, whatever it scans over.
+	// FindParallel, FindIndexParallel, and FindMany load the automaton once and scan
+	// every chunk or text against that one snapshot, so their hit rate is directly
+	// comparable to a serial workload's. Calls that never reach the automaton —
+	// writes, Suggest, Info — record nothing here.
 	Hits uint64
 	// Misses is the number of reads that had to wait for the local automaton to be
 	// rebuilt, whether because a peer's write invalidated it or because nothing was

--- a/pkg/acor/stats_test.go
+++ b/pkg/acor/stats_test.go
@@ -4,6 +4,7 @@ package acor
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -49,6 +50,42 @@ func TestCacheStatsUncachedV2(t *testing.T) {
 	if got := ac.CacheStats().RebuildDuration; got <= 0 {
 		t.Errorf("RebuildDuration = %v, want > 0 after a rebuild", got)
 	}
+}
+
+// TestCacheStatsCountsOneReadPerCall pins the accounting CacheStats.Hits
+// documents: one call into ACOR is one read, however many chunks or texts it
+// scans. Before v1.5.0 the multi-scan paths loaded the automaton per chunk, so a
+// 63-chunk text recorded 63 reads and a parallel workload's hit rate was not
+// comparable to a serial one's. The godoc said so; the fix made that false, and
+// this keeps the two from drifting apart again.
+func TestCacheStatsCountsOneReadPerCall(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+
+	if _, err := ac.Add("he"); err != nil {
+		t.Fatal(err)
+	}
+
+	longText := strings.Repeat("he is here. ", 480)
+	opts := parallelRTTOptions()
+	if chunks := len(splitChunks(longText, opts)); chunks < 20 {
+		t.Fatalf("fixture split into %d chunks; this test needs a genuinely multi-chunk text", chunks)
+	}
+
+	if _, err := ac.FindParallel(longText, opts); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 0, 1, 1)
+
+	if _, err := ac.FindIndexParallel(longText, opts); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 1, 1, 1)
+
+	if _, err := ac.FindMany([]string{"he", "her", "him", "nothing"}); err != nil {
+		t.Fatal(err)
+	}
+	assertStats(t, ac.CacheStats(), 2, 1, 1)
 }
 
 // TestCacheStatsUncachedV2Rebuilds proves the digest is doing real work: a changed

--- a/pkg/acor/stats_test.go
+++ b/pkg/acor/stats_test.go
@@ -61,6 +61,7 @@ func TestCacheStatsUncachedV2(t *testing.T) {
 func TestCacheStatsCountsOneReadPerCall(t *testing.T) {
 	ac, mr := createAhoCorasick(t)
 	defer mr.Close()
+	defer func() { _ = ac.Close() }()
 
 	if _, err := ac.Add("he"); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Description

`FindParallel`, `FindIndexParallel`, and `FindMany` called into `find` per chunk or per text, and every `find` reloaded the automaton — so a 63-chunk text issued **63** `HGETALL` calls of the full outputs hash where a serial `Find` issues **1** at any input size. At the default chunk size a 1 MB input was roughly 1000 concurrent reads: a burst, not a trickle. The fixed read cost is the architectural claim for V2, and these paths did not honor it.

Measured on the existing `countRTT` harness (default V2, uncached):

| Chunks | `FindParallel` | `FindIndexParallel` | serial `Find` | after |
|---|---|---|---|---|
| 1 | 1 | 1 | 1 | 1 |
| 6 | 6 | 6 | 1 | 1 |
| 21 | 21 | 21 | 1 | 1 |
| 63 | 63 | 63 | 1 | 1 |

`FindMany` had the same root cause — 5 texts, 5 round trips — and is fixed in the same hoist.

**The fix adds nothing.** `loadEngine` is already on the `operations` interface, and `FindSet`, `Contains`, `FindMatches`, and `FindStream` already call it exactly this way; the change lifts the call out of the loop so every chunk scans one snapshot. That also gives chunks a consistent view of the dictionary, which per-chunk loads never guaranteed.

Three behaviors are preserved deliberately, each because a test depends on it:

- **Empty text returns before the load**, so it still costs zero round trips.
- **`ctx.Err()` is still checked per chunk** — in `Preset` mode `loadEngine` touches no Redis, so that check is the only place a cancellation is noticed (`batch_parallel_test.go` covers exactly this).
- **`normalizeText` stays per chunk**, mirroring `find`.

### Why the godoc changes too

`CacheStats.Hits` documented the old accounting — *"one call over a text split into N chunks records N reads"* — and that sentence is on the **frozen `v1` surface** (`api/v1.txt:50`). `compatibility.md` counts changed documented behavior as breaking, so correcting it before the tag is free and after the tag needs a major version. `monitoring.md` repeated the claim; `benchmarks.md` now publishes the measured rows. Those two lines were the only places in the tree documenting per-chunk behavior.

The round-trip count itself is not a breaking change — `compatibility.md` explicitly excludes round-trip counts — and `api/v1.txt` is byte-identical: godoc changed, signatures did not.

### The gate that was missing

Twelve `TestRTT*` cases pinned serial `Find`, cached `Find`, preset `Find`, V1 `Find`, and both `Add` paths. None covered these, which is how the defect survived. Two new cases assert the count stays at 1 across 1/6/21/63 chunks and 1/5/50 texts. **Flatness is the claim** — a single-size assertion would pass a version that regressed only above some threshold — plus a guard that fails if the fixture stops splitting, so the test can never pass vacuously. Both fail on the previous code:

```
FindParallel() over 6 chunks = 6 round trips, want 1
FindMany() over 5 texts = 5 round trips, want 1
```

Counts verified identical on miniredis and on a real server, which is what makes them structural:

```
ACOR_INTEGRATION_ADDR=localhost:6379 go test -run RTT ./pkg/acor
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog
- [x] Commit messages follow guidelines

Also run: `make race`, `make api-check` (`api/v1.txt` unchanged), and `make all`.

## Additional Notes

- **`FindMany` is beyond the literal scope of the issue**, which names `FindParallel`. It is the same root cause, the same hoist, and the same frozen surface; leaving it would have made the first `v1` bug fix one this work had already found. Severable if you'd rather it went separately.
- **V1 error shape shifts on these paths**: a Redis failure used to arrive wrapped as `OperationError{Op: "find", Schema: 1}` and now surfaces as the bare `RedisError`. `FindSet`/`Contains`/`FindMatches` already behave this way, so this makes the surface more consistent; `compatibility.md` puts error wording outside the promise, and no test pinned the wrapper here.
- This is a precondition on the `v1.5.0` tag — it must land before the tag, since after it a behavioral correction becomes a breaking change rather than a fix.

Closes #205