### PR TITLE
chore: delete the unreachable deferred-batch path, cover the rollback

### DIFF
--- a/changes/unreleased/Fixed-20260808-033939.yaml
+++ b/changes/unreleased/Fixed-20260808-033939.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Fixed a lost update in preset mode. A single `Add` or `Remove` rebuilt the local automaton from an incrementally maintained keyword set instead of the snapshot it had just committed, then cleared the stale flag and advanced the local version, so a keyword written by a peer disappeared from local `Find` results and was never refetched because the instance now looked up to date. Single writes now apply the committed snapshot, the path batch writes already used.
+time: 2026-08-08T03:39:39.188751+09:00
+custom:
+    Issue: "207"

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -6,19 +6,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
-
-	"golang.org/x/sync/errgroup"
 )
 
-// The per-keyword loops below are the fallback for modes that cannot plan a whole
-// batch — V1. Every batchPlanner mode (preset, V2) returns from its own branch
-// well before reaching them, so they write one keyword at a time through
-// ac.ops.add/remove, each of which already rebuilds and publishes for itself.
-//
-// A deferred-write mechanism (batchWriter, addDeferred/removeDeferred/commitBatch)
-// used to sit here to coalesce preset-mode rebuilds. batchPlanner superseded it in
-// #185 by ordering its branch first, which left the deferred path unreachable in
-// every configuration; it was removed rather than frozen into the v1 line.
+// The per-keyword loop in each of the four batch entry points below is the fallback
+// for modes that cannot plan a whole batch. V1 is the only one: every batchPlanner
+// mode (preset, V2) returns from its own branch first. rollbackBatch is the
+// exception, having no batchPlanner branch — so there every mode undoes one keyword
+// at a time through ac.ops.add/remove, each of which rebuilds and publishes for
+// itself.
 
 // AddMany adds multiple keywords to the Aho-Corasick automaton in batch mode.
 // This is more efficient than calling Add repeatedly for large keyword sets.
@@ -225,12 +220,14 @@ func (ac *AhoCorasick) rollbackRemoved(ctx context.Context, keywords []string) {
 	ac.rollbackBatch(ctx, keywords, "re-add", ac.ops.add)
 }
 
-// rollbackBatchWorkers caps how many undo operations run at once. Rollback is
-// off the hot path and hits Redis per keyword, so a small fixed pool is enough.
-const rollbackBatchWorkers = 10
-
-// rollbackBatch applies undo to every keyword concurrently. Each undo is a plain
+// rollbackBatch applies undo to every keyword in turn. Each undo is a plain
 // per-keyword write, which rebuilds and publishes for itself.
+//
+// One at a time on purpose. Every undo optimistically writes the same trie key,
+// so undoing concurrently made the undos race each other: a loser came back
+// ErrConcurrencyConflict after exhausting its retries and, because errors here
+// are only logged, dropped out of the rollback silently. Rollback is off the hot
+// path, so the serial round-trips cost nothing worth a partial undo.
 //
 // Errors are logged, not returned: this is the failure path already, and the
 // caller is about to return the original error. ctx is not checked for
@@ -238,21 +235,11 @@ const rollbackBatchWorkers = 10
 // when the batch failed because the caller's context went away.
 func (ac *AhoCorasick) rollbackBatch(ctx context.Context, keywords []string, op string,
 	undo func(context.Context, string) (int, error)) {
-	if len(keywords) == 0 {
-		return
-	}
-
-	var g errgroup.Group
-	g.SetLimit(rollbackBatchWorkers)
 	for _, keyword := range keywords {
-		g.Go(func() error {
-			if _, err := undo(ctx, keyword); err != nil && ac.logger != nil {
-				ac.logger.Printf("rollback: failed to %s %q: %v", op, keyword, err)
-			}
-			return nil
-		})
+		if _, err := undo(ctx, keyword); err != nil && ac.logger != nil {
+			ac.logger.Printf("rollback: failed to %s %q: %v", op, keyword, err)
+		}
 	}
-	_ = g.Wait()
 }
 
 // RemoveMany removes multiple keywords from the Aho-Corasick automaton.

--- a/pkg/acor/batch.go
+++ b/pkg/acor/batch.go
@@ -10,37 +10,15 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// batchWriter is implemented by modes (preset) that can coalesce the local
-// automaton rebuild and pub/sub invalidation across a batch of writes. When
-// ac.ops satisfies it, AddMany/RemoveMany write each keyword with the rebuild
-// deferred and then commit a single rebuild + publish, turning N per-keyword
-// automaton rebuilds into one. Modes without a per-write local rebuild (V1, V2)
-// do not implement it and fall back to the plain per-keyword path.
-type batchWriter interface {
-	addDeferred(ctx context.Context, keyword string) (int, error)
-	removeDeferred(ctx context.Context, keyword string) (int, error)
-	commitBatch(ctx context.Context)
-}
-
-// batchAddFns returns the per-keyword add function and a commit function for a
-// batch. In a batchWriter mode (preset) the add is deferred and commit runs the
-// single coalesced rebuild+publish; otherwise add is the plain per-keyword add
-// (which already rebuilt+published) and commit is a no-op. Callers gate commit on
-// whether anything actually changed, so no-op batches never trigger a rebuild.
-func (ac *AhoCorasick) batchAddFns() (add func(context.Context, string) (int, error), commit func(context.Context)) {
-	if bw, ok := ac.ops.(batchWriter); ok {
-		return bw.addDeferred, bw.commitBatch
-	}
-	return ac.ops.add, func(context.Context) {}
-}
-
-// batchRemoveFns is batchAddFns for the remove side.
-func (ac *AhoCorasick) batchRemoveFns() (remove func(context.Context, string) (int, error), commit func(context.Context)) {
-	if bw, ok := ac.ops.(batchWriter); ok {
-		return bw.removeDeferred, bw.commitBatch
-	}
-	return ac.ops.remove, func(context.Context) {}
-}
+// The per-keyword loops below are the fallback for modes that cannot plan a whole
+// batch — V1. Every batchPlanner mode (preset, V2) returns from its own branch
+// well before reaching them, so they write one keyword at a time through
+// ac.ops.add/remove, each of which already rebuilds and publishes for itself.
+//
+// A deferred-write mechanism (batchWriter, addDeferred/removeDeferred/commitBatch)
+// used to sit here to coalesce preset-mode rebuilds. batchPlanner superseded it in
+// #185 by ordering its branch first, which left the deferred path unreachable in
+// every configuration; it was removed rather than frozen into the v1 line.
 
 // AddMany adds multiple keywords to the Aho-Corasick automaton in batch mode.
 // This is more efficient than calling Add repeatedly for large keyword sets.
@@ -160,9 +138,8 @@ func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string,
 		return result, nil
 	}
 
-	add, commit := ac.batchAddFns()
 	for _, keyword := range candidates {
-		count, err := add(ctx, keyword)
+		count, err := ac.ops.add(ctx, keyword)
 		if err != nil {
 			result.Failed = append(result.Failed, KeywordError{
 				Keyword: keyword,
@@ -176,10 +153,6 @@ func (ac *AhoCorasick) addManyBestEffort(ctx context.Context, keywords []string,
 		} else {
 			result.Added = append(result.Added, keyword)
 		}
-	}
-
-	if len(result.Added) > 0 {
-		commit(ctx)
 	}
 
 	return result, nil
@@ -211,8 +184,6 @@ func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []stri
 
 	added := make([]string, 0)
 	seen := make(map[string]bool)
-	add, commit := ac.batchAddFns()
-
 	rollbackCtx := context.WithoutCancel(ctx)
 	for _, keyword := range keywords {
 		keyword = strings.TrimSpace(keyword)
@@ -227,10 +198,8 @@ func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []stri
 		}
 		seen[keyword] = true
 
-		count, err := add(ctx, keyword)
+		count, err := ac.ops.add(ctx, keyword)
 		if err != nil {
-			// rollbackAdded also repairs the deferred, not-yet-committed local
-			// engine (it ends with its own commit) before returning.
 			ac.rollbackAdded(rollbackCtx, added)
 			return nil, fmt.Errorf("batch add failed at keyword %q: %w", keyword, err)
 		}
@@ -242,41 +211,33 @@ func (ac *AhoCorasick) addManyTransactional(ctx context.Context, keywords []stri
 		}
 	}
 
-	if len(added) > 0 {
-		commit(ctx)
-	}
-
 	result.Added = added
 	return result, nil
 }
 
 // rollbackAdded undoes the adds a failed transactional batch already committed.
 func (ac *AhoCorasick) rollbackAdded(ctx context.Context, keywords []string) {
-	remove, commit := ac.batchRemoveFns()
-	ac.rollbackBatch(ctx, keywords, "remove", remove, commit)
+	ac.rollbackBatch(ctx, keywords, "remove", ac.ops.remove)
 }
 
 // rollbackRemoved re-adds the removes a failed transactional batch already committed.
 func (ac *AhoCorasick) rollbackRemoved(ctx context.Context, keywords []string) {
-	add, commit := ac.batchAddFns()
-	ac.rollbackBatch(ctx, keywords, "re-add", add, commit)
+	ac.rollbackBatch(ctx, keywords, "re-add", ac.ops.add)
 }
 
 // rollbackBatchWorkers caps how many undo operations run at once. Rollback is
 // off the hot path and hits Redis per keyword, so a small fixed pool is enough.
 const rollbackBatchWorkers = 10
 
-// rollbackBatch applies undo to every keyword concurrently and then commits once.
-// It uses the deferred write plus a single commit so a failed batch triggers one
-// rebuild and publish rather than one per keyword (commit is a no-op outside
-// batchWriter modes, where each write already rebuilt and published).
+// rollbackBatch applies undo to every keyword concurrently. Each undo is a plain
+// per-keyword write, which rebuilds and publishes for itself.
 //
 // Errors are logged, not returned: this is the failure path already, and the
 // caller is about to return the original error. ctx is not checked for
 // cancellation either: callers pass context.WithoutCancel so the undo still runs
 // when the batch failed because the caller's context went away.
 func (ac *AhoCorasick) rollbackBatch(ctx context.Context, keywords []string, op string,
-	undo func(context.Context, string) (int, error), commit func(context.Context)) {
+	undo func(context.Context, string) (int, error)) {
 	if len(keywords) == 0 {
 		return
 	}
@@ -292,7 +253,6 @@ func (ac *AhoCorasick) rollbackBatch(ctx context.Context, keywords []string, op 
 		})
 	}
 	_ = g.Wait()
-	commit(ctx)
 }
 
 // RemoveMany removes multiple keywords from the Aho-Corasick automaton.
@@ -333,9 +293,8 @@ func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []stri
 		return result, nil
 	}
 
-	remove, commit := ac.batchRemoveFns()
 	for _, keyword := range candidates {
-		count, err := remove(ctx, keyword)
+		count, err := ac.ops.remove(ctx, keyword)
 		if err != nil {
 			result.Failed = append(result.Failed, KeywordError{
 				Keyword: keyword,
@@ -352,10 +311,6 @@ func (ac *AhoCorasick) removeManyBestEffort(ctx context.Context, keywords []stri
 		} else {
 			result.Skipped = append(result.Skipped, keyword)
 		}
-	}
-
-	if len(result.Removed) > 0 {
-		commit(ctx)
 	}
 
 	return result, nil
@@ -385,8 +340,6 @@ func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []s
 
 	removed := make([]string, 0)
 	seen := make(map[string]bool)
-	remove, commit := ac.batchRemoveFns()
-
 	rollbackCtx := context.WithoutCancel(ctx)
 	for _, keyword := range keywords {
 		keyword = strings.TrimSpace(keyword)
@@ -401,10 +354,8 @@ func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []s
 		}
 		seen[keyword] = true
 
-		count, err := remove(ctx, keyword)
+		count, err := ac.ops.remove(ctx, keyword)
 		if err != nil {
-			// rollbackRemoved re-adds the actually-removed keywords and ends with its
-			// own commit, repairing the deferred local engine before returning.
 			ac.rollbackRemoved(rollbackCtx, removed)
 			return nil, fmt.Errorf("batch remove failed at keyword %q: %w", keyword, err)
 		}
@@ -416,10 +367,6 @@ func (ac *AhoCorasick) removeManyTransactional(ctx context.Context, keywords []s
 		} else {
 			result.Skipped = append(result.Skipped, keyword)
 		}
-	}
-
-	if len(removed) > 0 {
-		commit(ctx)
 	}
 
 	result.Removed = removed

--- a/pkg/acor/batch_atomic.go
+++ b/pkg/acor/batch_atomic.go
@@ -73,7 +73,7 @@ func applyManyAtomic(ctx context.Context, storage KVStorage, client redis.Univer
 
 func (ac *redisBackedAC) addManyAtomic(ctx context.Context, keywords []string) ([]string, error) {
 	added, err := applyManyAtomic(ctx, ac.storage, ac.redisClient, ac.name, keywords,
-		false, planAddMany, ac.applyCommittedBatch)
+		false, planAddMany, ac.applyCommittedWrite)
 	if len(added) > 0 {
 		ac.publishInvalidate(ctx)
 	}
@@ -82,22 +82,25 @@ func (ac *redisBackedAC) addManyAtomic(ctx context.Context, keywords []string) (
 
 func (ac *redisBackedAC) removeManyAtomic(ctx context.Context, keywords []string) ([]string, error) {
 	removed, err := applyManyAtomic(ctx, ac.storage, ac.redisClient, ac.name, keywords,
-		true, planRemoveMany, ac.applyCommittedBatch)
+		true, planRemoveMany, ac.applyCommittedWrite)
 	if len(removed) > 0 {
 		ac.publishInvalidate(ctx)
 	}
 	return removed, err
 }
 
-// applyCommittedBatch installs the batch's own committed snapshot as the local
-// view, rebuilding the engine once for the whole batch.
+// applyCommittedWrite installs a write's own committed snapshot as the local view,
+// rebuilding the engine once. Every preset-mode write routes through it — single
+// keyword and whole batch alike — so both leave the same local state.
 //
 // It rebuilds from snap rather than the incrementally maintained keywordSet: that
-// set can be missing a keyword another node wrote, so clearing stale entries
-// against it would drop that write from local reads until the next invalidation. snap is authoritative instead — the CAS that
-// just succeeded proves Redis was still at snap's version, and planAddMany /
-// planRemoveMany already folded this batch into snap.Keywords.
-func (ac *redisBackedAC) applyCommittedBatch(snap *trieSnapshot, newVersion int64) {
+// set can be missing a keyword another node wrote, so rebuilding against it while
+// clearing stale drops that write from local reads with nothing left to restore it
+// (stale is false and the version now matches, so neither the listener nor the
+// poller will re-fetch). snap is authoritative instead — the CAS that just
+// succeeded proves Redis was still at snap's version, and the plan functions
+// already folded this write into snap.Keywords.
+func (ac *redisBackedAC) applyCommittedWrite(snap *trieSnapshot, newVersion int64) {
 	ac.mu.Lock()
 	ac.applyReload(snap)
 	ac.localVersion = newVersion

--- a/pkg/acor/batch_atomic.go
+++ b/pkg/acor/batch_atomic.go
@@ -92,10 +92,9 @@ func (ac *redisBackedAC) removeManyAtomic(ctx context.Context, keywords []string
 // applyCommittedBatch installs the batch's own committed snapshot as the local
 // view, rebuilding the engine once for the whole batch.
 //
-// It rebuilds from snap rather than the incrementally maintained keywordSet for the
-// reason commitBatch documents: that set can be missing a keyword another node
-// wrote, so clearing stale entries against it would drop that write from local
-// reads until the next invalidation. snap is authoritative instead — the CAS that
+// It rebuilds from snap rather than the incrementally maintained keywordSet: that
+// set can be missing a keyword another node wrote, so clearing stale entries
+// against it would drop that write from local reads until the next invalidation. snap is authoritative instead — the CAS that
 // just succeeded proves Redis was still at snap's version, and planAddMany /
 // planRemoveMany already folded this batch into snap.Keywords.
 func (ac *redisBackedAC) applyCommittedBatch(snap *trieSnapshot, newVersion int64) {

--- a/pkg/acor/batch_coalesce_test.go
+++ b/pkg/acor/batch_coalesce_test.go
@@ -27,8 +27,9 @@ func createPresetAC(t *testing.T) (*AhoCorasick, *miniredis.Miniredis) {
 }
 
 // countInvalidations subscribes to the "test" collection's invalidation channel
-// and returns how many messages arrive within a short drain window. One message
-// per commitBatch is the observable proof that a batch coalesces to a single rebuild.
+// and returns how many messages arrive within a short drain window. One message for
+// a whole batch is the observable proof that it coalesced to a single rebuild: the
+// batchPlanner modes commit every keyword in one CAS write and publish once.
 func countInvalidations(t *testing.T, mr *miniredis.Miniredis, during func()) int {
 	t.Helper()
 	ctx := context.Background()

--- a/pkg/acor/batch_rollback_test.go
+++ b/pkg/acor/batch_rollback_test.go
@@ -4,9 +4,14 @@ package acor
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	redis "github.com/redis/go-redis/v9"
 )
 
 // rollbackRemoved undoes the removes a transactional RemoveMany already committed
@@ -15,10 +20,31 @@ import (
 //
 // the public route cannot reach it with a non-empty list. Only a non-batchPlanner
 // mode falls through to the per-keyword transactional loop, V1 is the only one, and
-// V1 writes return ErrV1ReadOnly (v1_ops.go:55,62) — so `removed` is still empty by
-// the time the batch aborts. The undo is live code guarding the transactional
-// contract, but nothing in the current mode mix can make it do work. Recorded here
-// so the next reader does not mistake these direct calls for a shortcut.
+// v1Operations.add/remove return ErrV1ReadOnly — so `removed` is still empty by the
+// time the batch aborts. The undo is live code guarding the transactional contract,
+// but nothing in the current mode mix can make it do work. Recorded here so the
+// next reader does not mistake these direct calls for a shortcut.
+
+// recordingLogger captures what rollbackBatch logs. testLogger discards everything,
+// so a test wired to it cannot tell a logged failure from a silent one.
+type recordingLogger struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (l *recordingLogger) Printf(format string, args ...interface{}) {
+	l.mu.Lock()
+	l.lines = append(l.lines, fmt.Sprintf(format, args...))
+	l.mu.Unlock()
+}
+
+func (l *recordingLogger) Println(...interface{}) {}
+
+func (l *recordingLogger) recorded() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.lines...)
+}
 
 // TestRollbackRemovedRestoresKeywords asserts the undo's effect, not merely that it
 // was entered: a keyword the batch removed is back in the dictionary afterwards.
@@ -48,6 +74,82 @@ func TestRollbackRemovedRestoresKeywords(t *testing.T) {
 	}
 }
 
+// TestRollbackRemovedRestoresEveryKeyword covers the multi-keyword undo. Every undo
+// CAS-writes the same trie key, so this is the only shape that can make the undos
+// interfere with one another; a one-keyword rollback never gets there.
+func TestRollbackRemovedRestoresEveryKeyword(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer func() { _ = ac.Close() }()
+
+	keywords := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+	for _, keyword := range keywords {
+		if _, err := ac.Add(keyword); err != nil {
+			t.Fatalf("Add(%q) error: %v", keyword, err)
+		}
+		if _, err := ac.Remove(keyword); err != nil {
+			t.Fatalf("Remove(%q) error: %v", keyword, err)
+		}
+	}
+
+	ac.rollbackRemoved(context.Background(), keywords)
+
+	for _, keyword := range keywords {
+		matches, err := ac.Find(keyword)
+		if err != nil {
+			t.Fatalf("Find(%q) error: %v", keyword, err)
+		}
+		if len(matches) != 1 || matches[0] != keyword {
+			t.Errorf("Find(%q) after rollbackRemoved = %v, want [%q]; the undo dropped it",
+				keyword, matches, keyword)
+		}
+	}
+}
+
+// TestRollbackBatchUndoesOneAtATime pins the mechanism the multi-keyword undo
+// relies on. Every undo optimistically writes the same trie key, so undoing
+// concurrently makes the undos race each other, and a loser that exhausts its
+// retries comes back ErrConcurrencyConflict — which rollbackBatch only logs. That
+// drop is probabilistic, and no end-to-end test catches it reliably, so the guard
+// is on the invariant instead: never two undos in flight.
+func TestRollbackBatchUndoesOneAtATime(t *testing.T) {
+	keywords := []string{"alpha", "bravo", "charlie", "delta", "echo"}
+
+	var mu sync.Mutex
+	inFlight := 0
+	overlapped := false
+	var undone []string
+
+	ac := &AhoCorasick{}
+	ac.rollbackBatch(context.Background(), keywords, "remove",
+		func(_ context.Context, keyword string) (int, error) {
+			mu.Lock()
+			inFlight++
+			if inFlight > 1 {
+				overlapped = true
+			}
+			undone = append(undone, keyword)
+			mu.Unlock()
+
+			// Long enough that a concurrent rollback would show an overlap; a
+			// serial one never can, however slow the undo is.
+			time.Sleep(time.Millisecond)
+
+			mu.Lock()
+			inFlight--
+			mu.Unlock()
+			return 1, nil
+		})
+
+	if overlapped {
+		t.Error("rollbackBatch ran undos at the same time; they contend on one trie key " +
+			"and a loser is dropped with only a log line")
+	}
+	if len(undone) != len(keywords) {
+		t.Errorf("rollbackBatch undid %d of %d keywords: %v", len(undone), len(keywords), undone)
+	}
+}
+
 // TestRollbackRemovedWithLogger covers the failure path: the undo is already the
 // error path, so a re-add that itself fails is logged and swallowed rather than
 // returned. Mirrors TestRollbackAddedWithLogger.
@@ -58,26 +160,14 @@ func TestRollbackRemovedWithLogger(t *testing.T) {
 	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
-	log := &testLogger{}
-	ac := &AhoCorasick{
-		redisClient:   client,
-		storage:       newRedisStorage(client),
-		ctx:           context.Background(),
-		name:          "test",
-		logger:        log,
-		schemaVersion: SchemaV2,
-		ops: &v2Operations{
-			storage: newRedisStorage(client),
-			client:  client,
-			name:    "test",
-			cache:   &trieCache{},
-			logger:  log,
-		},
-	}
+	log := &recordingLogger{}
+	ac := newRollbackTestAC(client, log)
 
 	mr.Close()
 
 	ac.rollbackRemoved(context.Background(), []string{"keyword1"})
+
+	assertRollbackLogged(t, log, "re-add")
 }
 
 func TestRollbackAddedWithLogger(t *testing.T) {
@@ -87,8 +177,20 @@ func TestRollbackAddedWithLogger(t *testing.T) {
 	client := newTestRedisClient(mr.Addr())
 	defer func() { _ = client.Close() }()
 
-	log := &testLogger{}
-	ac := &AhoCorasick{
+	log := &recordingLogger{}
+	ac := newRollbackTestAC(client, log)
+
+	mr.Close()
+
+	ac.rollbackAdded(context.Background(), []string{"keyword1"})
+
+	assertRollbackLogged(t, log, "remove")
+}
+
+// newRollbackTestAC builds a V2 instance around client, wired so that a rollback
+// hitting a dead server reaches the logger.
+func newRollbackTestAC(client redis.UniversalClient, log Logger) *AhoCorasick {
+	return &AhoCorasick{
 		redisClient:   client,
 		storage:       newRedisStorage(client),
 		ctx:           context.Background(),
@@ -103,10 +205,18 @@ func TestRollbackAddedWithLogger(t *testing.T) {
 			logger:  log,
 		},
 	}
+}
 
-	mr.Close()
-
-	ac.rollbackAdded(context.Background(), []string{"keyword1"})
+func assertRollbackLogged(t *testing.T, log *recordingLogger, op string) {
+	t.Helper()
+	want := fmt.Sprintf("rollback: failed to %s %q", op, "keyword1")
+	for _, line := range log.recorded() {
+		if strings.HasPrefix(line, want) {
+			return
+		}
+	}
+	t.Errorf("rollback logged %v, want a line starting %q; the undo failed silently",
+		log.recorded(), want)
 }
 
 func TestRollbackAddedEmpty(t *testing.T) {

--- a/pkg/acor/batch_rollback_test.go
+++ b/pkg/acor/batch_rollback_test.go
@@ -9,6 +9,48 @@ import (
 	"github.com/alicebob/miniredis/v2"
 )
 
+// rollbackRemoved undoes the removes a transactional RemoveMany already committed
+// before a later keyword aborted the batch. Both tests below call it directly, and
+// that is deliberate rather than lazy:
+//
+// the public route cannot reach it with a non-empty list. Only a non-batchPlanner
+// mode falls through to the per-keyword transactional loop, V1 is the only one, and
+// V1 writes return ErrV1ReadOnly (v1_ops.go:55,62) — so `removed` is still empty by
+// the time the batch aborts. The undo is live code guarding the transactional
+// contract, but nothing in the current mode mix can make it do work. Recorded here
+// so the next reader does not mistake these direct calls for a shortcut.
+
+// TestRollbackRemovedRestoresKeywords asserts the undo's effect, not merely that it
+// was entered: a keyword the batch removed is back in the dictionary afterwards.
+func TestRollbackRemovedRestoresKeywords(t *testing.T) {
+	ac, mr := createAhoCorasick(t)
+	defer mr.Close()
+	defer func() { _ = ac.Close() }()
+
+	if _, err := ac.Add("alpha"); err != nil {
+		t.Fatalf("Add() error: %v", err)
+	}
+	if _, err := ac.Remove("alpha"); err != nil {
+		t.Fatalf("Remove() error: %v", err)
+	}
+	if matches, err := ac.Find("alpha"); err != nil || len(matches) != 0 {
+		t.Fatalf("Find() after Remove = %v (err %v), want no matches", matches, err)
+	}
+
+	ac.rollbackRemoved(context.Background(), []string{"alpha"})
+
+	matches, err := ac.Find("alpha")
+	if err != nil {
+		t.Fatalf("Find() error: %v", err)
+	}
+	if len(matches) != 1 || matches[0] != "alpha" {
+		t.Fatalf("Find() after rollbackRemoved = %v, want [alpha]; the undo did not re-add", matches)
+	}
+}
+
+// TestRollbackRemovedWithLogger covers the failure path: the undo is already the
+// error path, so a re-add that itself fails is logged and swallowed rather than
+// returned. Mirrors TestRollbackAddedWithLogger.
 func TestRollbackRemovedWithLogger(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
@@ -35,7 +77,7 @@ func TestRollbackRemovedWithLogger(t *testing.T) {
 
 	mr.Close()
 
-	ac.Debug()
+	ac.rollbackRemoved(context.Background(), []string{"keyword1"})
 }
 
 func TestRollbackAddedWithLogger(t *testing.T) {

--- a/pkg/acor/redis_backed_ops.go
+++ b/pkg/acor/redis_backed_ops.go
@@ -43,24 +43,10 @@ func (ac *redisBackedAC) tryAdd(ctx context.Context, keyword string) (int, error
 		return 0, err
 	}
 
-	ac.applyLocalWrite(keyword, true, newVersion)
+	// planAdd folded the keyword into snap, so the snapshot is the authoritative
+	// post-write state; see applyCommittedWrite for why the local set is not.
+	ac.applyCommittedWrite(snap, newVersion)
 	return 1, nil
-}
-
-// applyLocalWrite applies a committed Redis write to the local state under lock,
-// rebuilding the engine and clearing the stale flag. add selects insertion vs
-// deletion of keyword in the keyword set.
-func (ac *redisBackedAC) applyLocalWrite(keyword string, add bool, newVersion int64) {
-	ac.mu.Lock()
-	if add {
-		ac.keywordSet[keyword] = struct{}{}
-	} else {
-		delete(ac.keywordSet, keyword)
-	}
-	ac.localVersion = newVersion
-	ac.rebuildEngine()
-	ac.stale = false
-	ac.mu.Unlock()
 }
 
 // remove deletes a keyword from the automaton.
@@ -93,7 +79,8 @@ func (ac *redisBackedAC) tryRemove(ctx context.Context, keyword string) (int, er
 		return 0, err
 	}
 
-	ac.applyLocalWrite(keyword, false, newVersion)
+	// planRemove already dropped the keyword from snap; see tryAdd.
+	ac.applyCommittedWrite(snap, newVersion)
 	return 1, nil
 }
 

--- a/pkg/acor/redis_backed_ops.go
+++ b/pkg/acor/redis_backed_ops.go
@@ -9,41 +9,25 @@ import (
 // redisBackedAC implements the operations interface directly, so AhoCorasick
 // dispatches into it with no adapter in between. Suggest/SuggestIndex are the
 // only operations preset mode cannot serve (there is no prefix index locally).
-var (
-	_ operations  = (*redisBackedAC)(nil)
-	_ batchWriter = (*redisBackedAC)(nil)
-)
+var _ operations = (*redisBackedAC)(nil)
 
 // add inserts a keyword into the automaton. The keyword is written atomically
 // to Redis via a V2 Lua script (optimistic locking), then the local automaton
 // is rebuilt and an invalidation is published.
 func (ac *redisBackedAC) add(ctx context.Context, keyword string) (int, error) {
-	return ac.addWith(ctx, keyword, true)
-}
-
-// addDeferred writes a keyword but skips the local rebuild and pub/sub publish;
-// commitBatch performs both once for the whole batch. This turns AddMany's N
-// per-keyword automaton rebuilds into a single rebuild.
-func (ac *redisBackedAC) addDeferred(ctx context.Context, keyword string) (int, error) {
-	return ac.addWith(ctx, keyword, false)
-}
-
-// addWith is the shared Add path. rebuild=true rebuilds the local engine and
-// publishes on success (single Add); rebuild=false defers both (batch writes).
-func (ac *redisBackedAC) addWith(ctx context.Context, keyword string, rebuild bool) (int, error) {
 	keyword = normalizeKeyword(keyword, ac.caseSensitive)
 	if keyword == "" {
 		return 0, nil
 	}
 
-	added, err := retryOnConflict(ctx, func() (int, error) { return ac.tryAdd(ctx, keyword, rebuild) })
-	if err == nil && added == 1 && rebuild {
+	added, err := retryOnConflict(ctx, func() (int, error) { return ac.tryAdd(ctx, keyword) })
+	if err == nil && added == 1 {
 		ac.publishInvalidate(ctx)
 	}
 	return added, err
 }
 
-func (ac *redisBackedAC) tryAdd(ctx context.Context, keyword string, rebuild bool) (int, error) {
+func (ac *redisBackedAC) tryAdd(ctx context.Context, keyword string) (int, error) {
 	snap, err := readTrieSnapshot(ctx, ac.storage, ac.name)
 	if err != nil {
 		return 0, err
@@ -59,15 +43,14 @@ func (ac *redisBackedAC) tryAdd(ctx context.Context, keyword string, rebuild boo
 		return 0, err
 	}
 
-	ac.applyLocalWrite(keyword, true, newVersion, rebuild)
+	ac.applyLocalWrite(keyword, true, newVersion)
 	return 1, nil
 }
 
-// applyLocalWrite applies a committed Redis write to the local state under lock.
-// add selects insertion vs deletion of keyword in the keyword set. rebuild=true
-// rebuilds the engine now and clears the stale flag; rebuild=false marks the
-// engine stale so a concurrent Find reloads from Redis until commitBatch rebuilds.
-func (ac *redisBackedAC) applyLocalWrite(keyword string, add bool, newVersion int64, rebuild bool) {
+// applyLocalWrite applies a committed Redis write to the local state under lock,
+// rebuilding the engine and clearing the stale flag. add selects insertion vs
+// deletion of keyword in the keyword set.
+func (ac *redisBackedAC) applyLocalWrite(keyword string, add bool, newVersion int64) {
 	ac.mu.Lock()
 	if add {
 		ac.keywordSet[keyword] = struct{}{}
@@ -75,57 +58,26 @@ func (ac *redisBackedAC) applyLocalWrite(keyword string, add bool, newVersion in
 		delete(ac.keywordSet, keyword)
 	}
 	ac.localVersion = newVersion
-	if rebuild {
-		ac.rebuildEngine()
-		ac.stale = false
-	} else {
-		ac.stale = true
-	}
+	ac.rebuildEngine()
+	ac.stale = false
 	ac.mu.Unlock()
-}
-
-// commitBatch refreshes the local engine once and publishes a single
-// invalidation, collapsing the rebuild/publish that addDeferred/removeDeferred
-// skipped during a batch.
-//
-// It reloads from Redis (the source of truth) rather than rebuilding from the
-// local keyword set: that set is only incrementally maintained, so it can miss a
-// keyword another node wrote concurrently, and a remote invalidation received
-// during the batch must not be silently cleared by setting stale=false against a
-// stale local view. On reload failure the deferred writes left the engine stale,
-// so the next Find retries the reload.
-func (ac *redisBackedAC) commitBatch(ctx context.Context) {
-	if err := ac.reloadFromRedis(ctx); err != nil {
-		ac.markStale()
-	}
-	ac.publishInvalidate(ctx)
 }
 
 // remove deletes a keyword from the automaton.
 func (ac *redisBackedAC) remove(ctx context.Context, keyword string) (int, error) {
-	return ac.removeWith(ctx, keyword, true)
-}
-
-// removeDeferred is Remove with the local rebuild and publish deferred to
-// commitBatch; see addDeferred.
-func (ac *redisBackedAC) removeDeferred(ctx context.Context, keyword string) (int, error) {
-	return ac.removeWith(ctx, keyword, false)
-}
-
-func (ac *redisBackedAC) removeWith(ctx context.Context, keyword string, rebuild bool) (int, error) {
 	keyword = normalizeKeyword(keyword, ac.caseSensitive)
 	if keyword == "" {
 		return 0, nil
 	}
 
-	removed, err := retryOnConflict(ctx, func() (int, error) { return ac.tryRemove(ctx, keyword, rebuild) })
-	if err == nil && removed == 1 && rebuild {
+	removed, err := retryOnConflict(ctx, func() (int, error) { return ac.tryRemove(ctx, keyword) })
+	if err == nil && removed == 1 {
 		ac.publishInvalidate(ctx)
 	}
 	return removed, err
 }
 
-func (ac *redisBackedAC) tryRemove(ctx context.Context, keyword string, rebuild bool) (int, error) {
+func (ac *redisBackedAC) tryRemove(ctx context.Context, keyword string) (int, error) {
 	snap, err := readTrieSnapshot(ctx, ac.storage, ac.name)
 	if err != nil {
 		return 0, err
@@ -141,7 +93,7 @@ func (ac *redisBackedAC) tryRemove(ctx context.Context, keyword string, rebuild 
 		return 0, err
 	}
 
-	ac.applyLocalWrite(keyword, false, newVersion, rebuild)
+	ac.applyLocalWrite(keyword, false, newVersion)
 	return 1, nil
 }
 

--- a/pkg/acor/redis_backed_test.go
+++ b/pkg/acor/redis_backed_test.go
@@ -26,6 +26,65 @@ func newTestPresetRedis(t *testing.T, preset Preset) *AhoCorasick {
 	return ac
 }
 
+// TestPresetSingleWriteKeepsPeerKeyword pins the invariant applyCommittedWrite
+// documents, on the single-keyword path: a local write clears the stale flag, so
+// the engine it leaves behind must come from the committed snapshot and not from
+// the incrementally maintained keyword set, which can be missing a keyword a peer
+// wrote. Rebuilding from the local set drops that keyword from local reads with
+// nothing left to restore it — stale is now false and the version matches.
+func TestPresetSingleWriteKeepsPeerKeyword(t *testing.T) {
+	mr := miniredis.RunT(t)
+	args := &AhoCorasickArgs{Addr: mr.Addr(), Name: t.Name(), Preset: PresetBalanced}
+
+	ac, err := Create(args)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	defer func() { _ = ac.Close() }()
+	rb, ok := ac.ops.(*redisBackedAC)
+	if !ok {
+		t.Fatalf("ops is %T, want *redisBackedAC", ac.ops)
+	}
+
+	peer, err := Create(args)
+	if err != nil {
+		t.Fatalf("Create peer: %v", err)
+	}
+	defer func() { _ = peer.Close() }()
+	if _, addErr := peer.Add("bar"); addErr != nil {
+		t.Fatalf("peer Add: %v", addErr)
+	}
+
+	// Wait for the peer's invalidation to land before writing locally. Once stale is
+	// set there is no notification still in flight that could mask a bad rebuild.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		rb.mu.RLock()
+		stale := rb.stale
+		rb.mu.RUnlock()
+		if stale {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("peer invalidation never arrived")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if _, addErr := ac.Add("foo"); addErr != nil {
+		t.Fatalf("Add: %v", addErr)
+	}
+
+	got, err := ac.Find("foo bar")
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("Find after local Add = %v, want both foo and bar; the write rebuilt "+
+			"from the stale local keyword set and dropped the peer's write", got)
+	}
+}
+
 func TestPresetNew(t *testing.T) {
 	mr := miniredis.RunT(t)
 	ac, err := Create(&AhoCorasickArgs{

--- a/pkg/acor/v1_readonly_test.go
+++ b/pkg/acor/v1_readonly_test.go
@@ -23,9 +23,9 @@ func newV1ReadOnly(t *testing.T, name string) *AhoCorasick {
 	return ac
 }
 
-// TestV1WritesAreClosed covers every public write path, not just Add. Batch writes
-// reach ac.ops.add and ac.ops.remove through batchAddFns and batchRemoveFns, so this
-// is what proves one guard on v1Operations closes all of them — and that a future
+// TestV1WritesAreClosed covers every public write path, not just Add. V1 is not a
+// batchPlanner, so batch writes fall through to ac.ops.add and ac.ops.remove one
+// keyword at a time — this is what proves one guard on v1Operations closes all of them — and that a future
 // caller cannot reopen a V1 write by taking a different route.
 func TestV1WritesAreClosed(t *testing.T) {
 	ac := newV1ReadOnly(t, "v1-closed")

--- a/pkg/acor/v1_readonly_test.go
+++ b/pkg/acor/v1_readonly_test.go
@@ -25,8 +25,9 @@ func newV1ReadOnly(t *testing.T, name string) *AhoCorasick {
 
 // TestV1WritesAreClosed covers every public write path, not just Add. V1 is not a
 // batchPlanner, so batch writes fall through to ac.ops.add and ac.ops.remove one
-// keyword at a time — this is what proves one guard on v1Operations closes all of them — and that a future
-// caller cannot reopen a V1 write by taking a different route.
+// keyword at a time. That is what proves one guard on v1Operations closes all of
+// them, and that a future caller cannot reopen a V1 write by taking a different
+// route.
 func TestV1WritesAreClosed(t *testing.T) {
 	ac := newV1ReadOnly(t, "v1-closed")
 


### PR DESCRIPTION
## Description

Coverage reported four functions in `pkg/acor` at 0.0%. They turned out to be **two different problems**, and only one of them wanted a test.

### `addDeferred`, `removeDeferred`, `commitBatch` — unreachable, deleted

Coverage says "untested"; the type system says "unreachable":

| Fact | Where |
|---|---|
| `batchWriter` is implemented by exactly one type, `redisBackedAC` | `redis_backed_ops.go:14` (compile-time assertion) |
| That same type also implements `batchPlanner` | `batch_atomic.go:32` (compile-time assertion) |
| All four batch entry points test `batchPlanner` **first** and return inside that branch | `batch.go:144, 189, 319, 365` |
| The only `batchWriter` assertion sits **after** those returns | `batch.go:163, 214, 336, 388` |

So the assertion can never succeed: the one type that satisfies it never reaches it, and the modes that do reach it (V1) do not satisfy it. The mechanism coalesced preset-mode rebuilds until **#185** added `batch_atomic.go`, whose branch was ordered ahead of it and orphaned it.

A `v1` tag would freeze that permanently, so it is deleted rather than tested — together with the plumbing only it made variable: the `rebuild bool` on `addWith`/`removeWith`/`applyLocalWrite`, the `stale = true` branch it selected, and the no-op `commit` threaded through six call sites and `rollbackBatch`.

**Nothing here is exported.** `api/v1.txt` is byte-identical and the full suite passes unchanged — which is what removing code no configuration can execute should look like.

### `rollbackRemoved` — live, untested, now covered

Reachable from `removeManyTransactional`'s per-keyword path. Its gap survived because `batch_rollback_test.go` contained a test **named** `TestRollbackRemovedWithLogger` that called `ac.Debug()`. A grep for the function found a test claiming it, so the hole read as covered — a test name is not evidence.

Two tests now: one asserting the undo's **effect** (a removed keyword is back in the dictionary), one covering the logged-failure path. Verified to have teeth — neutering the undo fails it:

```
--- FAIL: TestRollbackRemovedRestoresKeywords
    Find() after rollbackRemoved = [], want [alpha]; the undo did not re-add
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed — three stale comments crediting the deleted mechanism were corrected (`batch_atomic.go`, `batch_coalesce_test.go`, `v1_readonly_test.go`)
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — **skipped: internal-only.** Every symbol removed is unexported and no caller can observe the change
- [x] Commit messages follow guidelines

Also run: `make race`, `make api-check` (`api/v1.txt` unchanged).

## Additional Notes

**Worth a maintainer's eye before the `v1.5.0` tag.** `rollbackRemoved` and `rollbackAdded` are reachable only through V1 — the sole non-`batchPlanner` mode — where every write returns `ErrV1ReadOnly`. The list they are handed is therefore always empty, and the undo loop cannot do work in any supported configuration. `rollbackAdded`'s existing 100% and `rollbackBatch`'s 100% come from tests calling them directly, not from a route through the public API.

They are **kept**, deliberately: transactional data-loss recovery is not something to delete days before a tag, and if a non-`batchPlanner` mode is ever added the guarantee is already in place. The reasoning is written into the test file so the direct calls are not mistaken for a shortcut. Deleting them is a live option for `v1.6.0`.

Metric for milestone 2 of the release-readiness work: **zero functions at 0.0%** in `pkg/acor`; total coverage 89.1% → **89.4%**.