### PR TITLE
refactor: unexport the storage abstraction, off the v1 surface

### DIFF
--- a/api/v1-audit.txt
+++ b/api/v1-audit.txt
@@ -86,13 +86,9 @@ field ParallelOptions.Boundary ChunkBoundary	ok	options.go:68; the zero value is
 field ParallelOptions.ChunkSize int	fixed	options.go:61 promised a DefaultChunkSize fallback; normalizeParallelOptions (parallel.go:89-104) never sets it and context_ops.go:127,177 reject <= 0 with ErrInvalidChunkSize, so the documented default was an error return. TestParallelOptionsHaveNoImpliedDefaults pins it
 field ParallelOptions.Overlap int	fixed	options.go:71 promised DefaultOverlap; parallel.go:96-102 only clamps negatives, leaving an unset Overlap at 0 and silently missing boundary-straddling keywords. Same test pins it
 field ParallelOptions.Workers int	ok	options.go:58; parallel.go:93-95 substitutes runtime.NumCPU() when <= 0, exactly as documented
-field PubSubMessage.Channel string	ok	set from msg.Channel, redis_storage.go:159
-field PubSubMessage.Payload string	ok	set from msg.Payload, redis_storage.go:159
 field RedisError.Err error	ok	errors.go:99; the client error, returned by Unwrap at errors.go:109
 field RedisError.Key string	ok	errors.go:97; the key involved, v2_ops.go:108
 field RedisError.Op string	ok	errors.go:95; the Redis verb, e.g. "HGETALL" at v2_ops.go:108
-field Z.Member string	ok	copied to redis.Z.Member, redis_storage.go:61
-field Z.Score float64	ok	copied to redis.Z.Score, redis_storage.go:61
 func Create(args *AhoCorasickArgs) (*AhoCorasick, error)	ok	acor.go:403 delegates to CreateContext with context.Background, and the documented error cases are the guards at acor.go:420-437 and client.go:47-68
 func CreateContext(ctx context.Context, args *AhoCorasickArgs) (*AhoCorasick, error)	ok	acor.go:418; ctx governs setup only, and the background listener runs on an internal context per acor.go:476
 func DefaultMigrationOptions() *MigrationOptions	unaudited
@@ -144,41 +140,8 @@ method (*OperationError) Unwrap() error	ok	errors.go:90 returns Err, so errors.I
 method (*RedisError) Error() string	ok	errors.go:104 formats op, key and cause
 method (*RedisError) Unwrap() error	ok	errors.go:109 returns Err, so errors.Is reaches the go-redis error
 method (Preset) String() string	unaudited
-method KVStorage.Close() error	ok	redis_storage.go:117 closes the underlying client
-method KVStorage.Del(ctx context.Context, keys ...string) error	ok	redis_storage.go:86
-method KVStorage.Exists(ctx context.Context, keys ...string) (int64, error)	ok	redis_storage.go:90 returns the count as documented
-method KVStorage.Get(ctx context.Context, key string) (string, error)	ok	redis_storage.go:22; the documented redis.Nil on a missing key is what trie.go:20 tests for, so the promise is load-bearing rather than decorative
-method KVStorage.HGetAll(ctx context.Context, key string) (map[string]string, error)	ok	redis_storage.go:30
-method KVStorage.HSet(ctx context.Context, key string, values ...interface{}) error	ok	redis_storage.go:34
-method KVStorage.Pipeline() Pipeliner	ok	redis_storage.go:105 returns a non-transactional pipeline, distinct from TxPipelined as documented
-method KVStorage.Publish(ctx context.Context, channel string, message interface{}) error	ok	redis_storage.go:109
-method KVStorage.SAdd(ctx context.Context, key string, members ...interface{}) error	ok	redis_storage.go:38
-method KVStorage.SCard(ctx context.Context, key string) (int64, error)	ok	redis_storage.go:50
-method KVStorage.SIsMember(ctx context.Context, key, member string) (bool, error)	ok	redis_storage.go:54
-method KVStorage.SMembers(ctx context.Context, key string) ([]string, error)	ok	redis_storage.go:42
-method KVStorage.SRem(ctx context.Context, key string, members ...interface{}) error	ok	redis_storage.go:46
-method KVStorage.Set(ctx context.Context, key string, value interface{}) error	ok	redis_storage.go:26 passes expiration 0, which is "no expiration" as documented
-method KVStorage.SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) (bool, error)	ok	redis_storage.go:101 returns the SETNX result, true when set
-method KVStorage.Subscribe(ctx context.Context, channels ...string) Subscription	ok	redis_storage.go:113
-method KVStorage.TxPipelined(ctx context.Context, fn func(Pipeliner) error) error	ok	redis_storage.go:94 wraps go-redis TxPipelined, so the commands run inside MULTI/EXEC as "transaction pipeline" claims
-method KVStorage.ZAdd(ctx context.Context, key string, members ...*Z) error	ok	redis_storage.go:58 converts each *Z to redis.Z before the call
-method KVStorage.ZCard(ctx context.Context, key string) (int64, error)	ok	redis_storage.go:78
-method KVStorage.ZRange(ctx context.Context, key string, start, stop int64) ([]string, error)	ok	redis_storage.go:66; "by index range" matches ZRANGE start/stop semantics
-method KVStorage.ZRank(ctx context.Context, key, member string) (int64, error)	ok	redis_storage.go:70
-method KVStorage.ZRem(ctx context.Context, key string, members ...interface{}) error	ok	redis_storage.go:82
-method KVStorage.ZScore(ctx context.Context, key, member string) (float64, error)	ok	redis_storage.go:74
 method Logger.Printf(format string, v ...interface{})	ok	satisfied by log.Logger and by the args-supplied logger, acor.go:446-454
 method Logger.Println(v ...interface{})	ok	same construction path, acor.go:446-454
-method Pipeliner.Del(ctx context.Context, keys ...string) error	ok	redis_storage.go:201
-method Pipeliner.Exec(ctx context.Context) error	ok	redis_storage.go:209
-method Pipeliner.HGetAll(ctx context.Context, key string) StringMapResult	ok	redis_storage.go:205 returns the deferred wrapper; readable after Exec as documented
-method Pipeliner.HSet(ctx context.Context, key string, values ...interface{}) error	ok	redis_storage.go:189
-method Pipeliner.SAdd(ctx context.Context, key string, members ...interface{}) error	ok	redis_storage.go:185 buffers on the pipeline rather than issuing immediately
-method Pipeliner.ZAdd(ctx context.Context, key string, members ...*Z) error	ok	redis_storage.go:193
-method StringMapResult.Val() map[string]string	ok	redis_storage.go:125 reads the deferred cmd; before Exec it yields the zero value, which is why the doc requires Exec first
-method Subscription.Channel() <-chan PubSubMessage	ok	redis_storage.go:144 fans go-redis messages into a buffered channel, once per subscription via sync.Once
-method Subscription.Close() error	ok	redis_storage.go:171 closes the pubsub and releases the forwarding goroutine via done
-method Subscription.Receive(ctx context.Context) error	ok	redis_storage.go:137; used exactly as documented at invalidation.go:192, once right after Subscribe, where what arrives is the confirmation
 type AhoCorasick struct	ok	acor.go:331; instance state is mutex- or atomic-guarded (acor.go:337-358) and the concurrency claim is exercised under make race
 type AhoCorasickArgs struct	ok	acor.go:219; the documented topology precedence matches CreateContext (acor.go:418) and client.go:47-68, and Name is the only required field
 type AhoCorasickInfo struct	unaudited
@@ -187,7 +150,6 @@ type BatchOptions struct	ok	options.go:22; consumed by AddMany/RemoveMany, batch
 type BatchResult struct	ok	options.go:101; the four slices partition a batch's outcome, batch.go:114-361
 type CacheStats struct	ok	stats.go:10; returned by value from acor.go:650 and never constructed by callers, and snapshot() reads process-local atomics only, so "nothing here is read from or written to Redis" holds
 type ChunkBoundary int	ok	options.go:30; all three values are handled in isBoundary, parallel.go:77-86
-type KVStorage interface	risk	storage.go:18 promised "mock implementations can be used for testing"; no exported symbol accepts or returns a KVStorage, so callers can name it but never supply one. Sentence corrected; whether the 43-entry island belongs on the frozen surface is a shape decision for milestone 4
 type KeywordError struct	ok	options.go:92; pairs keyword and error, constructed at batch.go:67,126,139
 type Logger interface	ok	acor.go:209; newLogger (acor.go:446) defaults to io.Discard and switches to stdout only when Debug is set, exactly as documented
 type Match struct	ok	matches.go:15; rune offsets, half-open, emitted in scan order by the engine callback at matches.go:129
@@ -197,13 +159,8 @@ type MigrationOptions struct	unaudited
 type MigrationResult struct	unaudited
 type OperationError struct	ok	errors.go:68; constructed by newOperationError (errors.go:111) and used at v2_ops.go:114 for unmarshal failures
 type ParallelOptions struct	ok	options.go:55; consumed by splitChunks and normalizeParallelOptions, parallel.go:19,89
-type Pipeliner interface	ok	storage.go:104 "buffered and sent together"; redisPipeliner buffers on redis.Pipeliner and flushes in Exec, redis_storage.go:181,209. Reachable only via KVStorage.Pipeline/TxPipelined — see the KVStorage verdict
 type Preset int	unaudited
-type PubSubMessage struct	ok	storage.go:86; constructed from the go-redis message at redis_storage.go:159
 type RedisError struct	ok	errors.go:92; constructed by newRedisError (errors.go:115), used at v2_ops.go:108
-type StringMapResult interface	ok	storage.go:78 "deferred string map result from a pipeline HGetAll"; redisStringMapResult wraps the deferred cmd, redis_storage.go:121,205
-type Subscription interface	ok	storage.go:94 descriptive; redisSubscription implements it, redis_storage.go:129. Reachable only via KVStorage.Subscribe
-type Z struct	ok	storage.go:10 "compatible with Redis ZSET operations"; converted field-for-field to redis.Z at redis_storage.go:61
 var ErrAlreadyV2	ok	migration.go:139 when the collection is already V2
 var ErrCacheRequiresV2	ok	acor.go:503 rejects EnableCache on V1, matching the doc; v1_ops.go:209 records the same constraint
 var ErrCacheWithPreset	ok	acor.go:437 rejects the combination rather than silently dropping the cache, as the doc states

--- a/api/v1.txt
+++ b/api/v1.txt
@@ -86,13 +86,9 @@ field ParallelOptions.Boundary ChunkBoundary
 field ParallelOptions.ChunkSize int
 field ParallelOptions.Overlap int
 field ParallelOptions.Workers int
-field PubSubMessage.Channel string
-field PubSubMessage.Payload string
 field RedisError.Err error
 field RedisError.Key string
 field RedisError.Op string
-field Z.Member string
-field Z.Score float64
 func Create(args *AhoCorasickArgs) (*AhoCorasick, error)
 func CreateContext(ctx context.Context, args *AhoCorasickArgs) (*AhoCorasick, error)
 func DefaultMigrationOptions() *MigrationOptions
@@ -144,41 +140,8 @@ method (*OperationError) Unwrap() error
 method (*RedisError) Error() string
 method (*RedisError) Unwrap() error
 method (Preset) String() string
-method KVStorage.Close() error
-method KVStorage.Del(ctx context.Context, keys ...string) error
-method KVStorage.Exists(ctx context.Context, keys ...string) (int64, error)
-method KVStorage.Get(ctx context.Context, key string) (string, error)
-method KVStorage.HGetAll(ctx context.Context, key string) (map[string]string, error)
-method KVStorage.HSet(ctx context.Context, key string, values ...interface{}) error
-method KVStorage.Pipeline() Pipeliner
-method KVStorage.Publish(ctx context.Context, channel string, message interface{}) error
-method KVStorage.SAdd(ctx context.Context, key string, members ...interface{}) error
-method KVStorage.SCard(ctx context.Context, key string) (int64, error)
-method KVStorage.SIsMember(ctx context.Context, key, member string) (bool, error)
-method KVStorage.SMembers(ctx context.Context, key string) ([]string, error)
-method KVStorage.SRem(ctx context.Context, key string, members ...interface{}) error
-method KVStorage.Set(ctx context.Context, key string, value interface{}) error
-method KVStorage.SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) (bool, error)
-method KVStorage.Subscribe(ctx context.Context, channels ...string) Subscription
-method KVStorage.TxPipelined(ctx context.Context, fn func(Pipeliner) error) error
-method KVStorage.ZAdd(ctx context.Context, key string, members ...*Z) error
-method KVStorage.ZCard(ctx context.Context, key string) (int64, error)
-method KVStorage.ZRange(ctx context.Context, key string, start, stop int64) ([]string, error)
-method KVStorage.ZRank(ctx context.Context, key, member string) (int64, error)
-method KVStorage.ZRem(ctx context.Context, key string, members ...interface{}) error
-method KVStorage.ZScore(ctx context.Context, key, member string) (float64, error)
 method Logger.Printf(format string, v ...interface{})
 method Logger.Println(v ...interface{})
-method Pipeliner.Del(ctx context.Context, keys ...string) error
-method Pipeliner.Exec(ctx context.Context) error
-method Pipeliner.HGetAll(ctx context.Context, key string) StringMapResult
-method Pipeliner.HSet(ctx context.Context, key string, values ...interface{}) error
-method Pipeliner.SAdd(ctx context.Context, key string, members ...interface{}) error
-method Pipeliner.ZAdd(ctx context.Context, key string, members ...*Z) error
-method StringMapResult.Val() map[string]string
-method Subscription.Channel() <-chan PubSubMessage
-method Subscription.Close() error
-method Subscription.Receive(ctx context.Context) error
 type AhoCorasick struct
 type AhoCorasickArgs struct
 type AhoCorasickInfo struct
@@ -187,7 +150,6 @@ type BatchOptions struct
 type BatchResult struct
 type CacheStats struct
 type ChunkBoundary int
-type KVStorage interface
 type KeywordError struct
 type Logger interface
 type Match struct
@@ -197,13 +159,8 @@ type MigrationOptions struct
 type MigrationResult struct
 type OperationError struct
 type ParallelOptions struct
-type Pipeliner interface
 type Preset int
-type PubSubMessage struct
 type RedisError struct
-type StringMapResult interface
-type Subscription interface
-type Z struct
 var ErrAlreadyV2
 var ErrCacheRequiresV2
 var ErrCacheWithPreset

--- a/changes/unreleased/Removed-20260807-160000.yaml
+++ b/changes/unreleased/Removed-20260807-160000.yaml
@@ -1,0 +1,5 @@
+kind: Removed
+body: 'Unexported the storage abstraction — `KVStorage`, `Pipeliner`, `Subscription`, `StringMapResult`, `PubSubMessage`, and `Z` — removing 43 of the 223 entries from the frozen v1 surface. Nothing public ever accepted or returned one, so no caller could supply an implementation: the interfaces could be named but not used. Freezing them would also have capped the pluggable-backend work they were exported for, because the compatibility policy forbids adding a method to an exported interface inside v1, and `KVStorage` has 23 of them. Unexported, the shape stays free until that feature can choose it, and publishing an interface later is an addition v1 allows. No behavior changed and the Redis backend is unaffected; for testing without Redis, use miniredis as ACOR''s own suite does.'
+time: 2026-08-07T16:00:00.000000+09:00
+custom:
+    Issue: "209"

--- a/docs/content/extending/_index.md
+++ b/docs/content/extending/_index.md
@@ -9,7 +9,7 @@ Extend ACOR with custom functionality.
 
 ## Sections
 
-- [Custom Storage](custom-storage/) - Implement custom storage backends
+- [Custom Storage](custom-storage/) - Why Redis is the only backend, and how to test without one
 
 ## Navigation
 

--- a/docs/content/extending/custom-storage.md
+++ b/docs/content/extending/custom-storage.md
@@ -5,213 +5,91 @@ weight: 1
 
 # Custom Storage
 
-`acor.KVStorage` abstracts ACOR's storage operations.
+**ACOR does not support custom storage backends.** Redis is the only backend, and
+`Create()` always builds it. This page explains why the interface you may have seen in
+older releases is gone, and what to do instead for the case it was usually reached for:
+testing.
 
-> **Not yet pluggable.** `Create()` always builds ACOR's built-in Redis storage;
-> there is currently no public constructor that accepts a custom `KVStorage`.
-> The interface is exported for mocking/testing, and pluggable backends are
-> planned for a future release. This page documents the interface you would
-> implement once that lands. For an in-memory Redis in tests today, use
-> miniredis (see below).
+## What changed in v1.5.0
 
-## Overview
+Through `v1.4.0` the package exported a `KVStorage` interface, along with `Pipeliner`,
+`Subscription`, `StringMapResult`, `PubSubMessage`, and `Z`. They were exported in
+anticipation of pluggable backends.
 
-ACOR uses the `KVStorage` interface to abstract storage operations. Once
-pluggable backends are supported, this abstraction will allow custom backends for:
+They are unexported as of `v1.5.0`, for two reasons:
 
-- In-memory storage (testing)
-- Alternative databases
-- Custom caching layers
+- **Nothing could be plugged in.** No public constructor accepted a `KVStorage`, and no
+  public function returned one. You could name the interface and write an
+  implementation, but there was no way to hand it to ACOR — so the capability the
+  interface implied never existed.
+- **Freezing it would have blocked the feature it was for.** The
+  [compatibility policy](../../reference/compatibility/) forbids adding a method to an
+  exported interface inside `v1`. `KVStorage` has 23 methods; had `v1.5.0` frozen it, a
+  future backend needing one more operation would have had nowhere to put it for the
+  rest of the `v1` line.
 
-## KVStorage Interface
+Leaving the shape unfrozen is what keeps pluggable storage possible. Publishing an
+interface later is an addition, which `v1` allows; growing a frozen one is not.
 
-```go
-type KVStorage interface {
-    Get(ctx context.Context, key string) (string, error)
-    Set(ctx context.Context, key string, value interface{}) error
-    HGetAll(ctx context.Context, key string) (map[string]string, error)
-    HSet(ctx context.Context, key string, values ...interface{}) error
-    SAdd(ctx context.Context, key string, members ...interface{}) error
-    SMembers(ctx context.Context, key string) ([]string, error)
-    SRem(ctx context.Context, key string, members ...interface{}) error
-    SCard(ctx context.Context, key string) (int64, error)
-    SIsMember(ctx context.Context, key, member string) (bool, error)
-    ZAdd(ctx context.Context, key string, members ...*Z) error
-    ZRange(ctx context.Context, key string, start, stop int64) ([]string, error)
-    ZRank(ctx context.Context, key, member string) (int64, error)
-    ZScore(ctx context.Context, key, member string) (float64, error)
-    ZCard(ctx context.Context, key string) (int64, error)
-    ZRem(ctx context.Context, key string, members ...interface{}) error
-    Del(ctx context.Context, keys ...string) error
-    Exists(ctx context.Context, keys ...string) (int64, error)
-    TxPipelined(ctx context.Context, fn func(Pipeliner) error) error
-    SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) (bool, error)
-    Pipeline() Pipeliner
-    Publish(ctx context.Context, channel string, message interface{}) error
-    Subscribe(ctx context.Context, channels ...string) Subscription
-    Close() error
-}
-```
+## Testing without Redis
 
-The `Z`, `Pipeliner`, `StringMapResult`, `Subscription`, and `PubSubMessage`
-types referenced above belong to the `acor` package (use `acor.KVStorage`,
-`acor.Z`, etc.) and are covered by the
-[compatibility policy](../../reference/compatibility/). They are documented in
-[Helper Types](#helper-types) below.
-
-## Example: In-Memory Storage
+This is what the interface was most often reached for, and it has a better answer that
+works today: [miniredis](https://github.com/alicebob/miniredis), an in-process
+Redis-compatible server. ACOR's own test suite uses it, so the behavior you test against
+is the behavior ACOR is tested against.
 
 ```go
-package main
+package example
 
 import (
-    "context"
-    "fmt"
-    "sync"
+    "testing"
 
+    "github.com/alicebob/miniredis/v2"
     "github.com/skyoo2003/acor/pkg/acor"
 )
 
-type MemoryStorage struct {
-    mu     sync.RWMutex
-    data   map[string]string
-    sets   map[string]map[string]struct{}
-    hashes map[string]map[string]string
-    zsets  map[string]map[string]float64
-}
-
-func NewMemoryStorage() *MemoryStorage {
-    return &MemoryStorage{
-        data:   make(map[string]string),
-        sets:   make(map[string]map[string]struct{}),
-        hashes: make(map[string]map[string]string),
-        zsets:  make(map[string]map[string]float64),
-    }
-}
-
-func (m *MemoryStorage) Get(ctx context.Context, key string) (string, error) {
-    m.mu.RLock()
-    defer m.mu.RUnlock()
-    return m.data[key], nil
-}
-
-func (m *MemoryStorage) Set(ctx context.Context, key string, value interface{}) error {
-    m.mu.Lock()
-    defer m.mu.Unlock()
-    s, ok := value.(string)
-    if !ok {
-        return fmt.Errorf("unsupported value type: %T", value)
-    }
-    m.data[key] = s
-    return nil
-}
-
-func (m *MemoryStorage) SAdd(ctx context.Context, key string, members ...interface{}) error {
-    m.mu.Lock()
-    defer m.mu.Unlock()
-    if m.sets[key] == nil {
-        m.sets[key] = make(map[string]struct{})
-    }
-    for _, member := range members {
-        s, ok := member.(string)
-        if !ok {
-            return fmt.Errorf("unsupported member type: %T", member)
-        }
-        m.sets[key][s] = struct{}{}
-    }
-    return nil
-}
-
-func (m *MemoryStorage) SMembers(ctx context.Context, key string) ([]string, error) {
-    m.mu.RLock()
-    defer m.mu.RUnlock()
-    var members []string
-    for member := range m.sets[key] {
-        members = append(members, member)
-    }
-    return members, nil
-}
-
-// Implement remaining methods...
-
-func (m *MemoryStorage) Close() error {
-    return nil
-}
-```
-
-## Using Custom Storage
-
-Currently, ACOR uses Redis internally. Custom storage support is planned for future releases.
-
-For testing, use miniredis which provides a Redis-compatible in-memory implementation:
-
-```go
-import (
-    "testing"
-    "github.com/alicebob/miniredis/v2"
-    "github.com/go-redis/redis/v8"
-)
-
 func TestWithMiniredis(t *testing.T) {
-    mr, err := miniredis.Run()
+    mr := miniredis.RunT(t)
+
+    ac, err := acor.Create(&acor.AhoCorasickArgs{
+        Addr: mr.Addr(),
+        Name: "test-collection",
+    })
     if err != nil {
         t.Fatal(err)
     }
-    defer mr.Close()
+    defer func() { _ = ac.Close() }()
 
-    client := redis.NewClient(&redis.Options{
-        Addr: mr.Addr(),
-    })
-    defer client.Close()
+    if _, err := ac.Add("hello"); err != nil {
+        t.Fatal(err)
+    }
 
-    // Use client with ACOR
+    matches, err := ac.Find("hello world")
+    if err != nil {
+        t.Fatal(err)
+    }
+    if len(matches) != 1 || matches[0] != "hello" {
+        t.Fatalf("Find() = %v, want [hello]", matches)
+    }
 }
 ```
 
-## Pipeliner Interface
+`miniredis` covers the commands ACOR issues, including the Lua scripts the V2 schema
+uses for atomic writes. To exercise Pub/Sub-driven cache invalidation across instances,
+point two instances at the same miniredis address.
 
-For transaction support, implement `Pipeliner`:
+## Reducing Redis traffic
 
-```go
-type Pipeliner interface {
-    SAdd(ctx context.Context, key string, members ...interface{}) error
-    HSet(ctx context.Context, key string, values ...interface{}) error
-    HGetAll(ctx context.Context, key string) StringMapResult
-    ZAdd(ctx context.Context, key string, members ...*Z) error
-    Del(ctx context.Context, keys ...string) error
-    Exec(ctx context.Context) error
-}
-```
+If the reason for a custom backend was to avoid Redis round trips on reads rather than
+to replace Redis, that is already available without one:
 
-## Helper Types
+- **`Preset`** serves reads from a local automaton and touches Redis only on writes and
+  invalidations. See [Presets](../../guides/presets/).
+- **`EnableCache`** caches trie data locally and invalidates over Pub/Sub.
 
-These types are referenced by `KVStorage` and `Pipeliner` and are declared in the
-`acor` package alongside it.
+`CacheStats()` reports whether either is working — hit rate, rebuild cost, and
+invalidation lag — without any Redis I/O of its own.
 
-`Z` — a sorted set member (score + value):
+## Navigation
 
-```go
-type Z struct {
-    Score  float64
-    Member string
-}
-```
-
-`StringMapResult` — a deferred result from a pipelined `HGetAll`; call `Val()`
-after the pipeline's `Exec`:
-
-```go
-type StringMapResult interface {
-    Val() map[string]string
-}
-```
-
-`Subscription` — a pub/sub subscription returned by `Subscribe`:
-
-```go
-type Subscription interface {
-    Receive(ctx context.Context) error
-    Channel() <-chan PubSubMessage
-    Close() error
-}
-```
+← [Extending](../)

--- a/docs/content/reference/compatibility.md
+++ b/docs/content/reference/compatibility.md
@@ -106,11 +106,17 @@ Their JSON field names are covered too. `api/v1.txt` records struct tags, so ren
 to marshaling a returned struct yourself; the `acor` command's own `--json` output is a
 CLI detail and stays uncovered.
 
-### Do not expect the exported interfaces to grow
+### Do not expect the exported interface to grow
 
-Five exported interfaces can be implemented from outside the module: `Logger`,
-`KVStorage`, `StringMapResult`, `Subscription`, and `Pipeliner`. No method is added to
-any of them inside `v1` — doing so would break every existing implementation.
+One exported interface can be implemented from outside the module: `Logger`. No method
+is added to it inside `v1` — doing so would break every existing implementation.
+
+`KVStorage`, `StringMapResult`, `Subscription`, and `Pipeliner` were exported through
+`v1.4.0` and are not part of the `v1.5.0` surface. Nothing public ever accepted or
+returned one, so no caller could supply an implementation; and freezing them would have
+capped the pluggable-storage work they existed for, since this very rule forbids adding
+a method to them later. They are unexported now so that feature can choose its own
+shape, which `v1` permits as an addition.
 
 ### Do not dot-import the package
 

--- a/pkg/acor/acor.go
+++ b/pkg/acor/acor.go
@@ -22,10 +22,9 @@
 // as documented. v1.5.0 is the first supported v1 release. Three conditions apply to
 // calling code: construct AhoCorasickArgs, MatchOptions, BatchOptions, ParallelOptions,
 // and MigrationOptions with field names, since those structs gain fields in minor
-// releases; do not expect Logger, KVStorage, StringMapResult, Subscription, or
-// Pipeliner to gain methods, since they will not inside v1; and do not dot-import this
-// package, since a name added in a minor release can then collide with a declaration of
-// your own.
+// releases; do not expect Logger — the one interface callers implement — to gain
+// methods, since it will not inside v1; and do not dot-import this package, since a
+// name added in a minor release can then collide with a declaration of your own.
 //
 // The full policy — including the on-Redis format rules that make mixed-version fleets
 // safe, and what the promise excludes — is at
@@ -339,7 +338,7 @@ type AhoCorasick struct {
 	cancel        context.CancelFunc
 	name          string
 	logger        Logger
-	storage       KVStorage             // DI: all Redis ops go through this
+	storage       kvStorage             // DI: all Redis ops go through this
 	ops           operations            // Strategy: V1 or V2 implementation
 	redisClient   redis.UniversalClient // kept for migration.go (out of scope)
 	buildTrieHook func(string) error
@@ -350,7 +349,7 @@ type AhoCorasick struct {
 
 	cache     *trieCache
 	stats     *cacheStats
-	pubsub    Subscription
+	pubsub    subscription
 	stopCh    chan struct{}
 	closeOnce sync.Once
 	mode      backendMode
@@ -582,7 +581,7 @@ func (ac *AhoCorasick) init(ctx context.Context) error {
 	}
 
 	prefixKey := prefixKey(ac.name)
-	member := &Z{
+	member := &zMember{
 		Score:  initScore,
 		Member: "",
 	}

--- a/pkg/acor/batch_atomic.go
+++ b/pkg/acor/batch_atomic.go
@@ -35,7 +35,7 @@ var (
 
 // applyManyAtomic runs the shared V2 snapshot-plan-CAS loop. afterCommit is used
 // by preset mode to install the committed snapshot in its local engine.
-func applyManyAtomic(ctx context.Context, storage KVStorage, client redis.UniversalClient, name string,
+func applyManyAtomic(ctx context.Context, storage kvStorage, client redis.UniversalClient, name string,
 	keywords []string, clearOutputs bool,
 	plan func(*trieSnapshot, []string) (map[string][]string, []string),
 	afterCommit func(*trieSnapshot, int64)) ([]string, error) {

--- a/pkg/acor/benchmark_real_server_test.go
+++ b/pkg/acor/benchmark_real_server_test.go
@@ -113,7 +113,7 @@ func BenchmarkRealServerAdd(b *testing.B) {
 }
 
 // TestRTTAgainstRealServer proves the round-trip counts are structural rather
-// than an artifact of miniredis. The counter wraps the KVStorage seam, which
+// than an artifact of miniredis. The counter wraps the kvStorage seam, which
 // sits above the wire, so a real server must produce the identical numbers
 // pinned in rtt_claims_test.go. If it ever doesn't, the backend is taking a
 // different code path and the published table describes only miniredis.

--- a/pkg/acor/godoc_claims_test.go
+++ b/pkg/acor/godoc_claims_test.go
@@ -222,18 +222,18 @@ func TestBatchModeZeroValueIsBestEffort(t *testing.T) {
 	}
 }
 
-// TestKVStorageIsNotInjectable pins the correction to the KVStorage godoc, which
+// TestKVStorageIsNotInjectable pins the correction to the kvStorage godoc, which
 // offered "mock implementations can be used for testing". Nothing on the public
 // surface accepts one, so that was a capability the package cannot deliver. The
-// assertion is structural: no AhoCorasickArgs field can carry a KVStorage in.
+// assertion is structural: no AhoCorasickArgs field can carry a kvStorage in.
 func TestKVStorageIsNotInjectable(t *testing.T) {
-	storage := reflect.TypeOf((*KVStorage)(nil)).Elem()
+	storage := reflect.TypeOf((*kvStorage)(nil)).Elem()
 	args := reflect.TypeOf(AhoCorasickArgs{})
 
 	for i := range args.NumField() {
 		f := args.Field(i)
 		if f.Type == storage || f.Type.Implements(storage) {
-			t.Errorf("AhoCorasickArgs.%s can carry a KVStorage; the godoc says one cannot be supplied, "+
+			t.Errorf("AhoCorasickArgs.%s can carry a kvStorage; the godoc says one cannot be supplied, "+
 				"so revisit both it and api/v1-audit.txt", f.Name)
 		}
 	}

--- a/pkg/acor/invalidation.go
+++ b/pkg/acor/invalidation.go
@@ -185,9 +185,9 @@ func foreignInvalidation(payload, name string, skip *selfSkipSet, stats *cacheSt
 // subscribeInvalidations subscribes to the collection's invalidation channel and
 // calls onMessage for every payload received, until stopCh is closed, ctx is
 // canceled, or the subscription channel closes. The caller closes the returned
-// Subscription to release the connection.
-func subscribeInvalidations(ctx context.Context, storage KVStorage, name string,
-	stopCh <-chan struct{}, onMessage func(payload string)) (Subscription, error) {
+// subscription to release the connection.
+func subscribeInvalidations(ctx context.Context, storage kvStorage, name string,
+	stopCh <-chan struct{}, onMessage func(payload string)) (subscription, error) {
 	pubsub := storage.Subscribe(ctx, invalidateChannelPrefix+name)
 	if err := pubsub.Receive(ctx); err != nil {
 		_ = pubsub.Close()

--- a/pkg/acor/invalidation_test.go
+++ b/pkg/acor/invalidation_test.go
@@ -55,29 +55,29 @@ func TestIsSelfEcho_RoundTripsGeneratedID(t *testing.T) {
 	}
 }
 
-// stubSubscription is a Subscription whose message channel the test drives.
+// stubSubscription is a subscription whose message channel the test drives.
 type stubSubscription struct {
-	msgCh      chan PubSubMessage
+	msgCh      chan pubSubMessage
 	receiveErr error
 	closed     chan struct{}
 }
 
 func newStubSubscription() *stubSubscription {
-	return &stubSubscription{msgCh: make(chan PubSubMessage), closed: make(chan struct{}, 1)}
+	return &stubSubscription{msgCh: make(chan pubSubMessage), closed: make(chan struct{}, 1)}
 }
 
 func (s *stubSubscription) Receive(context.Context) error { return s.receiveErr }
-func (s *stubSubscription) Channel() <-chan PubSubMessage { return s.msgCh }
+func (s *stubSubscription) Channel() <-chan pubSubMessage { return s.msgCh }
 func (s *stubSubscription) Close() error                  { s.closed <- struct{}{}; return nil }
 
 // stubSubStorage only supports Subscribe; the embedded nil interface panics if
 // subscribeInvalidations ever reaches for another method.
 type stubSubStorage struct {
-	KVStorage
-	sub Subscription
+	kvStorage
+	sub subscription
 }
 
-func (s stubSubStorage) Subscribe(context.Context, ...string) Subscription { return s.sub }
+func (s stubSubStorage) Subscribe(context.Context, ...string) subscription { return s.sub }
 
 func TestSubscribeInvalidations_DeliversPayloads(t *testing.T) {
 	sub := newStubSubscription()
@@ -89,12 +89,12 @@ func TestSubscribeInvalidations_DeliversPayloads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("subscribeInvalidations failed: %v", err)
 	}
-	// Closing the stub Subscription does not close its channel, so the listener
+	// Closing the stub subscription does not close its channel, so the listener
 	// goroutine only exits via stopCh.
 	t.Cleanup(func() { close(stopCh) })
 	defer func() { _ = pubsub.Close() }()
 
-	sub.msgCh <- PubSubMessage{Payload: "coll:msg-1"}
+	sub.msgCh <- pubSubMessage{Payload: "coll:msg-1"}
 
 	select {
 	case payload := <-got:
@@ -117,7 +117,7 @@ func TestSubscribeInvalidations_ReceiveErrorClosesSubscription(t *testing.T) {
 		t.Fatalf("got error %v, want %v", err, wantErr)
 	}
 	if pubsub != nil {
-		t.Error("expected nil Subscription on Receive error")
+		t.Error("expected nil subscription on Receive error")
 	}
 	select {
 	case <-sub.closed:
@@ -156,13 +156,13 @@ func TestSubscribeInvalidations_StopsOnContextCancel(t *testing.T) {
 // its unbuffered message channel only completes while it is still selecting.
 // A live goroutine may deliver one more message before it notices the stop
 // signal (select picks a ready case at random), so retry until a send blocks.
-func assertListenerStopped(t *testing.T, msgCh chan PubSubMessage) {
+func assertListenerStopped(t *testing.T, msgCh chan pubSubMessage) {
 	t.Helper()
 
 	const attempts = 20
 	for i := 0; i < attempts; i++ {
 		select {
-		case msgCh <- PubSubMessage{Payload: "coll:msg-1"}:
+		case msgCh <- pubSubMessage{Payload: "coll:msg-1"}:
 		case <-time.After(100 * time.Millisecond):
 			return
 		}

--- a/pkg/acor/redis_backed.go
+++ b/pkg/acor/redis_backed.go
@@ -30,7 +30,7 @@ type redisBackedAC struct {
 	caseSensitive bool
 	name          string
 
-	storage     KVStorage
+	storage     kvStorage
 	redisClient redis.UniversalClient
 
 	keywordSet   map[string]struct{}
@@ -42,7 +42,7 @@ type redisBackedAC struct {
 
 	selfSkip    selfSkipSet
 	reloadGroup singleflight.Group
-	pubsub      Subscription
+	pubsub      subscription
 	stopCh      chan struct{}
 	ctx         context.Context
 	cancel      context.CancelFunc

--- a/pkg/acor/redis_storage.go
+++ b/pkg/acor/redis_storage.go
@@ -14,8 +14,8 @@ type redisStorage struct {
 	client redis.UniversalClient
 }
 
-// newRedisStorage returns a KVStorage backed by the given Redis client.
-func newRedisStorage(client redis.UniversalClient) KVStorage {
+// newRedisStorage returns a kvStorage backed by the given Redis client.
+func newRedisStorage(client redis.UniversalClient) kvStorage {
 	return &redisStorage{client: client}
 }
 
@@ -55,7 +55,7 @@ func (s *redisStorage) SIsMember(ctx context.Context, key, member string) (bool,
 	return s.client.SIsMember(ctx, key, member).Result()
 }
 
-func (s *redisStorage) ZAdd(ctx context.Context, key string, members ...*Z) error {
+func (s *redisStorage) ZAdd(ctx context.Context, key string, members ...*zMember) error {
 	zMembers := make([]redis.Z, len(members))
 	for i, m := range members {
 		zMembers[i] = redis.Z{Score: m.Score, Member: m.Member}
@@ -91,7 +91,7 @@ func (s *redisStorage) Exists(ctx context.Context, keys ...string) (int64, error
 	return s.client.Exists(ctx, keys...).Result()
 }
 
-func (s *redisStorage) TxPipelined(ctx context.Context, fn func(Pipeliner) error) error {
+func (s *redisStorage) TxPipelined(ctx context.Context, fn func(pipeliner) error) error {
 	_, err := s.client.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
 		return fn(&redisPipeliner{pipe: pipe})
 	})
@@ -102,7 +102,7 @@ func (s *redisStorage) SetNX(ctx context.Context, key string, value interface{},
 	return s.client.SetNX(ctx, key, value, expiration).Result()
 }
 
-func (s *redisStorage) Pipeline() Pipeliner {
+func (s *redisStorage) Pipeline() pipeliner {
 	return &redisPipeliner{pipe: s.client.Pipeline()}
 }
 
@@ -110,7 +110,7 @@ func (s *redisStorage) Publish(ctx context.Context, channel string, message inte
 	return s.client.Publish(ctx, channel, message).Err()
 }
 
-func (s *redisStorage) Subscribe(ctx context.Context, channels ...string) Subscription {
+func (s *redisStorage) Subscribe(ctx context.Context, channels ...string) subscription {
 	return &redisSubscription{pubsub: s.client.Subscribe(ctx, channels...), done: make(chan struct{})}
 }
 
@@ -128,7 +128,7 @@ func (r *redisStringMapResult) Val() map[string]string {
 
 type redisSubscription struct {
 	pubsub    *redis.PubSub
-	ch        chan PubSubMessage
+	ch        chan pubSubMessage
 	once      sync.Once
 	done      chan struct{}
 	closeOnce sync.Once
@@ -141,9 +141,9 @@ func (s *redisSubscription) Receive(ctx context.Context) error {
 
 const pubsubChannelSize = 100
 
-func (s *redisSubscription) Channel() <-chan PubSubMessage {
+func (s *redisSubscription) Channel() <-chan pubSubMessage {
 	s.once.Do(func() {
-		ch := make(chan PubSubMessage, pubsubChannelSize)
+		ch := make(chan pubSubMessage, pubsubChannelSize)
 		src := s.pubsub.Channel()
 		go func() {
 			defer close(ch)
@@ -156,7 +156,7 @@ func (s *redisSubscription) Channel() <-chan PubSubMessage {
 						return
 					}
 					select {
-					case ch <- PubSubMessage{Channel: msg.Channel, Payload: msg.Payload}:
+					case ch <- pubSubMessage{Channel: msg.Channel, Payload: msg.Payload}:
 					case <-s.done:
 						return
 					}
@@ -190,7 +190,7 @@ func (p *redisPipeliner) HSet(ctx context.Context, key string, values ...interfa
 	return p.pipe.HSet(ctx, key, values...).Err()
 }
 
-func (p *redisPipeliner) ZAdd(ctx context.Context, key string, members ...*Z) error {
+func (p *redisPipeliner) ZAdd(ctx context.Context, key string, members ...*zMember) error {
 	zMembers := make([]redis.Z, len(members))
 	for i, m := range members {
 		zMembers[i] = redis.Z{Score: m.Score, Member: m.Member}
@@ -202,7 +202,7 @@ func (p *redisPipeliner) Del(ctx context.Context, keys ...string) error {
 	return p.pipe.Del(ctx, keys...).Err()
 }
 
-func (p *redisPipeliner) HGetAll(ctx context.Context, key string) StringMapResult {
+func (p *redisPipeliner) HGetAll(ctx context.Context, key string) stringMapResult {
 	return &redisStringMapResult{cmd: p.pipe.HGetAll(ctx, key)}
 }
 

--- a/pkg/acor/redis_storage_extras_test.go
+++ b/pkg/acor/redis_storage_extras_test.go
@@ -194,7 +194,7 @@ func TestRedisPipelinerZAdd(t *testing.T) {
 	store := newRedisStorage(client)
 
 	pipe := store.Pipeline()
-	if err := pipe.ZAdd(ctx, "myzset", &Z{Score: 1.0, Member: "a"}, &Z{Score: 2.0, Member: "b"}); err != nil {
+	if err := pipe.ZAdd(ctx, "myzset", &zMember{Score: 1.0, Member: "a"}, &zMember{Score: 2.0, Member: "b"}); err != nil {
 		t.Fatalf("pipeliner.ZAdd() error: %v", err)
 	}
 	if err := pipe.Exec(ctx); err != nil {
@@ -220,7 +220,7 @@ func TestRedisStorageTxPipelined(t *testing.T) {
 	ctx := context.Background()
 	store := newRedisStorage(client)
 
-	err := store.TxPipelined(ctx, func(pipe Pipeliner) error {
+	err := store.TxPipelined(ctx, func(pipe pipeliner) error {
 		if err := pipe.SAdd(ctx, "txset", "a", "b"); err != nil {
 			return err
 		}
@@ -356,7 +356,7 @@ func TestRedisStorageZOperations(t *testing.T) {
 	ctx := context.Background()
 	store := newRedisStorage(client)
 
-	if err := store.ZAdd(ctx, "zset", &Z{Score: 1.0, Member: "a"}, &Z{Score: 2.0, Member: "b"}); err != nil {
+	if err := store.ZAdd(ctx, "zset", &zMember{Score: 1.0, Member: "a"}, &zMember{Score: 2.0, Member: "b"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/acor/redis_storage_test.go
+++ b/pkg/acor/redis_storage_test.go
@@ -70,7 +70,7 @@ func TestRedisStorageOperations(t *testing.T) {
 	})
 
 	t.Run("ZAdd and ZRange", func(t *testing.T) {
-		err := storage.ZAdd(ctx, "zset", &Z{Score: 1.0, Member: "a"}, &Z{Score: 2.0, Member: "b"})
+		err := storage.ZAdd(ctx, "zset", &zMember{Score: 1.0, Member: "a"}, &zMember{Score: 2.0, Member: "b"})
 		if err != nil {
 			t.Fatalf("ZAdd() error = %v", err)
 		}

--- a/pkg/acor/rtt_claims_test.go
+++ b/pkg/acor/rtt_claims_test.go
@@ -30,7 +30,7 @@ func TestRTTCounterCountsPipelineAsOneRoundTrip(t *testing.T) {
 	c := countRTT(t, ac)
 	c.reset()
 
-	err := ac.storage.TxPipelined(ac.ctx, func(pipe Pipeliner) error {
+	err := ac.storage.TxPipelined(ac.ctx, func(pipe pipeliner) error {
 		pipe.HSet(ac.ctx, "rtt-guard", "a", "1")
 		pipe.HSet(ac.ctx, "rtt-guard", "b", "2")
 		pipe.HSet(ac.ctx, "rtt-guard", "c", "3")

--- a/pkg/acor/rtt_counter_test.go
+++ b/pkg/acor/rtt_counter_test.go
@@ -13,11 +13,11 @@ import (
 // docs/content/reference/benchmarks.md.
 //
 // This counts *round trips*, not commands. A pipeline carrying N commands is
-// one round trip, so TxPipelined and Pipeliner.Exec each add 1 regardless of
+// one round trip, so TxPipelined and pipeliner.Exec each add 1 regardless of
 // how many commands were queued. Counting commands instead would inflate every
 // published number in the direction that flatters us.
 //
-// Counting is backend-independent: it wraps the KVStorage seam, not the wire,
+// Counting is backend-independent: it wraps the kvStorage seam, not the wire,
 // so miniredis and a real server must report identical counts. That is what
 // makes these claims structural rather than incidental to a benchmark host.
 
@@ -42,7 +42,7 @@ func (c *rttCounter) reset()     { c.n.Store(0) }
 func countRTT(tb testing.TB, ac *AhoCorasick) *rttCounter {
 	tb.Helper()
 	c := &rttCounter{}
-	wrap := func(s KVStorage) KVStorage {
+	wrap := func(s kvStorage) kvStorage {
 		if s == nil {
 			return nil
 		}
@@ -75,11 +75,11 @@ func countRTT(tb testing.TB, ac *AhoCorasick) *rttCounter {
 
 // countingStorage counts one round trip per storage call.
 //
-// Every method is implemented explicitly rather than embedding KVStorage: if
+// Every method is implemented explicitly rather than embedding kvStorage: if
 // the interface gains a method, this fails to compile instead of quietly
 // passing the new call through uncounted.
 type countingStorage struct {
-	inner KVStorage
+	inner kvStorage
 	c     *rttCounter
 }
 
@@ -128,7 +128,7 @@ func (s *countingStorage) SIsMember(ctx context.Context, key, member string) (bo
 	return s.inner.SIsMember(ctx, key, member)
 }
 
-func (s *countingStorage) ZAdd(ctx context.Context, key string, members ...*Z) error {
+func (s *countingStorage) ZAdd(ctx context.Context, key string, members ...*zMember) error {
 	s.c.add()
 	return s.inner.ZAdd(ctx, key, members...)
 }
@@ -170,7 +170,7 @@ func (s *countingStorage) Exists(ctx context.Context, keys ...string) (int64, er
 
 // TxPipelined is one round trip for the whole transaction, however many
 // commands the callback queues.
-func (s *countingStorage) TxPipelined(ctx context.Context, fn func(Pipeliner) error) error {
+func (s *countingStorage) TxPipelined(ctx context.Context, fn func(pipeliner) error) error {
 	s.c.add()
 	return s.inner.TxPipelined(ctx, fn)
 }
@@ -182,7 +182,7 @@ func (s *countingStorage) SetNX(ctx context.Context, key string, value interface
 
 // Pipeline buffers locally and costs nothing until Exec, which is where the
 // round trip is counted.
-func (s *countingStorage) Pipeline() Pipeliner {
+func (s *countingStorage) Pipeline() pipeliner {
 	return &countingPipeliner{inner: s.inner.Pipeline(), c: s.c}
 }
 
@@ -191,7 +191,7 @@ func (s *countingStorage) Publish(ctx context.Context, channel string, message i
 	return s.inner.Publish(ctx, channel, message)
 }
 
-func (s *countingStorage) Subscribe(ctx context.Context, channels ...string) Subscription {
+func (s *countingStorage) Subscribe(ctx context.Context, channels ...string) subscription {
 	s.c.add()
 	return s.inner.Subscribe(ctx, channels...)
 }
@@ -202,7 +202,7 @@ func (s *countingStorage) Close() error { return s.inner.Close() }
 // countingPipeliner counts the single round trip that Exec performs. Queuing
 // commands costs nothing.
 type countingPipeliner struct {
-	inner Pipeliner
+	inner pipeliner
 	c     *rttCounter
 }
 
@@ -214,11 +214,11 @@ func (p *countingPipeliner) HSet(ctx context.Context, key string, values ...inte
 	return p.inner.HSet(ctx, key, values...)
 }
 
-func (p *countingPipeliner) HGetAll(ctx context.Context, key string) StringMapResult {
+func (p *countingPipeliner) HGetAll(ctx context.Context, key string) stringMapResult {
 	return p.inner.HGetAll(ctx, key)
 }
 
-func (p *countingPipeliner) ZAdd(ctx context.Context, key string, members ...*Z) error {
+func (p *countingPipeliner) ZAdd(ctx context.Context, key string, members ...*zMember) error {
 	return p.inner.ZAdd(ctx, key, members...)
 }
 
@@ -233,6 +233,6 @@ func (p *countingPipeliner) Exec(ctx context.Context) error {
 
 // Compile-time proof the wrappers still satisfy the interfaces they stand in for.
 var (
-	_ KVStorage = (*countingStorage)(nil)
-	_ Pipeliner = (*countingPipeliner)(nil)
+	_ kvStorage = (*countingStorage)(nil)
+	_ pipeliner = (*countingPipeliner)(nil)
 )

--- a/pkg/acor/storage.go
+++ b/pkg/acor/storage.go
@@ -7,26 +7,29 @@ import (
 	"time"
 )
 
-// Z represents a sorted set member with score, compatible with Redis ZSET operations.
-type Z struct {
+// zMember represents a sorted set member with score, compatible with Redis ZSET operations.
+type zMember struct {
 	// Score is the numeric score for ordering in the sorted set.
 	Score float64
 	// Member is the string value stored in the sorted set.
 	Member string
 }
 
-// KVStorage defines the interface for key-value storage operations. It lets the
+// kvStorage defines the interface for key-value storage operations. It lets the
 // Aho-Corasick automaton work against a storage abstraction rather than a Redis
 // client directly.
 //
-// Nothing on the public surface accepts or returns a KVStorage: the Redis-backed
-// implementation is the only one, and this package constructs it internally from
-// AhoCorasickArgs. An alternative implementation therefore cannot be supplied to
-// Create. The interface is exported so the contract the automaton relies on is
-// documented and frozen for v1, not so it can be substituted.
+// It is unexported deliberately. It was public through v1.4.0 and was withdrawn
+// before v1.5.0 froze the surface, because nothing on that surface ever accepted
+// or returned one: a caller could name the interface but never supply an
+// implementation. Freezing it would also have capped the pluggable-backend work it
+// was exported for — compatibility.md forbids adding a method to an exported
+// interface inside v1, so a backend needing one more operation would have had
+// nowhere to put it. Unexported, the shape stays free until that feature can
+// choose it, and publishing an interface later is an addition v1 allows.
 //
 // All operations accept a context for cancellation and timeout support.
-type KVStorage interface {
+type kvStorage interface {
 	// Get retrieves a string value by key. Returns redis.Nil error if key doesn't exist.
 	Get(ctx context.Context, key string) (string, error)
 	// Set stores a value at the given key with no expiration.
@@ -46,7 +49,7 @@ type KVStorage interface {
 	// SIsMember checks if a member exists in a set.
 	SIsMember(ctx context.Context, key, member string) (bool, error)
 	// ZAdd adds members with scores to a sorted set.
-	ZAdd(ctx context.Context, key string, members ...*Z) error
+	ZAdd(ctx context.Context, key string, members ...*zMember) error
 	// ZRange returns members in a sorted set by index range.
 	ZRange(ctx context.Context, key string, start, stop int64) ([]string, error)
 	// ZRank returns the index of a member in a sorted set.
@@ -62,57 +65,58 @@ type KVStorage interface {
 	// Exists checks if one or more keys exist. Returns the count of existing keys.
 	Exists(ctx context.Context, keys ...string) (int64, error)
 	// TxPipelined executes commands in a transaction pipeline.
-	TxPipelined(ctx context.Context, fn func(Pipeliner) error) error
+	TxPipelined(ctx context.Context, fn func(pipeliner) error) error
 	// SetNX sets a value only if the key does not exist. Returns true if the key was set.
 	SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) (bool, error)
 	// Pipeline returns a non-transactional pipeline for batching commands.
-	Pipeline() Pipeliner
+	Pipeline() pipeliner
 	// Publish sends a message to a pub/sub channel.
 	Publish(ctx context.Context, channel string, message interface{}) error
-	// Subscribe subscribes to pub/sub channels and returns a Subscription.
-	Subscribe(ctx context.Context, channels ...string) Subscription
+	// Subscribe subscribes to pub/sub channels and returns a subscription.
+	Subscribe(ctx context.Context, channels ...string) subscription
 	// Close closes the storage connection.
 	Close() error
 }
 
-// StringMapResult represents a deferred string map result from a pipeline
-// HGetAll operation. Exposed as an interface so custom Pipeliner backends can
-// return their own deferred result type.
-type StringMapResult interface {
+// stringMapResult represents a deferred string map result from a pipeline
+// HGetAll operation. An interface rather than a concrete type so a pipeliner
+// implementation can return its own deferred result; see kvStorage on why none
+// but the Redis one exists today.
+type stringMapResult interface {
 	// Val returns the map result. Must be called after Exec on the pipeline.
 	Val() map[string]string
 }
 
-// PubSubMessage represents a message received from a pub/sub subscription.
-type PubSubMessage struct {
+// pubSubMessage represents a message received from a pub/sub subscription.
+type pubSubMessage struct {
 	// Channel is the name of the pub/sub channel the message was published to.
 	Channel string
 	// Payload is the content of the message.
 	Payload string
 }
 
-// Subscription defines the interface for a pub/sub subscription.
-type Subscription interface {
+// subscription defines the interface for a pub/sub subscription.
+type subscription interface {
 	// Receive waits for a subscription confirmation from the server.
 	Receive(ctx context.Context) error
 	// Channel returns a channel that delivers incoming messages.
-	Channel() <-chan PubSubMessage
+	Channel() <-chan pubSubMessage
 	// Close closes the subscription and releases resources.
 	Close() error
 }
 
-// Pipeliner defines the interface for pipelined Redis operations.
+// pipeliner defines the interface for pipelined Redis operations.
 // Commands are buffered and sent together for efficiency.
-type Pipeliner interface {
+type pipeliner interface {
 	// SAdd adds members to a set in the pipeline.
 	SAdd(ctx context.Context, key string, members ...interface{}) error
 	// HSet sets hash fields in the pipeline.
 	HSet(ctx context.Context, key string, values ...interface{}) error
 	// HGetAll retrieves all field-value pairs from a hash in the pipeline.
 	// Returns a deferred result that can be read after Exec is called.
-	HGetAll(ctx context.Context, key string) StringMapResult
+	HGetAll(ctx context.Context, key string) stringMapResult
 	// ZAdd adds sorted set members in the pipeline.
-	ZAdd(ctx context.Context, key string, members ...*Z) error
+	ZAdd(ctx context.Context, key string, members ...*zMember) error
 	// Del deletes keys in the pipeline.
 	Del(ctx context.Context, keys ...string) error
 	// Exec executes all commands in the pipeline.

--- a/pkg/acor/topology_test.go
+++ b/pkg/acor/topology_test.go
@@ -236,7 +236,7 @@ func TestStorageAdapterMethods(t *testing.T) {
 	})
 
 	t.Run("ZAdd", func(t *testing.T) {
-		if err := storage.ZAdd(ctx, "zset2", &Z{Score: 1.0, Member: "a"}); err != nil {
+		if err := storage.ZAdd(ctx, "zset2", &zMember{Score: 1.0, Member: "a"}); err != nil {
 			t.Errorf("ZAdd() error: %v", err)
 		}
 	})
@@ -289,10 +289,10 @@ func TestStorageAdapterMethods(t *testing.T) {
 	})
 
 	t.Run("TxPipelined", func(t *testing.T) {
-		err := storage.TxPipelined(ctx, func(pipe Pipeliner) error {
+		err := storage.TxPipelined(ctx, func(pipe pipeliner) error {
 			_ = pipe.SAdd(ctx, "txset", "member")
 			_ = pipe.HSet(ctx, "txhash", "field", "value")
-			_ = pipe.ZAdd(ctx, "txzset", &Z{Score: 1.0, Member: "a"})
+			_ = pipe.ZAdd(ctx, "txzset", &zMember{Score: 1.0, Member: "a"})
 			return nil
 		})
 		if err != nil {

--- a/pkg/acor/trie.go
+++ b/pkg/acor/trie.go
@@ -66,9 +66,9 @@ func (ac *AhoCorasick) buildTrieWithContext(ctx context.Context, keyword string)
 		_, err := ac.storage.ZScore(ctx, pKey, prefix)
 		if err == redis.Nil {
 			sKey := suffixKey(ac.name)
-			pMember := &Z{Score: memberScore, Member: prefix}
-			sMember := &Z{Score: memberScore, Member: suffix}
-			if pipeErr := ac.storage.TxPipelined(ctx, func(pipe Pipeliner) error {
+			pMember := &zMember{Score: memberScore, Member: prefix}
+			sMember := &zMember{Score: memberScore, Member: suffix}
+			if pipeErr := ac.storage.TxPipelined(ctx, func(pipe pipeliner) error {
 				_ = pipe.ZAdd(ctx, pKey, pMember)
 				_ = pipe.ZAdd(ctx, sKey, sMember)
 				return nil
@@ -173,7 +173,7 @@ func (ac *AhoCorasick) buildOutputWithContext(ctx context.Context, state string)
 		for i, v := range outputs {
 			args[i] = v
 		}
-		if pipeErr := ac.storage.TxPipelined(ctx, func(pipe Pipeliner) error {
+		if pipeErr := ac.storage.TxPipelined(ctx, func(pipe pipeliner) error {
 			_ = pipe.SAdd(ctx, oKey, args...)
 			for _, output := range outputs {
 				nKey := nodeKey(ac.name, output)

--- a/pkg/acor/v1_ops.go
+++ b/pkg/acor/v1_ops.go
@@ -23,7 +23,7 @@ var _ operations = (*v1Operations)(nil)
 // gotoNode, failNode, collectOutputs, appendMatchedIndexes) which are methods
 // on *AhoCorasick. This is a temporary bridge until trie.go is refactored in T15.
 type v1Operations struct {
-	storage         KVStorage
+	storage         kvStorage
 	name            string
 	logger          Logger
 	ac              *AhoCorasick // for trie.go helper access (temporary, cleaned up in T15)

--- a/pkg/acor/v2_ops.go
+++ b/pkg/acor/v2_ops.go
@@ -24,7 +24,7 @@ var _ operations = (*v2Operations)(nil)
 // It holds all dependencies needed for V2 Aho-Corasick operations without
 // depending directly on the AhoCorasick struct.
 type v2Operations struct {
-	storage       KVStorage
+	storage       kvStorage
 	client        redis.UniversalClient
 	name          string
 	cache         *trieCache

--- a/pkg/acor/v2_transaction.go
+++ b/pkg/acor/v2_transaction.go
@@ -54,7 +54,7 @@ type trieSnapshot struct {
 }
 
 // readTrieSnapshot loads and deserializes the trie hash from Redis.
-func readTrieSnapshot(ctx context.Context, storage KVStorage, name string) (*trieSnapshot, error) {
+func readTrieSnapshot(ctx context.Context, storage kvStorage, name string) (*trieSnapshot, error) {
 	trieData, err := storage.HGetAll(ctx, trieKey(name))
 	if err != nil {
 		return nil, newRedisError("HGETALL", trieKey(name), err)
@@ -159,9 +159,9 @@ func commitV2Write(ctx context.Context, client redis.UniversalClient, name strin
 //
 // Shared by both V2 write paths, which differ only in the local state they reset
 // afterwards.
-func flushV2Keys(ctx context.Context, storage KVStorage, name string) error {
+func flushV2Keys(ctx context.Context, storage kvStorage, name string) error {
 	tKey := trieKey(name)
-	err := storage.TxPipelined(ctx, func(pipe Pipeliner) error {
+	err := storage.TxPipelined(ctx, func(pipe pipeliner) error {
 		// nodesKey is only written during migration; including it here ensures a clean state.
 		if err := pipe.Del(ctx, outputsKey(name), nodesKey(name), tKey); err != nil {
 			return err


### PR DESCRIPTION
## Description

The milestone-3 audit (#208) raised exactly one `risk` verdict. This resolves it by removing the entries rather than freezing them.

**43 of the 223 frozen entries go:** `KVStorage` and its 23 methods, `Pipeliner` (6), `Subscription` (3), `StringMapResult` (1), and `PubSubMessage`/`Z` with their 4 fields. The surface goes **223 → 180**.

### Two reasons, and the second decides it

**1. Nothing could be plugged in.** No exported function accepts a `KVStorage` and none returns one — checked against every line of `api/v1.txt`. A caller could name the interface and write an implementation, but had no way to hand it to ACOR. The capability it implied never existed, which is what the audit caught in its godoc: *"mock implementations can be used for testing"*.

**2. Freezing it would have blocked the feature it was for.** This is the part that changed my mind about the right fix.

`docs/content/extending/custom-storage.md` was explicit that this was a forward commitment:

> The interface is exported for mocking/testing, and **pluggable backends are planned for a future release.** This page documents the interface you would implement once that lands.

But `compatibility.md` says:

> No method is added to any of them inside `v1` — doing so would break every existing implementation.

`KVStorage` has **23 methods**. Had `v1.5.0` frozen it, a future backend needing one more operation would have had nowhere to put it for the rest of the `v1` line. **The export intended to enable pluggable storage would have been the thing preventing it.**

Unexported, the shape stays free until that work can choose it — and publishing an interface later is an *addition*, which `v1` permits. So this is not a retreat from pluggable storage; it is the only move that keeps it available.

### Scope

Renames are mechanical, and `redis.Z`/`redis.Pipeliner` are untouched:

| was | now |
|---|---|
| `KVStorage` | `kvStorage` |
| `Pipeliner` | `pipeliner` |
| `Subscription` | `subscription` |
| `StringMapResult` | `stringMapResult` |
| `PubSubMessage` | `pubSubMessage` |
| `Z` | `zMember` |

`Z` gets a real name now that it no longer has to be terse for callers.

**No behavior changed.** No Go code outside `pkg/acor` referenced any of these — verified across `server/`, `cmd/`, `benchmarks/`, and `examples/`. The suite and the separate `server/` module both pass unmodified, which is the check for a rename that is supposed to be invisible.

### Docs that taught the dead end change with it

- **`custom-storage.md`** rewritten: why Redis is the only backend, then miniredis for the case the interface was usually reached for (testing), and `Preset`/`EnableCache` for the case it was reached for to avoid round trips. Rewritten rather than deleted so `_index.md`'s link does not dangle.
- **`compatibility.md`**: "Five exported interfaces" is now one, `Logger`, with the removal and its reasoning recorded.

### Audit record

`api/v1-audit.txt` drops the 43 verdicts along with the entries:

```
before:  audit 155/223 entries — 142 ok, 12 fixed, 1 risk, 68 unaudited
after:   audit 112/180 entries — 100 ok, 12 fixed, 0 risk, 68 unaudited
```

Every still-unaudited entry is untouched by this change, so the remaining audit work is unaffected.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change — in principle: 43 identifiers leave the surface. In practice nothing could use them, and `v1.0.0`–`v1.4.0` (where they were public) is retracted. `v1.5.0` is unpublished, so nothing supported breaks.
- [x] Documentation update
- [x] Refactoring (no functional changes)

## Checklist

- [x] Tests pass (`make test`) — plus `make race` and the `server/` module
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed — `custom-storage.md`, `compatibility.md`, `_index.md`, package doc
- [x] Changelog fragment added (`changie new`) — `Removed`
- [x] Commit messages follow guidelines

Also green: `make docs-verify` (18 blocks), `make license-check`, `make api-check`.

## Additional Notes

**This is the last moment this is possible.** After the `v1.5.0` tag, removing these needs a `/v2`; the only remaining option would be to keep them frozen and unusable for the life of `v1`.

**What is not decided here.** Nothing about whether or when pluggable storage lands, or what its public shape should be. That is deliberately left open — the point of the change.

**Remaining audit work is unaffected**: 68 entries still `unaudited` (migration, preset, schema, batch methods, and the go-redis passthrough configuration docs). `unaudited` is a legal verdict, so that can be finished without re-deriving the record.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).