### PR TITLE
ci: fail when a pkg/acor function sits at 0.0% coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,23 @@ jobs:
             awk -v c="$coverage" 'BEGIN { exit (c < 70) ? 1 : 0 }' \
               || { echo "::error::${mod} coverage ${coverage}% is below threshold 70%"; fail=1; }
           done
+          # A percentage cannot see a function nothing calls: pkg/acor was 89% green
+          # while four functions sat at exactly 0.0%. Reading them turned up one of
+          # each failure shape — rollbackRemoved was live error-recovery code no test
+          # drove, and the deferred-batch trio was unreachable from any configuration.
+          # Both are worse to discover after v1 freezes, so this is a gate rather than
+          # a measurement someone remembers to take.
+          #
+          # Scoped to pkg/acor by path prefix, and the prefix is load-bearing: the
+          # profile is built with -coverpkg=./..., so examples/, cmd/ and tools/ are
+          # in it and legitimately carry 0.0% functions.
+          uncovered=$(go tool cover -func=coverage.nogen.out \
+            | awk '$1 ~ /^github\.com\/skyoo2003\/acor\/pkg\/acor\// && $3 == "0.0%"')
+          if [ -n "$uncovered" ]; then
+            echo "$uncovered"
+            echo "::error::pkg/acor has functions at 0.0% coverage. Cover them, or delete them if nothing can reach them."
+            fail=1
+          fi
           exit $fail
       - name: Run fuzz testing
         if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.26'


### PR DESCRIPTION
## Description

A percentage cannot see a function nothing calls. `pkg/acor` was 89% green while four functions sat at exactly **0.0%**, and reading them turned up one of each failure shape:

- `rollbackRemoved` — live error-recovery code that no test drove
- `addDeferred` / `commitBatch` / `removeDeferred` — unreachable from any configuration, since deleted in #207

Both shapes get worse once `v1` freezes: an untested error path ships unexercised, and dead code becomes permanent. The existing threshold check cannot catch either, so this asserts the count directly instead of leaving it to a measurement someone remembers to take before a release.

This closes the last gap in the `v1.5.0` readiness criteria. Two of the three checkable criteria were already commands that fail — `go test -run RTT` in the integration matrix, and `make api-check` for the godoc audit record. The zero-coverage criterion was the only one still held by a number someone had written down.

## Implementation notes

- **Scoped to `pkg/acor` by path prefix, and the prefix is load-bearing.** The profile is built with `-coverpkg=./...`, so `examples/`, `cmd/` and `tools/` are in it and legitimately carry 0.0% functions — 20 of them today. An unscoped check would fail immediately.
- **No extra test run.** Reuses the `coverage.nogen.out` the threshold check already produces, in the same step, on the same single matrix leg.
- **Verified to fire**, not just to pass: adding an uncalled function to `pkg/acor` makes the step fail naming that function and line; removing it returns the count to 0.

## Type of Change

- [x] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [ ] Documentation updated if needed — n/a
- [x] Changelog fragment added — **skipped, internal-only (CI)**, per the template and RELEASE.md
- [x] Commit messages follow guidelines