### PR TITLE
refactor: drop the unreachable kvStorage Get/Set/SetNX seam methods

### DIFF
--- a/changes/unreleased/Changed-20260809-130000.yaml
+++ b/changes/unreleased/Changed-20260809-130000.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: 'Dropped three unreachable methods from the internal `kvStorage` seam — `Get`, `Set`, and `SetNX` — along with their `redisStorage` implementations. No production path called any of them: `MigrateV1ToV2` takes its lock through `redisClient.SetNX` directly, so the seam''s copy was never on a code path, and `Get`/`Set` only ever appeared in tests exercising themselves. The tests that used them as fixture setup now write through the go-redis client they already hold, so what they assert (`Del`, `Exists`) is unchanged. `kvStorage` is unexported and was withdrawn from the public surface before v1.5.0 froze it, so `api/v1.txt` is untouched. Also moved `stringRuneSource` into the engine test file that is its only caller, and replaced the deprecated `sort.Ints`/`sort.Strings`/`sort.Slice` with `slices.Sort`/`slices.SortFunc`; the generated `api/v1.txt` and `NOTICE` come back byte-identical.'
+time: 2026-08-09T13:00:00.000000+09:00
+custom:
+    Issue: "220"

--- a/internal/engine/engine_handle.go
+++ b/internal/engine/engine_handle.go
@@ -2,10 +2,6 @@
 
 package engine
 
-import (
-	"strings"
-)
-
 // container is the optional specialization behind Engine.Contains. Routing a
 // presence check through matchString was the most expensive of the cheap
 // operations: it missed the byte-scan fast path on ASCII text and reported a match
@@ -95,22 +91,6 @@ func (e *Engine) FindSet(text string) []string {
 // It lets callers scan an io.Reader without materializing the whole input.
 func (e *Engine) Stream(next func() (rune, bool), emit func(keyword string, start, end int) bool) {
 	e.impl.matchStream(next, emit)
-}
-
-// stringRuneSource adapts a string to the rune-pull source matchStream expects.
-// strings.Reader.ReadRune decodes exactly like a range loop (invalid UTF-8 yields
-// RuneError), which makes it useful for testing Stream against a string. The match
-// entry points no longer route through it: that indirect call per rune is what
-// matchString exists to avoid.
-func stringRuneSource(s string) func() (rune, bool) {
-	rd := strings.NewReader(s)
-	return func() (rune, bool) {
-		r, _, err := rd.ReadRune()
-		if err != nil {
-			return 0, false
-		}
-		return r, true
-	}
 }
 
 // Info returns statistics about the built automaton.

--- a/internal/engine/engine_matches_test.go
+++ b/internal/engine/engine_matches_test.go
@@ -11,6 +11,22 @@ import (
 	"unicode/utf8"
 )
 
+// stringRuneSource adapts a string to the rune-pull source matchStream expects.
+// strings.Reader.ReadRune decodes exactly like a range loop (invalid UTF-8 yields
+// RuneError), which makes it useful for testing Stream against a string. The match
+// entry points deliberately do not route through it: that indirect call per rune is
+// what matchString exists to avoid, so it lives here rather than beside Engine.
+func stringRuneSource(s string) func() (rune, bool) {
+	rd := strings.NewReader(s)
+	return func() (rune, bool) {
+		r, _, err := rd.ReadRune()
+		if err != nil {
+			return 0, false
+		}
+		return r, true
+	}
+}
+
 // match is the test's own record of what MatchString emitted. The engine reports a
 // keyword and its span as arguments and declares no match type of its own — that
 // type belongs to the public acor package.

--- a/internal/engine/engine_presets.go
+++ b/internal/engine/engine_presets.go
@@ -14,6 +14,9 @@ func newMatchEngine(preset Preset) matchEngine {
 		return newSpeedEngine()
 	case PresetMemoryEfficient:
 		return newMemEfficientEngine()
+	// Listed explicitly rather than folded into default: the exhaustive linter
+	// requires every Preset value to appear. default then covers only values no
+	// Preset constant names, for which Balanced is the documented fallback.
 	case PresetNone, PresetBalanced, PresetDefault:
 		return newBalancedEngine(defaultBandDepth)
 	default:

--- a/pkg/acor/parallel.go
+++ b/pkg/acor/parallel.go
@@ -5,7 +5,7 @@ package acor
 import (
 	"context"
 	"runtime"
-	"sort"
+	"slices"
 	"unicode"
 
 	"golang.org/x/sync/errgroup"
@@ -223,7 +223,7 @@ func mergeIndexResults(chunks []chunk, perChunk []map[string][]int) map[string][
 		for idx := range indices {
 			sorted = append(sorted, idx)
 		}
-		sort.Ints(sorted)
+		slices.Sort(sorted)
 		result[keyword] = sorted
 	}
 	return result

--- a/pkg/acor/redis_storage.go
+++ b/pkg/acor/redis_storage.go
@@ -5,7 +5,6 @@ package acor
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -17,14 +16,6 @@ type redisStorage struct {
 // newRedisStorage returns a kvStorage backed by the given Redis client.
 func newRedisStorage(client redis.UniversalClient) kvStorage {
 	return &redisStorage{client: client}
-}
-
-func (s *redisStorage) Get(ctx context.Context, key string) (string, error) {
-	return s.client.Get(ctx, key).Result()
-}
-
-func (s *redisStorage) Set(ctx context.Context, key string, value interface{}) error {
-	return s.client.Set(ctx, key, value, 0).Err()
 }
 
 func (s *redisStorage) HGetAll(ctx context.Context, key string) (map[string]string, error) {
@@ -96,10 +87,6 @@ func (s *redisStorage) TxPipelined(ctx context.Context, fn func(pipeliner) error
 		return fn(&redisPipeliner{pipe: pipe})
 	})
 	return err
-}
-
-func (s *redisStorage) SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) (bool, error) {
-	return s.client.SetNX(ctx, key, value, expiration).Result()
 }
 
 func (s *redisStorage) Pipeline() pipeliner {

--- a/pkg/acor/redis_storage_extras_test.go
+++ b/pkg/acor/redis_storage_extras_test.go
@@ -5,79 +5,10 @@ package acor
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
 )
-
-func TestRedisStorageSetNX(t *testing.T) {
-	const testValue = "value"
-
-	mr := miniredis.RunT(t)
-	defer mr.Close()
-
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	defer func() { _ = client.Close() }()
-
-	store := newRedisStorage(client)
-	ctx := context.Background()
-
-	t.Run("sets new key successfully", func(t *testing.T) {
-		ok, err := store.SetNX(ctx, "test-key", testValue, 10*time.Second)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !ok {
-			t.Fatal("expected SetNX to return true for new key")
-		}
-
-		got, err := store.Get(ctx, "test-key")
-		if err != nil {
-			t.Fatalf("Get() error: %v", err)
-		}
-		if got != testValue {
-			t.Errorf("Get() = %q, want %q", got, testValue)
-		}
-	})
-
-	t.Run("returns false when key already exists", func(t *testing.T) {
-		ok, err := store.SetNX(ctx, "test-key", "value2", 10*time.Second)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if ok {
-			t.Fatal("expected SetNX to return false for existing key")
-		}
-
-		got, err := store.Get(ctx, "test-key")
-		if err != nil {
-			t.Fatalf("Get() error: %v", err)
-		}
-		if got != testValue {
-			t.Errorf("Get() = %q, want %q", got, testValue)
-		}
-	})
-
-	t.Run("succeeds after key expires", func(t *testing.T) {
-		mr.FastForward(11 * time.Second)
-		ok, err := store.SetNX(ctx, "test-key", "value3", 10*time.Second)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !ok {
-			t.Fatal("expected SetNX to return true after expiration")
-		}
-
-		got, err := store.Get(ctx, "test-key")
-		if err != nil {
-			t.Fatalf("Get() error: %v", err)
-		}
-		if got != "value3" {
-			t.Errorf("Get() = %q, want %q", got, "value3")
-		}
-	})
-}
 
 func TestRedisPipelinerDel(t *testing.T) {
 	mr := miniredis.RunT(t)
@@ -89,10 +20,10 @@ func TestRedisPipelinerDel(t *testing.T) {
 	ctx := context.Background()
 
 	store := newRedisStorage(client)
-	if err := store.Set(ctx, "key1", "val1"); err != nil {
+	if err := client.Set(ctx, "key1", "val1", 0).Err(); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Set(ctx, "key2", "val2"); err != nil {
+	if err := client.Set(ctx, "key2", "val2", 0).Err(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -268,7 +199,7 @@ func TestRedisStorageExists(t *testing.T) {
 		t.Errorf("expected 0 existing, got %d", count)
 	}
 
-	if setErr := store.Set(ctx, "key1", "val"); setErr != nil {
+	if setErr := client.Set(ctx, "key1", "val", 0).Err(); setErr != nil {
 		t.Fatal(setErr)
 	}
 

--- a/pkg/acor/redis_storage_test.go
+++ b/pkg/acor/redis_storage_test.go
@@ -39,21 +39,6 @@ func TestRedisStorageOperations(t *testing.T) {
 	storage := newRedisStorage(client)
 	ctx := context.Background()
 
-	t.Run("Set and Get", func(t *testing.T) {
-		err := storage.Set(ctx, "key", "value")
-		if err != nil {
-			t.Fatalf("Set() error = %v", err)
-		}
-
-		got, err := storage.Get(ctx, "key")
-		if err != nil {
-			t.Fatalf("Get() error = %v", err)
-		}
-		if got != "value" {
-			t.Errorf("Get() = %q, want %q", got, "value")
-		}
-	})
-
 	t.Run("SAdd and SMembers", func(t *testing.T) {
 		err := storage.SAdd(ctx, "set", "member1", "member2")
 		if err != nil {
@@ -100,7 +85,7 @@ func TestRedisStorageOperations(t *testing.T) {
 	})
 
 	t.Run("Del", func(t *testing.T) {
-		err := storage.Set(ctx, "delkey", "value")
+		err := client.Set(ctx, "delkey", "value", 0).Err()
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -110,7 +95,7 @@ func TestRedisStorageOperations(t *testing.T) {
 			t.Fatalf("Del() error = %v", err)
 		}
 
-		_, err = storage.Get(ctx, "delkey")
+		_, err = client.Get(ctx, "delkey").Result()
 		if err == nil {
 			t.Error("Get() should fail for deleted key")
 		}

--- a/pkg/acor/rtt_counter_test.go
+++ b/pkg/acor/rtt_counter_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
-	"time"
 )
 
 // Round-trip counting for the performance claims published in README.md and
@@ -81,16 +80,6 @@ func countRTT(tb testing.TB, ac *AhoCorasick) *rttCounter {
 type countingStorage struct {
 	inner kvStorage
 	c     *rttCounter
-}
-
-func (s *countingStorage) Get(ctx context.Context, key string) (string, error) {
-	s.c.add()
-	return s.inner.Get(ctx, key)
-}
-
-func (s *countingStorage) Set(ctx context.Context, key string, value interface{}) error {
-	s.c.add()
-	return s.inner.Set(ctx, key, value)
 }
 
 func (s *countingStorage) HGetAll(ctx context.Context, key string) (map[string]string, error) {
@@ -173,11 +162,6 @@ func (s *countingStorage) Exists(ctx context.Context, keys ...string) (int64, er
 func (s *countingStorage) TxPipelined(ctx context.Context, fn func(pipeliner) error) error {
 	s.c.add()
 	return s.inner.TxPipelined(ctx, fn)
-}
-
-func (s *countingStorage) SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) (bool, error) {
-	s.c.add()
-	return s.inner.SetNX(ctx, key, value, expiration)
 }
 
 // Pipeline buffers locally and costs nothing until Exec, which is where the

--- a/pkg/acor/storage.go
+++ b/pkg/acor/storage.go
@@ -2,10 +2,7 @@
 
 package acor
 
-import (
-	"context"
-	"time"
-)
+import "context"
 
 // zMember represents a sorted set member with score, compatible with Redis ZSET operations.
 type zMember struct {
@@ -30,10 +27,6 @@ type zMember struct {
 //
 // All operations accept a context for cancellation and timeout support.
 type kvStorage interface {
-	// Get retrieves a string value by key. Returns redis.Nil error if key doesn't exist.
-	Get(ctx context.Context, key string) (string, error)
-	// Set stores a value at the given key with no expiration.
-	Set(ctx context.Context, key string, value interface{}) error
 	// HGetAll retrieves all field-value pairs from a hash.
 	HGetAll(ctx context.Context, key string) (map[string]string, error)
 	// HSet sets multiple field-value pairs in a hash.
@@ -66,8 +59,6 @@ type kvStorage interface {
 	Exists(ctx context.Context, keys ...string) (int64, error)
 	// TxPipelined executes commands in a transaction pipeline.
 	TxPipelined(ctx context.Context, fn func(pipeliner) error) error
-	// SetNX sets a value only if the key does not exist. Returns true if the key was set.
-	SetNX(ctx context.Context, key string, value interface{}, expiration time.Duration) (bool, error)
 	// Pipeline returns a non-transactional pipeline for batching commands.
 	Pipeline() pipeliner
 	// Publish sends a message to a pub/sub channel.

--- a/pkg/acor/topology_test.go
+++ b/pkg/acor/topology_test.go
@@ -278,7 +278,7 @@ func TestStorageAdapterMethods(t *testing.T) {
 	})
 
 	t.Run("Exists", func(t *testing.T) {
-		_ = storage.Set(ctx, "existskey", "value")
+		_ = client.Set(ctx, "existskey", "value", 0).Err()
 		count, err := storage.Exists(ctx, "existskey")
 		if err != nil {
 			t.Errorf("Exists() error: %v", err)
@@ -320,13 +320,13 @@ func TestStorageDel(t *testing.T) {
 	storage := newRedisStorage(client)
 	ctx := context.Background()
 
-	_ = storage.Set(ctx, "delkey", "value")
+	_ = client.Set(ctx, "delkey", "value", 0).Err()
 
 	if delErr := storage.Del(ctx, "delkey"); delErr != nil {
 		t.Errorf("Del() error: %v", delErr)
 	}
 
-	_, err = storage.Get(ctx, "delkey")
+	_, err = client.Get(ctx, "delkey").Result()
 	if err == nil {
 		t.Error("Get() should fail for deleted key")
 	}

--- a/tools/apisnap/main.go
+++ b/tools/apisnap/main.go
@@ -54,7 +54,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 )
@@ -261,7 +260,7 @@ func auditProblems(entries []string, path string, roots []string) (tally map[str
 			problems = append(problems, fmt.Sprintf("%s: %q is not in %s; the entry was removed or the line is misspelled", path, entry, snapFile))
 		}
 	}
-	sort.Strings(problems)
+	slices.Sort(problems)
 	return tally, problems
 }
 
@@ -301,7 +300,7 @@ func snapshot(dir string) ([]string, error) {
 		lines = append(lines, declLines(f)...)
 	}
 
-	sort.Strings(lines)
+	slices.Sort(lines)
 	return dedupe(lines), nil
 }
 

--- a/tools/licensesnap/main.go
+++ b/tools/licensesnap/main.go
@@ -39,6 +39,7 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -47,7 +48,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -243,7 +244,7 @@ func modules() ([]module, error) {
 	}
 	mods = append(mods, goMod)
 
-	sort.Slice(mods, func(i, j int) bool { return mods[i].path < mods[j].path })
+	slices.SortFunc(mods, func(a, b module) int { return cmp.Compare(a.path, b.path) })
 	return mods, nil
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Removes three methods from the unexported `kvStorage` seam that no production path could reach, plus two small stdlib cleanups found alongside them.

**`Get`, `Set`, `SetNX`** — none had a production caller:

- `SetNX` looked live, but `MigrateV1ToV2` takes its migration lock through `ac.redisClient.SetNX` directly (`migration.go:60`), bypassing the seam. The interface copy was never on a code path.
- `Get` and `Set` appeared only in tests written against themselves.

Removing all three also removes three methods from `countingStorage`, the RTT test fake that mirrors the interface by hand.

The tests that used `Set`/`Get` as fixture setup now write through the go-redis client they already hold in scope, so what they actually assert — `Del` and `Exists` — is unchanged. `TestRedisStorageSetNX` tested only the removed method and goes with it.

Two more, unrelated to the above but in the same sweep:

- `stringRuneSource` moved into `engine_matches_test.go`, its only caller. Its own doc comment already said the match entry points deliberately do not route through it.
- `sort.Ints` / `sort.Strings` / `sort.Slice` (deprecated since Go 1.22) → `slices.Sort` / `slices.SortFunc`, in 4 places.

**Not a public API change.** `kvStorage` is unexported and was withdrawn from the public surface before v1.5.0 froze it, so `api/v1.txt` is untouched. `NOTICE` and `api/v1.txt` both regenerate byte-identical after the sort swap — verified with `make api-check` and `make license-check`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [x] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed — no doc references any of the removed symbols
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog
- [x] Commit messages follow guidelines

## Additional Notes

The changelog fragment is arguably optional here: the template says to skip internal-only refactors, and nothing user-visible changed. Kept because it records *why* `SetNX` was safe to remove despite looking live, which is the part a future reader would otherwise have to re-derive. Happy to drop it.

`Issue:` in the fragment is set to this PR's number.

One finding from the same audit pass was **wrong** and is not in this PR: the duplicated `PresetNone, PresetBalanced, PresetDefault` branch in `newMatchEngine` is not redundant — the `exhaustive` linter requires every enum value to be named, and `default` alone fails `make lint`. Left as-is, with a comment now saying so.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).
