### PR TITLE
refactor: parse the CLI's enum flags through one generic

### DIFF
--- a/changes/unreleased/Changed-20260809-160000.yaml
+++ b/changes/unreleased/Changed-20260809-160000.yaml
@@ -1,0 +1,5 @@
+kind: Changed
+body: 'Collapsed the CLI''s four string-to-enum flag parsers — `-preset`, `-batch-mode`, `-boundary`, and `-match-kind` — onto one generic `parseEnum` plus a name table each. The four functions were the same `switch` over `strings.ToLower(strings.TrimSpace(raw))`, differing only in which library enum they returned and which noun their error used, so adding a value meant editing a switch and adding a fifth flag meant copying the whole shape again. Accepted values, case-insensitive matching, and the error wording (`unknown preset "quick"`, and the same for batch mode, boundary, and match kind) are unchanged. The single-use `command*` constants were left alone: only 8 of the 19 have one caller, and inlining those while the other 11 stay named would leave the file less consistent than either end.'
+time: 2026-08-09T16:00:00.000000+09:00
+custom:
+    Issue: "223"

--- a/cmd/acor/main.go
+++ b/cmd/acor/main.go
@@ -376,43 +376,41 @@ func parseArgs(args []string) (*acor.AhoCorasickArgs, *commandOptions, []string,
 	}, commandOpts, fs.Args(), nil
 }
 
-func parsePreset(raw string) (acor.Preset, error) {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "none":
-		return acor.PresetNone, nil
-	case "speed":
-		return acor.PresetSpeed, nil
-	case "balanced":
-		return acor.PresetBalanced, nil
-	case "memory-efficient":
-		return acor.PresetMemoryEfficient, nil
-	default:
-		return acor.PresetNone, fmt.Errorf("unknown preset %q", raw)
+// The string-valued flags each map onto a library enum. The names live in maps
+// rather than in four switch statements that differed only in which enum they
+// returned and which word the error used.
+var (
+	presetNames = map[string]acor.Preset{
+		"none":             acor.PresetNone,
+		"speed":            acor.PresetSpeed,
+		"balanced":         acor.PresetBalanced,
+		"memory-efficient": acor.PresetMemoryEfficient,
 	}
-}
+	batchModeNames = map[string]acor.BatchMode{
+		"best-effort":   acor.BatchModeBestEffort,
+		"transactional": acor.BatchModeTransactional,
+	}
+	boundaryNames = map[string]acor.ChunkBoundary{
+		"word":     acor.ChunkBoundaryWord,
+		"sentence": acor.ChunkBoundarySentence,
+		"line":     acor.ChunkBoundaryLine,
+	}
+	matchKindNames = map[string]acor.MatchKind{
+		"overlapping":      acor.MatchKindOverlapping,
+		"leftmost-longest": acor.MatchKindLeftmostLongest,
+	}
+)
 
-func parseBatchMode(raw string) (acor.BatchMode, error) {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "best-effort":
-		return acor.BatchModeBestEffort, nil
-	case "transactional":
-		return acor.BatchModeTransactional, nil
-	default:
-		return acor.BatchModeBestEffort, fmt.Errorf("unknown batch mode %q", raw)
+// parseEnum resolves one flag value against its name table. what is the noun the
+// error uses, so an unknown value reads as "unknown preset \"quick\"" rather than
+// naming the Go type. An unparseable value returns the zero enum, which every
+// caller discards along with the error.
+func parseEnum[T any](raw, what string, names map[string]T) (T, error) {
+	if v, ok := names[strings.ToLower(strings.TrimSpace(raw))]; ok {
+		return v, nil
 	}
-}
-
-func parseBoundary(raw string) (acor.ChunkBoundary, error) {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "word":
-		return acor.ChunkBoundaryWord, nil
-	case "sentence":
-		return acor.ChunkBoundarySentence, nil
-	case "line":
-		return acor.ChunkBoundaryLine, nil
-	default:
-		return acor.ChunkBoundaryWord, fmt.Errorf("unknown boundary %q", raw)
-	}
+	var zero T
+	return zero, fmt.Errorf("unknown %s %q", what, raw)
 }
 
 // enumOptions holds the flags that map a string onto a library enum. They are
@@ -425,19 +423,19 @@ type enumOptions struct {
 }
 
 func parseEnumOptions(config *commandConfig) (*enumOptions, error) {
-	preset, err := parsePreset(config.preset)
+	preset, err := parseEnum(config.preset, "preset", presetNames)
 	if err != nil {
 		return nil, err
 	}
-	batchMode, err := parseBatchMode(config.batchMode)
+	batchMode, err := parseEnum(config.batchMode, "batch mode", batchModeNames)
 	if err != nil {
 		return nil, err
 	}
-	boundary, err := parseBoundary(config.boundary)
+	boundary, err := parseEnum(config.boundary, "boundary", boundaryNames)
 	if err != nil {
 		return nil, err
 	}
-	matchKind, err := parseMatchKind(config.matchKind)
+	matchKind, err := parseEnum(config.matchKind, "match kind", matchKindNames)
 	if err != nil {
 		return nil, err
 	}
@@ -447,17 +445,6 @@ func parseEnumOptions(config *commandConfig) (*enumOptions, error) {
 		boundary:  boundary,
 		matchKind: matchKind,
 	}, nil
-}
-
-func parseMatchKind(raw string) (acor.MatchKind, error) {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
-	case "overlapping":
-		return acor.MatchKindOverlapping, nil
-	case "leftmost-longest":
-		return acor.MatchKindLeftmostLongest, nil
-	default:
-		return acor.MatchKindOverlapping, fmt.Errorf("unknown match kind %q", raw)
-	}
 }
 
 func validateNumericOptions(config *commandConfig) error {


### PR DESCRIPTION
# Pull Request

## Description

`-preset`, `-batch-mode`, `-boundary`, and `-match-kind` each had their own parse function, and all four were the same shape:

```go
func parseBoundary(raw string) (acor.ChunkBoundary, error) {
	switch strings.ToLower(strings.TrimSpace(raw)) {
	case "word":     return acor.ChunkBoundaryWord, nil
	...
	default:         return acor.ChunkBoundaryWord, fmt.Errorf("unknown boundary %q", raw)
	}
}
```

They differed only in which library enum they returned and which noun the error used. Adding a value meant editing a switch; adding a fifth such flag meant copying the whole shape again.

Replaced with one generic plus a name table each:

```go
func parseEnum[T any](raw, what string, names map[string]T) (T, error) {
	if v, ok := names[strings.ToLower(strings.TrimSpace(raw))]; ok {
		return v, nil
	}
	var zero T
	return zero, fmt.Errorf("unknown %s %q", what, raw)
}
```

### Behavior is unchanged

Accepted values, case-insensitive matching, and error wording all identical. Verified against the built binary, not just the test suite:

```
$ ./acor -preset quick find x            → unknown preset "quick"
$ ./acor -batch-mode yolo add-many a     → unknown batch mode "yolo"
$ ./acor -boundary para find-parallel x  → unknown boundary "para"
$ ./acor -match-kind greedy find-matches x → unknown match kind "greedy"
$ ./acor -preset SPEED ... find x        → accepted (reaches the Redis dial)
```

The old functions returned a named default alongside the error (`acor.PresetNone`, `acor.ChunkBoundaryWord`, …); `parseEnum` returns the zero value. Same value in all four cases, and `parseEnumOptions` discards it either way.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed — flag names and accepted values are unchanged, so `docs/content` and the CLI usage text need no edit
- [x] Changelog fragment added (`changie new`)
- [x] Commit messages follow guidelines

## Additional Notes

**Smallest of the four audit PRs by line count: −13.** Reporting that honestly because I estimated −35 when planning it — the name tables take back most of what the switches gave up. The actual win is the marginal cost of the next such flag: 4 lines of map instead of a 14-line function.

**One planned item deliberately dropped.** The audit also proposed inlining the single-use `command*` constants into the `commandSpecs` map keys. On counting, only 8 of the 19 have a single caller; the other 11 are referenced by `validateCommandOptions`, `presetUnsupported`, or the tests. Inlining 8 while 11 stay named would leave the file less consistent than either end, so it is untouched.

`Issue:` in the fragment is set to this PR's number.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).
