### PR TITLE
docs: give the CLI its own site section

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ multi-instance invalidation safety.
 - [Batch operations](docs/content/guides/batch-operations.md) and [parallel matching](docs/content/guides/parallel-matching.md)
 - [Schema V2 and migration](docs/content/reference/schema-v2.md) and [benchmarks](docs/content/reference/benchmarks.md)
 - [Deployment](docs/content/operations/deployment.md), [monitoring](docs/content/operations/monitoring.md), and [troubleshooting](docs/content/operations/troubleshooting.md)
-- [CLI installation](docs/content/getting-started/installation.md#cli-installation)
+- [The `acor` CLI](docs/content/cli/_index.md) — nineteen commands over the same collection
 
 Browse the [full documentation](https://skyoo2003.github.io/acor/) or the
 [Go API reference](https://pkg.go.dev/github.com/skyoo2003/acor/pkg/acor).

--- a/changes/unreleased/Documentation-20260809-221035.yaml
+++ b/changes/unreleased/Documentation-20260809-221035.yaml
@@ -1,0 +1,5 @@
+kind: Documentation
+body: 'The CLI now has its own section on the documentation site. Its usage — batch modes, the four matching shapes, the whole-word caveat for scripts without inter-word boundaries, parallel chunking, and preset selection — had been filed under a heading called `CLI Installation` on the Getting Started page, where a reader looking for the CLI had no reason to open it; that prose moved unchanged. The new section index adds what it never carried: the nineteen commands grouped by what they do, and the caveat already stated on the compatibility page that the CLI''s flags, output format, and exit codes sit outside the `v1` promise. The site''s landing page had also fallen behind the site: its hero named two of the three public entry points, and its card grid linked five of the seven sections. Both now match what the site contains.'
+time: 2026-08-09T22:10:35.80236+09:00
+custom:
+    Issue: "229"

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,7 +1,7 @@
 ---
 title: ACOR Documentation
 hero_title: Aho-Corasick on Redis, with one API across multiple topologies.
-hero_text: ACOR is a Go library and CLI for storing and querying Aho-Corasick patterns in Redis. It supports standalone Redis, Sentinel, Cluster, and Ring deployments through the same Create API.
+hero_text: ACOR stores and queries Aho-Corasick patterns in Redis, and reaches you three ways — a Go library, an acor CLI, and an experimental server module speaking HTTP and gRPC. All three drive the same collection, across standalone Redis, Sentinel, Cluster, and Ring.
 ---
 
 ## Getting Started
@@ -59,5 +59,13 @@ func main() {
   <a class="doc-card" href="server/">
     <strong>Server</strong>
     <span>Serve a collection over HTTP or gRPC.</span>
+  </a>
+  <a class="doc-card" href="cli/">
+    <strong>CLI</strong>
+    <span>Drive a collection from the shell, nineteen commands.</span>
+  </a>
+  <a class="doc-card" href="extending/">
+    <strong>Extending</strong>
+    <span>Why Redis is the only backend, and how to test without one.</span>
   </a>
 </div>

--- a/docs/content/cli/_index.md
+++ b/docs/content/cli/_index.md
@@ -1,0 +1,54 @@
+---
+title: "CLI"
+weight: 6
+---
+
+# CLI
+
+`acor` is the third way into the same collection: one binary, nineteen commands, every one of
+them a shell over the library. It is the entry point for the things a program should not have
+to be written for — seeding a dictionary, checking what is in one, running a migration,
+grepping a log against keywords that live in Redis.
+
+> **The CLI is not covered by the `v1` compatibility promise.** Quoting
+> [Compatibility](../reference/compatibility/#what-is-not-covered) directly:
+>
+> **The CLI.** Flags, output format, and exit codes of the `acor` command can change in
+> any release. If you need a stable contract, call the library rather than parsing CLI
+> output.
+>
+> The library (`pkg/acor`) is covered; this is the surface that is not.
+
+## Install
+
+```bash
+go install github.com/skyoo2003/acor/cmd/acor@latest
+```
+
+Full instructions, including verifying the install, are on
+[Getting Started → Installation](../getting-started/installation/#cli-installation).
+
+## The nineteen commands
+
+| Group | Commands |
+| ----- | -------- |
+| Write | `add`, `add-many`, `remove`, `remove-many`, `flush` |
+| Match | `find`, `find-index`, `find-set`, `find-matches`, `contains`, `find-parallel`, `find-index-parallel` |
+| Suggest | `suggest`, `suggest-index` |
+| Inspect | `info`, `schema-version`, `version` |
+| Migrate | `migrate`, `migrate-rollback` |
+
+Flags are deliberately not tabulated here. `acor --help` prints the command list followed by
+the flag set's own defaults, so each flag's description lives exactly once — next to where the
+flag is registered — and cannot drift out of step with a copy on this page.
+
+`acor version` is the one command that needs no Redis. It prints the version stamped in at
+release build time, or `dev` for a binary you built yourself.
+
+## Sections
+
+- [Commands](commands/) - Option ordering, batch modes, the four matching shapes, parallel chunking, and when the local cache earns its memory
+
+## Navigation
+
+← [Server](../server/) | [Extending](../extending/) →

--- a/docs/content/cli/commands.md
+++ b/docs/content/cli/commands.md
@@ -1,0 +1,86 @@
+---
+title: "Commands"
+weight: 1
+---
+
+# Commands
+
+`acor --help` prints the command list and every flag with its default. This page covers the
+behavior those one-line flag descriptions cannot carry: the ordering rule, what each batch
+mode does on failure, how the matching commands differ from one another, and when the local
+cache is worth its memory.
+
+## Options come before the command
+
+CLI options must appear before the command. Batch commands accept keywords as
+arguments, or `-` as the only argument to read one keyword per line from stdin:
+
+```bash
+acor -addr localhost:6379 -batch-mode transactional add-many foo bar "hello world"
+printf 'foo\nbar\n' | acor -addr localhost:6379 remove-many -
+```
+
+`best-effort` is the default and reports per-keyword failures in JSON while
+returning success; `transactional` fails the command if the whole batch cannot
+be committed.
+
+## Matching
+
+Beyond `find` and `find-index`, the matching commands cover the set, span, and
+presence shapes of the same scan:
+
+```bash
+acor -addr localhost:6379 find-set "he is him"
+acor -addr localhost:6379 contains "he is him"
+acor -addr localhost:6379 -match-kind leftmost-longest -whole-word \
+  find-matches "he is him"
+```
+
+`find-set` reports each keyword once, `contains` stops at the first match, and
+`find-matches` reports each occurrence with its rune span in scan order.
+`-match-kind` and `-whole-word` apply only to `find-matches`.
+
+`-whole-word` assumes a script that separates words with spaces or punctuation.
+In scripts written without inter-word boundaries (CJK, Thai, …) every adjacent
+character counts as a word character, so nearly every match is treated as
+mid-word and dropped — scan such text without `-whole-word`, or use the library's
+`MatchOptions.WordRune` to supply your own boundary rule.
+
+## Parallel matching
+
+Parallel matching accepts a text argument, or `-` to read the complete text
+from stdin. `word`, `sentence`, and `line` chunk boundaries are available:
+
+```bash
+acor -addr localhost:6379 -workers 8 -chunk-size 10000 \
+  -boundary line -overlap 100 find-parallel - < large.log
+
+acor -addr localhost:6379 -workers 8 \
+  find-index-parallel - < document.txt
+```
+
+## Local cache and presets
+
+Use `-cache` with the normal V2 engine, or select a Redis-backed local preset
+engine. Preset mode already keeps a local engine, so `-cache` and `-preset`
+cannot be combined:
+
+```bash
+acor -addr localhost:6379 -cache find-parallel - < document.txt
+
+acor -addr localhost:6379 -preset balanced \
+  -invalidation-poll-interval 30s find-parallel - < document.txt
+```
+
+Available presets are `speed`, `balanced`, and `memory-efficient`; `none` is
+the compatibility-preserving default. Preset mode requires an explicit Redis
+address and does not support `suggest`, `suggest-index`, or migration commands.
+The local cache is most useful for parallel matching, where every chunk shares
+one CLI process; a one-shot `find` invocation has no later lookup to reuse it.
+
+The trade-offs behind each preset are in
+[Guides → Preset-Optimized Engine](../../guides/preset-engine/).
+
+## Navigation
+
+← [CLI](../) | [Extending](../../extending/) →

--- a/docs/content/extending/_index.md
+++ b/docs/content/extending/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Extending"
-weight: 6
+weight: 7
 ---
 
 # Extending
@@ -13,4 +13,4 @@ Extend ACOR with custom functionality.
 
 ## Navigation
 
-← [Server](../server/)
+← [CLI](../cli/)

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -64,65 +64,9 @@ acor version
 `acor version` needs no Redis and prints the version stamped at release build
 time (`dev` for a locally built binary).
 
-CLI options must appear before the command. Batch commands accept keywords as
-arguments, or `-` as the only argument to read one keyword per line from stdin:
-
-```bash
-acor -addr localhost:6379 -batch-mode transactional add-many foo bar "hello world"
-printf 'foo\nbar\n' | acor -addr localhost:6379 remove-many -
-```
-
-`best-effort` is the default and reports per-keyword failures in JSON while
-returning success; `transactional` fails the command if the whole batch cannot
-be committed.
-
-Beyond `find` and `find-index`, the matching commands cover the set, span, and
-presence shapes of the same scan:
-
-```bash
-acor -addr localhost:6379 find-set "he is him"
-acor -addr localhost:6379 contains "he is him"
-acor -addr localhost:6379 -match-kind leftmost-longest -whole-word \
-  find-matches "he is him"
-```
-
-`find-set` reports each keyword once, `contains` stops at the first match, and
-`find-matches` reports each occurrence with its rune span in scan order.
-`-match-kind` and `-whole-word` apply only to `find-matches`.
-
-`-whole-word` assumes a script that separates words with spaces or punctuation.
-In scripts written without inter-word boundaries (CJK, Thai, …) every adjacent
-character counts as a word character, so nearly every match is treated as
-mid-word and dropped — scan such text without `-whole-word`, or use the library's
-`MatchOptions.WordRune` to supply your own boundary rule.
-
-Parallel matching accepts a text argument, or `-` to read the complete text
-from stdin. `word`, `sentence`, and `line` chunk boundaries are available:
-
-```bash
-acor -addr localhost:6379 -workers 8 -chunk-size 10000 \
-  -boundary line -overlap 100 find-parallel - < large.log
-
-acor -addr localhost:6379 -workers 8 \
-  find-index-parallel - < document.txt
-```
-
-Use `-cache` with the normal V2 engine, or select a Redis-backed local preset
-engine. Preset mode already keeps a local engine, so `-cache` and `-preset`
-cannot be combined:
-
-```bash
-acor -addr localhost:6379 -cache find-parallel - < document.txt
-
-acor -addr localhost:6379 -preset balanced \
-  -invalidation-poll-interval 30s find-parallel - < document.txt
-```
-
-Available presets are `speed`, `balanced`, and `memory-efficient`; `none` is
-the compatibility-preserving default. Preset mode requires an explicit Redis
-address and does not support `suggest`, `suggest-index`, or migration commands.
-The local cache is most useful for parallel matching, where every chunk shares
-one CLI process; a one-shot `find` invocation has no later lookup to reuse it.
+That is the whole of installing it. What the nineteen commands do — option ordering, batch
+modes, the four matching shapes, parallel chunking, and when the local cache earns its
+memory — is the [CLI](../../cli/) section.
 
 ## Next Steps
 

--- a/docs/content/server/_index.md
+++ b/docs/content/server/_index.md
@@ -41,4 +41,4 @@ serve, so they live together under
 
 ## Navigation
 
-← [Operations](../operations/) | [Extending](../extending/) →
+← [Operations](../operations/) | [CLI](../cli/) →

--- a/docs/content/server/grpc-api.md
+++ b/docs/content/server/grpc-api.md
@@ -172,4 +172,4 @@ knowing before you set a probe interval:
 
 ## Navigation
 
-← [HTTP API](../http-api/) | [Extending](../../extending/) →
+← [HTTP API](../http-api/) | [CLI](../../cli/) →

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -39,6 +39,9 @@ menu:
     - name: Server
       url: /server/
       weight: 5
+    - name: CLI
+      url: /cli/
+      weight: 6
     - name: Extending
       url: /extending/
-      weight: 6
+      weight: 7


### PR DESCRIPTION
# Pull Request

## Description

The site documented three public entry points as two.

`pkg/acor` and `acor/server` each had a section. The CLI had ~60 lines of usage prose — batch modes, the four matching shapes, the `-whole-word` caveat for scripts without inter-word boundaries, parallel chunking, preset selection — filed under a heading called **"CLI Installation"** on the Getting Started page. A reader who wants the CLI has no reason to open Installation, and the nav gave them no other door.

`docs/content/_index.md` had fallen behind the same way: the hero said "a Go library and CLI" — two of three, stale since #225 shipped the server section — and the card grid linked five of the six sections that existed.

What changed:

- **`docs/content/cli/`** — a section index plus `commands.md`. The usage prose moves **verbatim**; only headings were added to give the standalone page structure. Rewriting prose while relocating it is how correct prose acquires new claims nobody checked.
- The index carries what the moved prose never did: the **19 commands** grouped by what they do, counted from `cmd/acor/main.go:22-46`; a pointer to `acor --help` instead of a flag table, since the help text is generated from the flag set (`writeUsage`, `main.go:54-60`) and a hand-copied table is not; and the stability caveat quoted from `docs/content/reference/compatibility.md:52-54` — the CLI's flags, output format, and exit codes sit outside the `v1` promise, which no page about the CLI had ever said.
- **Navigation** — CLI enters at `weight: 6`, between Server and Extending, so the two non-library entry points sit together. Extending shifts to 7 and the three prev/next links that spanned the gap are retargeted. Weight 2 would have renumbered five sections instead of one.
- **Landing page** — the hero names three entry points; the grid covers all seven sections.
- **`README.md:96`** — the CLI bullet pointed at `installation.md#cli-installation`; it points at the section. The `## CLI Installation` heading stays, so that anchor still resolves for anything else linking to it.

No Go file changed.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — skip for internal-only changes (CI, tests, refactors); see [RELEASE.md](../RELEASE.md)
- [x] Commit messages follow guidelines

All seven ran together as `make all`, which exits 0:

```
doccheck: all 22 block(s) compiled
apisnap: audit 180/180 entries — 142 ok, 38 fixed, 0 risk, 0 unaudited
```

Site-specific checks, none of which `make all` covers:

```
hugo --source docs --gc --minify     EXIT=0, 36 pages, /cli/ and /cli/commands/ emitted
doc-cards == menu.main entries       7 == 7
front-matter weight == menu weight   7/7 match
grep -rn cli-installation            1 hit — the new CLI index linking the kept heading
```

`docs-verify` compiles Go fences only, and every fence that moved is `bash`, so the compiled set is unchanged at 22.

## Additional Notes

**The README/Pages split is decided but not applied.** `README.md:88-96` still carries a section-by-section link list that duplicates the landing page. The discoverability PRD's milestone 2 is in progress and inserts its own block into the README, so the rule gets applied to the README that exists after that lands rather than to a moving target. The one-line change at line 96 here is a broken-link fix, not the split.

**Two counts in my own plan were wrong and are corrected here.** The CLI has **19** commands, not 20, and the moved region is lines **67-125**, not 65-126. Both were asserted before being counted — the same failure mode the reviews on #227 kept finding, so it is recorded rather than quietly fixed.

**Local Hugo is 0.164.0; CI pins 0.147.9** (`.github/workflows/pages.yaml`). A clean local build is therefore not full proof, though this change uses no version-sensitive feature. The build also emits two pre-existing deprecation warnings for `languageCode` and `.Language.LanguageCode`, unrelated to this change and not present at the pinned version.

---

By submitting this PR, I agree that my contributions will be licensed under the [Apache License 2.0](https://github.com/skyoo2003/acor/blob/main/LICENSE).