### PR TITLE
ci: gate on tidy module manifests before lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,19 @@ jobs:
             go.sum
             server/go.sum
             benchmarks/go.sum
+      # Runs before lint because a stale manifest is what lint reports as
+      # "no go files to analyze", which names neither the module nor the fix.
+      # server/ and benchmarks/ replace the core with ../, so a Dependabot bump
+      # to the root alone moves their build list and leaves their own manifests
+      # behind — that is PR #233, where all six jobs failed on it. pre-commit
+      # runs this same target, but Dependabot pushes through the API and never
+      # runs the hooks, so the hook cannot be the gate for the case that needs one.
+      #
+      # Pinned to one leg: the check is a git diff of generated text, so it is
+      # platform- and version-independent.
+      - name: Check module manifests are tidy
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.26'
+        run: make tidy-check
       - name: Execute golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # golangci-lint-action v9.3.0
         with:


### PR DESCRIPTION
# Pull Request

## Description

Adds a `make tidy-check` step to the `CI` job, ahead of the lint steps.

`server/` and `benchmarks/` both `replace github.com/skyoo2003/acor => ../`, so a
Dependabot bump to the root manifest alone moves their build list while their own
`go.mod` stays pinned to the old version. #233 is what that costs: all six Go jobs
failed, and the message was golangci-lint's `no go files to analyze`, which names
neither the module nor the fix.

`make tidy-check` already existed and pre-commit already ran it. Dependabot pushes
through the API and never runs the hooks, so the hook was not the gate for the one
case that needed one. Running the same target in CI turns that failure into a diff
of the manifest that is stale.

Pinned to the ubuntu/1.26 leg for the same reason as `license-check` and
`api-check`: the check is a git diff of generated text, so running it four times
adds no signal. Verified green on `main`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

CI only.

## Checklist

- [x] Tests pass (`make test`)
- [x] Vet/`make vet`
- [x] Linting passes (`make lint`)
- [x] Build succeeds (`make build`)
- [x] Documentation updated if needed — n/a
- [x] Changelog fragment added (`changie new`) if this change belongs in the changelog — skipped, internal-only (CI)
- [x] Commit messages follow guidelines

## Additional Notes

The manifest fix for #233 itself is pushed to that PR's branch (`11272f6`), which
also adds `golang.org/x/sys` to the NOTICE attribution — go-redis v9.22.0 imports
`golang.org/x/sys/cpu`, so it is now linked into the `acor` binary. That failure
was queued behind the lint one and would have surfaced next.
